### PR TITLE
ci: set up zero-commit release with release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,46 @@
+name-template: $NEXT_PATCH_VERSION
+tag-template: $NEXT_PATCH_VERSION
+version-template: $MAJOR.$MINOR.$PATCH
+commitish: main
+
+categories:
+  - title: ":boom: Breaking changes"
+    labels:
+      - breaking
+  - title: 🚨 Removed
+    label: removed
+  - title: 🚀 New features and improvements
+    labels:
+      - enhancement
+      - feature
+  - title: 🐛 Bug Fixes
+    labels:
+      - bug
+      - fix
+      - bugfix
+  - title: 📦 Dependency updates
+    label: dependencies
+  - title: 📝 Documentation updates
+    label: documentation
+  - title: 👻 Maintenance
+    labels:
+      - chore
+      - internal
+      - maintenance
+  - title: 🔧 Build
+    label: build
+  - title: 🚦 Tests
+    labels:
+      - test
+      - tests
+exclude-labels:
+  - reverted
+  - no-changelog
+  - skip-changelog
+  - invalid
+
+change-template: '- $TITLE ([#$NUMBER]($URL)) @$AUTHOR'
+
+template: |
+  <!-- Optional: add a release summary here -->
+  $CHANGES

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,7 +8,8 @@ categories:
     labels:
       - breaking
   - title: 🚨 Removed
-    label: removed
+    labels:
+      - removed
   - title: 🚀 New features and improvements
     labels:
       - enhancement
@@ -19,16 +20,19 @@ categories:
       - fix
       - bugfix
   - title: 📦 Dependency updates
-    label: dependencies
+    labels:
+      - dependencies
   - title: 📝 Documentation updates
-    label: documentation
+    labels:
+      - documentation
   - title: 👻 Maintenance
     labels:
       - chore
       - internal
       - maintenance
   - title: 🔧 Build
-    label: build
+    labels:
+      - build
   - title: 🚦 Tests
     labels:
       - test

--- a/.github/release-settings.xml
+++ b/.github/release-settings.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <pluginGroups>
+    <pluginGroup>eu.maveniverse.maven.plugins</pluginGroup>
+  </pluginGroups>
+
+  <servers>
+    <server>
+      <id>pilot-publish</id>
+      <username>${env.MAVEN_USER}</username>
+      <password>${env.MAVEN_PASSWORD}</password>
+      <configuration>
+        <njord.publisher>sonatype-cp</njord.publisher>
+        <njord.releaseUrl>njord:template:release-sca</njord.releaseUrl>
+        <njord.snapshotUrl>njord:template:snapshot-sca</njord.snapshotUrl>
+      </configuration>
+    </server>
+  </servers>
+
+</settings>

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,23 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run release drafter
+        uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '[0-9]*.[0-9]*.[0-9]*'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     name: Release to Maven Central
@@ -21,7 +24,6 @@ jobs:
       - name: Verify tag state
         id: version
         run: |
-          git fetch --tags
           echo "All recent tags:"
           git tag -l --sort=version:refname | tail -5
           echo "Current commit: $(git rev-parse HEAD)"
@@ -61,7 +63,7 @@ jobs:
           gh extension install valeriobelli/gh-milestone
           version=${{ steps.version.outputs.version }}
           echo "Trying to find milestone $version"
-          milestone=$(gh milestone list --json id,title,state  --jq "map_values(select(.title == \"${version}\" and .state == \"OPEN\")).[].number")
+          milestone=$(gh milestone list --json number,title,state --jq "map(select(.title == \"${version}\" and .state == \"OPEN\"))[].number")
           if [ ! -z "$milestone" ]; then
               echo "Found milestone $version, closing it"
               gh milestone edit $milestone --state closed
@@ -79,7 +81,7 @@ jobs:
             echo "Preparing development $next_version"
             echo "Trying to find milestone $next_version"
 
-            milestone=$(gh milestone list --json id,title,state --jq "map_values(select(.title == \"${next_version}\" and .state == \"OPEN\")).[].number")
+            milestone=$(gh milestone list --json number,title,state --jq "map(select(.title == \"${next_version}\" and .state == \"OPEN\"))[].number")
             if [ -z "$milestone" ]; then
               echo "Creating milestone $next_version"
               gh milestone create --title $next_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]*.[0-9]*.[0-9]*'
+
+jobs:
+  release:
+    name: Release to Maven Central
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
+    steps:
+
+      - name: Checkout ${{ github.ref_name }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref }}
+
+      - name: Verify tag state
+        id: version
+        run: |
+          git fetch --tags
+          echo "All recent tags:"
+          git tag -l --sort=version:refname | tail -5
+          echo "Current commit: $(git rev-parse HEAD)"
+          echo "Git describe: $(git describe --tags --always)"
+          echo "Tag: ${GITHUB_REF#refs/tags/}"
+          echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        with:
+          gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          fingerprint: ${{ secrets.GPG_KEY_FINGERPRINT }}
+
+      - name: Release
+        env:
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          MAVEN_GPG_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          MAVEN_GPG_KEY_FINGERPRINT: ${{ secrets.GPG_KEY_FINGERPRINT }}
+          MAVEN_USER: ${{ secrets.MAVEN_USER }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+        run: |
+          mvn -B deploy -Dnjord.autoPublish -Pbundle,javadoc,sign -s .github/release-settings.xml
+
+      - name: Post release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          gh extension install valeriobelli/gh-milestone
+          version=${{ steps.version.outputs.version }}
+          echo "Trying to find milestone $version"
+          milestone=$(gh milestone list --json id,title,state  --jq "map_values(select(.title == \"${version}\" and .state == \"OPEN\")).[].number")
+          if [ ! -z "$milestone" ]; then
+              echo "Found milestone $version, closing it"
+              gh milestone edit $milestone --state closed
+          fi
+
+          # Parse semantic version and increment patch version
+          if [[ $version =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            major=${BASH_REMATCH[1]}
+            minor=${BASH_REMATCH[2]}
+            patch=${BASH_REMATCH[3]}
+
+            next_patch=$((patch + 1))
+            next_version="${major}.${minor}.${next_patch}"
+
+            echo "Preparing development $next_version"
+            echo "Trying to find milestone $next_version"
+
+            milestone=$(gh milestone list --json id,title,state --jq "map_values(select(.title == \"${next_version}\" and .state == \"OPEN\")).[].number")
+            if [ -z "$milestone" ]; then
+              echo "Creating milestone $next_version"
+              gh milestone create --title $next_version
+            fi
+          else
+            echo "ERROR: Version $version is not a valid semantic version (x.y.z)"
+            exit 1
+          fi
+
+          name="Pilot"
+          echo "Creating release \"$name $version\" from tag"
+          gh release create $version --verify-tag --notes-from-tag --title "$name $version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           MAVEN_USER: ${{ secrets.MAVEN_USER }}
           MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
         run: |
-          mvn -B deploy -Dnjord.autoPublish -Pbundle,javadoc,sign -s .github/release-settings.xml
+          mvn -B deploy -Dnjord.autoPublish -Pmaveniverse-release -s .github/release-settings.xml
 
       - name: Post release
         env:

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,7 +2,7 @@
 <extensions>
   <extension>
     <groupId>eu.maveniverse.maven.nisse</groupId>
-    <artifactId>extension3</artifactId>
+    <artifactId>extension</artifactId>
     <version>0.8.1</version>
   </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<extensions>
+  <extension>
+    <groupId>eu.maveniverse.maven.nisse</groupId>
+    <artifactId>extension3</artifactId>
+    <version>0.8.1</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+-Dnisse.source.jgit.dynamicVersion=true

--- a/.mvn/nisse-translation.properties
+++ b/.mvn/nisse-translation.properties
@@ -1,0 +1,1 @@
+jgit.dynamicVersion=revision

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@ under the License.
     <maven.compiler.release>17</maven.compiler.release>
     <mavenVersion>3.9.9</mavenVersion>
     <tamboui.version>0.1.0</tamboui.version>
-    <domtrip.version>0.6.0</domtrip.version>
+    <domtrip.version>1.0.0</domtrip.version>
 
     <!-- SonarCloud -->
     <sonar.projectKey>maveniverse_pilot</sonar.projectKey>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
 
   <groupId>eu.maveniverse.maven.plugins</groupId>
   <artifactId>pilot</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>maven-plugin</packaging>
 
   <name>Pilot</name>
@@ -49,7 +49,7 @@ under the License.
   <scm>
     <connection>scm:git:git@github.com:maveniverse/pilot.git</connection>
     <developerConnection>scm:git:git@github.com:maveniverse/pilot.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>${revision}</tag>
     <url>https://github.com/maveniverse/pilot</url>
   </scm>
 


### PR DESCRIPTION
## Summary
- Set up [zero-commit release](https://blog.gnodet.fr/posts/zero-commit-release/) process using nisse for dynamic versioning from git tags
- Add release workflow that triggers on tag push to deploy to Maven Central via njord
- Add release drafter to auto-generate release notes from merged PRs
- No more version bumps in pom.xml — just `git tag 0.1.0 && git push --tags` to release

## Files added
- `.mvn/extensions.xml` — nisse extension for `${revision}` from git
- `.mvn/maven.config` — enable jgit dynamic version
- `.mvn/nisse-translation.properties` — map jgit property to `revision`
- `.github/workflows/release.yml` — tag-triggered release to Maven Central
- `.github/workflows/release-drafter.yml` — auto-draft release notes
- `.github/release-drafter.yml` — release notes categories config
- `.github/release-settings.xml` — CI publishing credentials template

## Secrets required
- `GPG_SIGNING_KEY`, `GPG_PASSPHRASE`, `GPG_KEY_FINGERPRINT`
- `MAVEN_USER`, `MAVEN_PASSWORD` (from central.sonatype.com)

## Test plan
- [x] `mvn verify` passes locally with nisse resolving dynamic version
- [ ] CI build passes
- [ ] Release drafter creates a draft release after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated release draft generation with categorized changelogs.
  * Added release publishing workflow triggered by semver tags, including milestone management and automated release creation.
  * Added CI steps for artifact publishing with credential-based authentication and GPG signing.
  * Enabled Maven runtime extension support and dynamic versioning for builds.
  * Updated project metadata and a dependency to align versions and use the dynamic revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->