### PR TITLE
feat: align goals with Maveniverse Toolbox behavior

### DIFF
--- a/src/main/java/eu/maveniverse/maven/pilot/AnalyzeMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AnalyzeMojo.java
@@ -36,10 +36,11 @@ import org.eclipse.aether.collection.CollectResult;
 import org.eclipse.aether.graph.DependencyNode;
 
 /**
- * Interactive dependency analysis — shows unused declared and used undeclared dependencies.
+ * Interactive TUI showing declared vs transitive dependency overview.
  *
- * <p>Note: This is a heuristic analysis based on the dependency tree structure.
- * For bytecode-level analysis, use maven-dependency-analyzer.</p>
+ * <p>Displays two views: declared dependencies (from the POM) and transitive
+ * dependencies (pulled in indirectly). Allows promoting transitive dependencies
+ * to declared, or removing declared dependencies from the POM.</p>
  *
  * <p>Usage:</p>
  * <pre>
@@ -61,8 +62,9 @@ public class AnalyzeMojo extends AbstractMojo {
     private RepositorySystem repoSystem;
 
     /**
-     * Performs dependency analysis: collects declared dependencies from the project POM, resolves the full transitive
-     * dependency tree, identifies transitive (undeclared) dependencies, and presents the results using the Analyze TUI.
+     * Collects declared dependencies from the project POM, resolves the full transitive
+     * dependency tree, and presents a side-by-side view of declared vs transitive dependencies
+     * using the Analyze TUI.
      *
      * @throws MojoExecutionException if dependency collection, traversal, or the TUI run fails
      */

--- a/src/main/java/eu/maveniverse/maven/pilot/AnalyzeTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AnalyzeTui.java
@@ -46,7 +46,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Interactive TUI for dependency analysis.
+ * Interactive TUI showing declared vs transitive dependency overview.
  */
 class AnalyzeTui {
 
@@ -272,7 +272,7 @@ class AnalyzeTui {
 
     private void renderHeader(Frame frame, Rect area) {
         Block block = Block.builder()
-                .title(" Pilot \u2014 Dependency Analysis ")
+                .title(" Pilot \u2014 Dependency Overview ")
                 .borderType(BorderType.ROUNDED)
                 .borderStyle(Style.create().cyan())
                 .build();

--- a/src/main/java/eu/maveniverse/maven/pilot/DependencyTreeModel.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependencyTreeModel.java
@@ -84,10 +84,17 @@ class DependencyTreeModel {
     /**
      * Scopes included for each resolution scope, following Maven Resolver conventions.
      */
+    private static final String SCOPE_COMPILE = "compile";
+
+    private static final String SCOPE_RUNTIME = "runtime";
+    private static final String SCOPE_TEST = "test";
+    private static final String SCOPE_PROVIDED = "provided";
+    private static final String SCOPE_SYSTEM = "system";
+
     private static final Map<String, Set<String>> SCOPE_INCLUSIONS = Map.of(
-            "compile", Set.of("compile", "provided", "system", ""),
-            "runtime", Set.of("compile", "runtime", ""),
-            "test", Set.of("compile", "provided", "system", "runtime", "test", ""));
+            SCOPE_COMPILE, Set.of(SCOPE_COMPILE, SCOPE_PROVIDED, SCOPE_SYSTEM, ""),
+            SCOPE_RUNTIME, Set.of(SCOPE_COMPILE, SCOPE_RUNTIME, ""),
+            SCOPE_TEST, Set.of(SCOPE_COMPILE, SCOPE_PROVIDED, SCOPE_SYSTEM, SCOPE_RUNTIME, SCOPE_TEST, ""));
 
     static DependencyTreeModel fromDependencyNode(DependencyNode rootNode) {
         return fromDependencyNode(rootNode, null);

--- a/src/main/java/eu/maveniverse/maven/pilot/DependencyTreeModel.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependencyTreeModel.java
@@ -47,7 +47,7 @@ class DependencyTreeModel {
             this.groupId = groupId;
             this.artifactId = artifactId;
             this.version = version;
-            this.scope = scope != null ? scope : "compile";
+            this.scope = scope != null ? scope : SCOPE_COMPILE;
             this.optional = optional;
             this.depth = depth;
             this.children = new ArrayList<>();

--- a/src/main/java/eu/maveniverse/maven/pilot/DependencyTreeModel.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependencyTreeModel.java
@@ -19,7 +19,6 @@
 package eu.maveniverse.maven.pilot;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -81,20 +80,34 @@ class DependencyTreeModel {
         this.totalNodes = totalNodes;
     }
 
-    static DependencyTreeModel fromDependencyNode(DependencyNode rootNode) {
-        Map<String, String> resolvedVersions = new HashMap<>();
-        int[] counter = {0};
-        TreeNode root = convertNode(rootNode, 0, resolvedVersions, counter, new HashSet<>());
+    /**
+     * Scopes included for each resolution scope, following Maven Resolver conventions.
+     */
+    private static final Map<String, Set<String>> SCOPE_INCLUSIONS = Map.of(
+            "compile", Set.of("compile", "provided", "system", ""),
+            "runtime", Set.of("compile", "runtime", ""),
+            "test", Set.of("compile", "provided", "system", "runtime", "test", ""));
 
-        // Detect conflicts: where requested != resolved
+    static DependencyTreeModel fromDependencyNode(DependencyNode rootNode) {
+        return fromDependencyNode(rootNode, null);
+    }
+
+    static DependencyTreeModel fromDependencyNode(DependencyNode rootNode, String scope) {
+        Set<String> includedScopes = scope != null ? SCOPE_INCLUSIONS.get(scope) : null;
+        int[] counter = {0};
         List<TreeNode> conflicts = new ArrayList<>();
-        collectConflicts(root, resolvedVersions, conflicts);
+        TreeNode root = convertNode(rootNode, 0, counter, new HashSet<>(), conflicts, includedScopes);
 
         return new DependencyTreeModel(root, conflicts, counter[0]);
     }
 
     private static TreeNode convertNode(
-            DependencyNode node, int depth, Map<String, String> resolvedVersions, int[] counter, Set<String> visited) {
+            DependencyNode node,
+            int depth,
+            int[] counter,
+            Set<String> visited,
+            List<TreeNode> conflicts,
+            Set<String> includedScopes) {
         counter[0]++;
 
         String groupId, artifactId, version, scope;
@@ -121,33 +134,33 @@ class DependencyTreeModel {
 
         TreeNode treeNode = new TreeNode(groupId, artifactId, version, scope, optional, depth);
 
-        String ga = treeNode.ga();
-        resolvedVersions.putIfAbsent(ga, version);
+        // Read conflict data from the Resolver's ConflictResolver transformer.
+        // After conflict resolution, losing nodes have their version replaced with
+        // the winner's version, and the original requested version is stored in
+        // "conflict.originalVersion" node data.
+        if (node.getData().get("conflict.originalVersion") instanceof String originalVersion) {
+            treeNode.requestedVersion = originalVersion;
+            conflicts.add(treeNode);
+        }
 
         // Guard against cycles
-        String nodeKey = ga + ":" + version;
+        String nodeKey = treeNode.ga() + ":" + version;
         if (!visited.add(nodeKey)) {
             return treeNode;
         }
 
         for (DependencyNode child : node.getChildren()) {
-            treeNode.children.add(convertNode(child, depth + 1, resolvedVersions, counter, visited));
+            if (includedScopes != null && child.getDependency() != null) {
+                String childScope = child.getDependency().getScope();
+                if (childScope != null && !includedScopes.contains(childScope)) {
+                    continue;
+                }
+            }
+            treeNode.children.add(convertNode(child, depth + 1, counter, visited, conflicts, includedScopes));
         }
 
         visited.remove(nodeKey);
         return treeNode;
-    }
-
-    private static void collectConflicts(
-            TreeNode node, Map<String, String> resolvedVersions, List<TreeNode> conflicts) {
-        String resolvedVersion = resolvedVersions.get(node.ga());
-        if (resolvedVersion != null && !resolvedVersion.equals(node.version) && node.depth > 0) {
-            node.requestedVersion = node.version;
-            conflicts.add(node);
-        }
-        for (TreeNode child : node.children) {
-            collectConflicts(child, resolvedVersions, conflicts);
-        }
     }
 
     /**

--- a/src/main/java/eu/maveniverse/maven/pilot/DependencyTreeModel.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependencyTreeModel.java
@@ -21,6 +21,7 @@ package eu.maveniverse.maven.pilot;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.eclipse.aether.graph.DependencyNode;
@@ -93,7 +94,15 @@ class DependencyTreeModel {
     }
 
     static DependencyTreeModel fromDependencyNode(DependencyNode rootNode, String scope) {
-        Set<String> includedScopes = scope != null ? SCOPE_INCLUSIONS.get(scope) : null;
+        Set<String> includedScopes = null;
+        if (scope != null) {
+            String normalized = scope.toLowerCase(Locale.ROOT);
+            includedScopes = SCOPE_INCLUSIONS.get(normalized);
+            if (includedScopes == null) {
+                throw new IllegalArgumentException(
+                        "Unsupported scope '" + scope + "'. Supported values: " + SCOPE_INCLUSIONS.keySet());
+            }
+        }
         int[] counter = {0};
         List<TreeNode> conflicts = new ArrayList<>();
         TreeNode root = convertNode(rootNode, 0, counter, new HashSet<>(), conflicts, includedScopes);

--- a/src/main/java/eu/maveniverse/maven/pilot/TreeMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/TreeMojo.java
@@ -67,7 +67,7 @@ public class TreeMojo extends AbstractMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
             CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(project));
-            DependencyTreeModel model = DependencyTreeModel.fromDependencyNode(result.getRoot());
+            DependencyTreeModel model = DependencyTreeModel.fromDependencyNode(result.getRoot(), scope);
 
             TreeTui tui = new TreeTui(
                     model, project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion());

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesMojo.java
@@ -54,8 +54,12 @@ public class UpdatesMojo extends AbstractMojo {
     @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
     private RepositorySystemSession repoSession;
 
+    private final RepositorySystem repoSystem;
+
     @Inject
-    private RepositorySystem repoSystem;
+    UpdatesMojo(RepositorySystem repoSystem) {
+        this.repoSystem = repoSystem;
+    }
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesMojo.java
@@ -19,9 +19,7 @@
 package eu.maveniverse.maven.pilot;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
@@ -95,11 +93,7 @@ public class UpdatesMojo extends AbstractMojo {
                     request.setArtifact(new DefaultArtifact(groupId, artifactId, "jar", "[0,)"));
                     request.setRepositories(project.getRemoteProjectRepositories());
                     VersionRangeResult result = repoSystem.resolveVersionRange(repoSession, request);
-                    List<String> versions = result.getVersions().stream()
-                            .map(Object::toString)
-                            .collect(Collectors.toCollection(ArrayList::new));
-                    Collections.reverse(versions); // newest first
-                    return versions;
+                    return UpdatesTui.versionsNewestFirst(result.getVersions());
                 } catch (VersionRangeResolutionException e) {
                     throw new IllegalStateException("Failed to resolve versions for " + groupId + ":" + artifactId, e);
                 }

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesMojo.java
@@ -89,19 +89,15 @@ public class UpdatesMojo extends AbstractMojo {
             // Use the Resolver to fetch available versions, respecting all configured
             // repositories, mirrors, authentication, and proxies.
             UpdatesTui.VersionResolver versionResolver = (groupId, artifactId) -> {
-                try {
-                    VersionRangeRequest request = new VersionRangeRequest();
-                    request.setArtifact(new DefaultArtifact(groupId, artifactId, "jar", "[0,)"));
-                    request.setRepositories(project.getRemoteProjectRepositories());
-                    VersionRangeResult result = repoSystem.resolveVersionRange(repoSession, request);
-                    List<String> versions = result.getVersions().stream()
-                            .map(Object::toString)
-                            .collect(Collectors.toCollection(ArrayList::new));
-                    Collections.reverse(versions); // newest first
-                    return versions;
-                } catch (Exception e) {
-                    return List.of();
-                }
+                VersionRangeRequest request = new VersionRangeRequest();
+                request.setArtifact(new DefaultArtifact(groupId, artifactId, "jar", "[0,)"));
+                request.setRepositories(project.getRemoteProjectRepositories());
+                VersionRangeResult result = repoSystem.resolveVersionRange(repoSession, request);
+                List<String> versions = result.getVersions().stream()
+                        .map(Object::toString)
+                        .collect(Collectors.toCollection(ArrayList::new));
+                Collections.reverse(versions); // newest first
+                return versions;
             };
 
             UpdatesTui tui = new UpdatesTui(dependencies, pomPath, gav, versionResolver);

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesMojo.java
@@ -34,6 +34,7 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.eclipse.aether.resolution.VersionRangeResult;
 
 /**
@@ -89,15 +90,19 @@ public class UpdatesMojo extends AbstractMojo {
             // Use the Resolver to fetch available versions, respecting all configured
             // repositories, mirrors, authentication, and proxies.
             UpdatesTui.VersionResolver versionResolver = (groupId, artifactId) -> {
-                VersionRangeRequest request = new VersionRangeRequest();
-                request.setArtifact(new DefaultArtifact(groupId, artifactId, "jar", "[0,)"));
-                request.setRepositories(project.getRemoteProjectRepositories());
-                VersionRangeResult result = repoSystem.resolveVersionRange(repoSession, request);
-                List<String> versions = result.getVersions().stream()
-                        .map(Object::toString)
-                        .collect(Collectors.toCollection(ArrayList::new));
-                Collections.reverse(versions); // newest first
-                return versions;
+                try {
+                    VersionRangeRequest request = new VersionRangeRequest();
+                    request.setArtifact(new DefaultArtifact(groupId, artifactId, "jar", "[0,)"));
+                    request.setRepositories(project.getRemoteProjectRepositories());
+                    VersionRangeResult result = repoSystem.resolveVersionRange(repoSession, request);
+                    List<String> versions = result.getVersions().stream()
+                            .map(Object::toString)
+                            .collect(Collectors.toCollection(ArrayList::new));
+                    Collections.reverse(versions); // newest first
+                    return versions;
+                } catch (VersionRangeResolutionException e) {
+                    throw new IllegalStateException("Failed to resolve versions for " + groupId + ":" + artifactId, e);
+                }
             };
 
             UpdatesTui tui = new UpdatesTui(dependencies, pomPath, gav, versionResolver);

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesMojo.java
@@ -19,7 +19,10 @@
 package eu.maveniverse.maven.pilot;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -27,6 +30,11 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResult;
 
 /**
  * Interactive TUI showing which dependencies have newer versions available.
@@ -43,6 +51,12 @@ public class UpdatesMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
+    private RepositorySystemSession repoSession;
+
+    @Inject
+    private RepositorySystem repoSystem;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
@@ -72,7 +86,25 @@ public class UpdatesMojo extends AbstractMojo {
             String pomPath = project.getFile().getAbsolutePath();
             String gav = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
 
-            UpdatesTui tui = new UpdatesTui(dependencies, pomPath, gav);
+            // Use the Resolver to fetch available versions, respecting all configured
+            // repositories, mirrors, authentication, and proxies.
+            UpdatesTui.VersionResolver versionResolver = (groupId, artifactId) -> {
+                try {
+                    VersionRangeRequest request = new VersionRangeRequest();
+                    request.setArtifact(new DefaultArtifact(groupId, artifactId, "jar", "[0,)"));
+                    request.setRepositories(project.getRemoteProjectRepositories());
+                    VersionRangeResult result = repoSystem.resolveVersionRange(repoSession, request);
+                    List<String> versions = result.getVersions().stream()
+                            .map(Object::toString)
+                            .collect(Collectors.toCollection(ArrayList::new));
+                    Collections.reverse(versions); // newest first
+                    return versions;
+                } catch (Exception e) {
+                    return List.of();
+                }
+            };
+
+            UpdatesTui tui = new UpdatesTui(dependencies, pomPath, gav, versionResolver);
             tui.run();
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to check updates: " + e.getMessage(), e);

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -43,12 +43,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
 
 /**
  * Interactive TUI for viewing and applying dependency updates.
@@ -58,6 +60,15 @@ class UpdatesTui {
     @FunctionalInterface
     interface VersionResolver {
         List<String> resolveVersions(String groupId, String artifactId);
+    }
+
+    /**
+     * Convert a list of version objects to strings ordered newest-first.
+     */
+    static List<String> versionsNewestFirst(List<?> versions) {
+        List<String> result = versions.stream().map(Object::toString).collect(Collectors.toCollection(ArrayList::new));
+        Collections.reverse(result);
+        return result;
     }
 
     static class DependencyInfo {

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -55,6 +55,11 @@ import java.util.concurrent.Executors;
  */
 class UpdatesTui {
 
+    @FunctionalInterface
+    interface VersionResolver {
+        List<String> resolveVersions(String groupId, String artifactId);
+    }
+
     static class DependencyInfo {
         final String groupId;
         final String artifactId;
@@ -94,6 +99,7 @@ class UpdatesTui {
     private List<DependencyInfo> displayDeps;
     private final String pomPath;
     private final String projectGav;
+    private final VersionResolver versionResolver;
     private final TableState tableState = new TableState();
     private final ExecutorService httpPool = Executors.newFixedThreadPool(5);
     private final Map<String, SearchTui.PomInfo> pomInfoCache = new HashMap<>();
@@ -125,11 +131,12 @@ class UpdatesTui {
      * @param pomPath path to the POM file that updates will be applied to
      * @param projectGav human-readable project identifier shown in the UI
      */
-    UpdatesTui(List<DependencyInfo> dependencies, String pomPath, String projectGav) {
+    UpdatesTui(List<DependencyInfo> dependencies, String pomPath, String projectGav, VersionResolver versionResolver) {
         this.allDeps = dependencies;
         this.displayDeps = new ArrayList<>(dependencies);
         this.pomPath = pomPath;
         this.projectGav = projectGav;
+        this.versionResolver = versionResolver;
         if (!displayDeps.isEmpty()) {
             tableState.select(0);
         }
@@ -154,8 +161,7 @@ class UpdatesTui {
 
     private void fetchAllUpdates() {
         for (var dep : allDeps) {
-            CompletableFuture.supplyAsync(
-                            () -> SearchTui.fetchVersionsFromMetadata(dep.groupId, dep.artifactId), httpPool)
+            CompletableFuture.supplyAsync(() -> versionResolver.resolveVersions(dep.groupId, dep.artifactId), httpPool)
                     .thenAccept(versions -> runner.runOnRenderThread(() -> {
                         loadedCount++;
                         String newest = null;

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -161,8 +161,13 @@ class UpdatesTui {
     }
 
     private void fetchAllUpdates() {
+        fetchUpdates(runner::runOnRenderThread, httpPool);
+    }
+
+    CompletableFuture<Void> fetchUpdates(java.util.function.Consumer<Runnable> renderThread, ExecutorService executor) {
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
         for (var dep : allDeps) {
-            CompletableFuture.supplyAsync(
+            var future = CompletableFuture.supplyAsync(
                             () -> {
                                 try {
                                     return versionResolver.resolveVersions(dep.groupId, dep.artifactId);
@@ -170,20 +175,22 @@ class UpdatesTui {
                                     throw new RuntimeException(e);
                                 }
                             },
-                            httpPool)
-                    .thenAccept(versions -> runner.runOnRenderThread(() -> {
+                            executor)
+                    .thenAccept(versions -> renderThread.accept(() -> {
                         applyVersionResult(dep, versions);
                         updateStatusIfDone();
                     }))
                     .exceptionally(ex -> {
-                        runner.runOnRenderThread(() -> {
+                        renderThread.accept(() -> {
                             loadedCount++;
                             failedCount++;
                             updateStatusIfDone();
                         });
                         return null;
                     });
+            futures.add(future);
         }
+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
     }
 
     /**

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -57,7 +57,7 @@ class UpdatesTui {
 
     @FunctionalInterface
     interface VersionResolver {
-        List<String> resolveVersions(String groupId, String artifactId);
+        List<String> resolveVersions(String groupId, String artifactId) throws Exception;
     }
 
     static class DependencyInfo {
@@ -108,6 +108,7 @@ class UpdatesTui {
     private String status = "Loading updates\u2026";
     private boolean loading = true;
     private int loadedCount = 0;
+    private int failedCount = 0;
 
     private TuiRunner runner;
 
@@ -161,7 +162,15 @@ class UpdatesTui {
 
     private void fetchAllUpdates() {
         for (var dep : allDeps) {
-            CompletableFuture.supplyAsync(() -> versionResolver.resolveVersions(dep.groupId, dep.artifactId), httpPool)
+            CompletableFuture.supplyAsync(
+                            () -> {
+                                try {
+                                    return versionResolver.resolveVersions(dep.groupId, dep.artifactId);
+                                } catch (Exception e) {
+                                    throw new RuntimeException(e);
+                                }
+                            },
+                            httpPool)
                     .thenAccept(versions -> runner.runOnRenderThread(() -> {
                         loadedCount++;
                         String newest = null;
@@ -176,15 +185,28 @@ class UpdatesTui {
                             dep.newestVersion = newest;
                             dep.updateType = VersionComparator.classify(dep.version, newest);
                         }
-                        if (loadedCount >= allDeps.size()) {
-                            loading = false;
-                            applyFilter();
-                            long updates = allDeps.stream()
-                                    .filter(DependencyInfo::hasUpdate)
-                                    .count();
-                            status = updates + " update(s) available out of " + allDeps.size() + " dependencies";
-                        }
-                    }));
+                        updateStatusIfDone();
+                    }))
+                    .exceptionally(ex -> {
+                        runner.runOnRenderThread(() -> {
+                            loadedCount++;
+                            failedCount++;
+                            updateStatusIfDone();
+                        });
+                        return null;
+                    });
+        }
+    }
+
+    private void updateStatusIfDone() {
+        if (loadedCount >= allDeps.size()) {
+            loading = false;
+            applyFilter();
+            long updates = allDeps.stream().filter(DependencyInfo::hasUpdate).count();
+            status = updates + " update(s) available out of " + allDeps.size() + " dependencies";
+            if (failedCount > 0) {
+                status += "; " + failedCount + " lookup(s) failed";
+            }
         }
     }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -172,19 +172,7 @@ class UpdatesTui {
                             },
                             httpPool)
                     .thenAccept(versions -> runner.runOnRenderThread(() -> {
-                        loadedCount++;
-                        String newest = null;
-                        for (String v : versions) {
-                            if (VersionComparator.isPreview(v)) continue;
-                            if (dep.version.isEmpty() || VersionComparator.isNewer(dep.version, v)) {
-                                newest = v;
-                                break; // versions are newest-first
-                            }
-                        }
-                        if (newest != null) {
-                            dep.newestVersion = newest;
-                            dep.updateType = VersionComparator.classify(dep.version, newest);
-                        }
+                        applyVersionResult(dep, versions);
                         updateStatusIfDone();
                     }))
                     .exceptionally(ex -> {
@@ -195,6 +183,25 @@ class UpdatesTui {
                         });
                         return null;
                     });
+        }
+    }
+
+    /**
+     * Apply resolved versions to a dependency, selecting the newest non-preview version.
+     */
+    void applyVersionResult(DependencyInfo dep, List<String> versions) {
+        loadedCount++;
+        String newest = null;
+        for (String v : versions) {
+            if (VersionComparator.isPreview(v)) continue;
+            if (dep.version.isEmpty() || VersionComparator.isNewer(dep.version, v)) {
+                newest = v;
+                break; // versions are newest-first
+            }
+        }
+        if (newest != null) {
+            dep.newestVersion = newest;
+            dep.updateType = VersionComparator.classify(dep.version, newest);
         }
     }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -105,10 +105,10 @@ class UpdatesTui {
     private final Map<String, SearchTui.PomInfo> pomInfoCache = new HashMap<>();
 
     private Filter filter = Filter.ALL;
-    private String status = "Loading updates\u2026";
-    private boolean loading = true;
-    private int loadedCount = 0;
-    private int failedCount = 0;
+    String status = "Loading updates\u2026";
+    boolean loading = true;
+    int loadedCount = 0;
+    int failedCount = 0;
 
     private TuiRunner runner;
 
@@ -198,7 +198,7 @@ class UpdatesTui {
         }
     }
 
-    private void updateStatusIfDone() {
+    void updateStatusIfDone() {
         if (loadedCount >= allDeps.size()) {
             loading = false;
             applyFilter();

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -57,7 +57,7 @@ class UpdatesTui {
 
     @FunctionalInterface
     interface VersionResolver {
-        List<String> resolveVersions(String groupId, String artifactId) throws Exception;
+        List<String> resolveVersions(String groupId, String artifactId);
     }
 
     static class DependencyInfo {
@@ -168,14 +168,7 @@ class UpdatesTui {
         List<CompletableFuture<Void>> futures = new ArrayList<>();
         for (var dep : allDeps) {
             var future = CompletableFuture.supplyAsync(
-                            () -> {
-                                try {
-                                    return versionResolver.resolveVersions(dep.groupId, dep.artifactId);
-                                } catch (Exception e) {
-                                    throw new RuntimeException(e);
-                                }
-                            },
-                            executor)
+                            () -> versionResolver.resolveVersions(dep.groupId, dep.artifactId), executor)
                     .thenAccept(versions -> renderThread.accept(() -> {
                         applyVersionResult(dep, versions);
                         updateStatusIfDone();

--- a/src/test/java/eu/maveniverse/maven/pilot/DependencyTreeModelTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/DependencyTreeModelTest.java
@@ -319,6 +319,25 @@ class DependencyTreeModelTest {
     }
 
     @Test
+    void fromDependencyNodeScopeIsCaseInsensitive() {
+        var root = rootNode("com.example", "app", "1.0.0");
+        var child = depNode("org.slf4j", "slf4j-api", "2.0.9", "compile");
+        root.setChildren(List.of(child));
+
+        var model = DependencyTreeModel.fromDependencyNode(root, "COMPILE");
+        assertThat(model.visibleNodes()).hasSize(2);
+    }
+
+    @Test
+    void fromDependencyNodeInvalidScopeThrows() {
+        var root = rootNode("com.example", "app", "1.0.0");
+
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            DependencyTreeModel.fromDependencyNode(root, "invalid");
+        });
+    }
+
+    @Test
     void fromDependencyNodeHandlesCycles() {
         var root = rootNode("com.example", "app", "1.0.0");
         var child = depNode("com.example", "lib-a", "1.0", "compile");

--- a/src/test/java/eu/maveniverse/maven/pilot/DependencyTreeModelTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/DependencyTreeModelTest.java
@@ -254,8 +254,9 @@ class DependencyTreeModelTest {
         var visible = model.visibleNodes();
         var childGas =
                 visible.stream().skip(1).map(DependencyTreeModel.TreeNode::ga).toList();
-        assertThat(childGas).contains("org.slf4j:slf4j-api", "javax.servlet:servlet-api");
-        assertThat(childGas).doesNotContain("org.junit:junit", "com.example:runtime-lib");
+        assertThat(childGas)
+                .contains("org.slf4j:slf4j-api", "javax.servlet:servlet-api")
+                .doesNotContain("org.junit:junit", "com.example:runtime-lib");
     }
 
     @Test
@@ -273,8 +274,9 @@ class DependencyTreeModelTest {
         var visible = model.visibleNodes();
         var childGas =
                 visible.stream().skip(1).map(DependencyTreeModel.TreeNode::ga).toList();
-        assertThat(childGas).contains("org.slf4j:slf4j-api", "com.example:runtime-lib");
-        assertThat(childGas).doesNotContain("org.junit:junit", "javax.servlet:servlet-api");
+        assertThat(childGas)
+                .contains("org.slf4j:slf4j-api", "com.example:runtime-lib")
+                .doesNotContain("org.junit:junit", "javax.servlet:servlet-api");
     }
 
     @Test

--- a/src/test/java/eu/maveniverse/maven/pilot/DependencyTreeModelTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/DependencyTreeModelTest.java
@@ -20,7 +20,12 @@ package eu.maveniverse.maven.pilot;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.Dependency;
 import org.junit.jupiter.api.Test;
 
 class DependencyTreeModelTest {
@@ -177,5 +182,158 @@ class DependencyTreeModelTest {
 
         var results = model.filter("nonexistent");
         assertThat(results).isEmpty();
+    }
+
+    // -- fromDependencyNode tests --
+
+    private DefaultDependencyNode depNode(String g, String a, String v, String scope) {
+        var artifact = new DefaultArtifact(g, a, "", "jar", v);
+        var dependency = new Dependency(artifact, scope);
+        return new DefaultDependencyNode(dependency);
+    }
+
+    private DefaultDependencyNode rootNode(String g, String a, String v) {
+        var artifact = new DefaultArtifact(g, a, "", "jar", v);
+        return new DefaultDependencyNode(artifact);
+    }
+
+    @Test
+    void fromDependencyNodeDetectsConflictsViaOriginalVersion() {
+        // Root -> child1 (guava:33.0) -> grandchild (failureaccess:1.0.2, conflict: originally requested 1.0.1)
+        var root = rootNode("com.example", "app", "1.0.0");
+        var child = depNode("com.google.guava", "guava", "33.0.0-jre", "compile");
+        var conflicting = depNode("com.google.guava", "failureaccess", "1.0.2", "compile");
+
+        // Simulate Resolver's ConflictResolver: losing node has version replaced
+        // and original version stored in data
+        Map<Object, Object> data = new HashMap<>();
+        data.put("conflict.originalVersion", "1.0.1");
+        conflicting.setData(data);
+
+        child.setChildren(List.of(conflicting));
+        root.setChildren(List.of(child));
+
+        var model = DependencyTreeModel.fromDependencyNode(root);
+
+        assertThat(model.conflicts).hasSize(1);
+        var conflict = model.conflicts.get(0);
+        assertThat(conflict.ga()).isEqualTo("com.google.guava:failureaccess");
+        assertThat(conflict.version).isEqualTo("1.0.2"); // resolved (winner) version
+        assertThat(conflict.requestedVersion).isEqualTo("1.0.1"); // original requested version
+        assertThat(conflict.isConflict()).isTrue();
+    }
+
+    @Test
+    void fromDependencyNodeNoConflictWithoutOriginalVersion() {
+        var root = rootNode("com.example", "app", "1.0.0");
+        var child = depNode("org.slf4j", "slf4j-api", "2.0.9", "compile");
+        root.setChildren(List.of(child));
+
+        var model = DependencyTreeModel.fromDependencyNode(root);
+
+        assertThat(model.conflicts).isEmpty();
+        // Node should not have requestedVersion set
+        var nodes = model.visibleNodes();
+        var childNode = nodes.get(1);
+        assertThat(childNode.requestedVersion).isNull();
+        assertThat(childNode.isConflict()).isFalse();
+    }
+
+    @Test
+    void fromDependencyNodeScopeFilterCompile() {
+        var root = rootNode("com.example", "app", "1.0.0");
+        var compileChild = depNode("org.slf4j", "slf4j-api", "2.0.9", "compile");
+        var testChild = depNode("org.junit", "junit", "5.10.0", "test");
+        var runtimeChild = depNode("com.example", "runtime-lib", "1.0", "runtime");
+        var providedChild = depNode("javax.servlet", "servlet-api", "4.0", "provided");
+        root.setChildren(List.of(compileChild, testChild, runtimeChild, providedChild));
+
+        var model = DependencyTreeModel.fromDependencyNode(root, "compile");
+
+        // compile scope includes: compile, provided, system — excludes test, runtime
+        var visible = model.visibleNodes();
+        var childGas =
+                visible.stream().skip(1).map(DependencyTreeModel.TreeNode::ga).toList();
+        assertThat(childGas).contains("org.slf4j:slf4j-api", "javax.servlet:servlet-api");
+        assertThat(childGas).doesNotContain("org.junit:junit", "com.example:runtime-lib");
+    }
+
+    @Test
+    void fromDependencyNodeScopeFilterRuntime() {
+        var root = rootNode("com.example", "app", "1.0.0");
+        var compileChild = depNode("org.slf4j", "slf4j-api", "2.0.9", "compile");
+        var testChild = depNode("org.junit", "junit", "5.10.0", "test");
+        var runtimeChild = depNode("com.example", "runtime-lib", "1.0", "runtime");
+        var providedChild = depNode("javax.servlet", "servlet-api", "4.0", "provided");
+        root.setChildren(List.of(compileChild, testChild, runtimeChild, providedChild));
+
+        var model = DependencyTreeModel.fromDependencyNode(root, "runtime");
+
+        // runtime scope includes: compile, runtime — excludes test, provided
+        var visible = model.visibleNodes();
+        var childGas =
+                visible.stream().skip(1).map(DependencyTreeModel.TreeNode::ga).toList();
+        assertThat(childGas).contains("org.slf4j:slf4j-api", "com.example:runtime-lib");
+        assertThat(childGas).doesNotContain("org.junit:junit", "javax.servlet:servlet-api");
+    }
+
+    @Test
+    void fromDependencyNodeScopeFilterTest() {
+        var root = rootNode("com.example", "app", "1.0.0");
+        var compileChild = depNode("org.slf4j", "slf4j-api", "2.0.9", "compile");
+        var testChild = depNode("org.junit", "junit", "5.10.0", "test");
+        var runtimeChild = depNode("com.example", "runtime-lib", "1.0", "runtime");
+        root.setChildren(List.of(compileChild, testChild, runtimeChild));
+
+        var model = DependencyTreeModel.fromDependencyNode(root, "test");
+
+        // test scope includes all scopes
+        var visible = model.visibleNodes();
+        assertThat(visible).hasSize(4); // root + 3 children
+    }
+
+    @Test
+    void fromDependencyNodeNoScopeFilterShowsAll() {
+        var root = rootNode("com.example", "app", "1.0.0");
+        var compileChild = depNode("org.slf4j", "slf4j-api", "2.0.9", "compile");
+        var testChild = depNode("org.junit", "junit", "5.10.0", "test");
+        root.setChildren(List.of(compileChild, testChild));
+
+        var model = DependencyTreeModel.fromDependencyNode(root, null);
+
+        var visible = model.visibleNodes();
+        assertThat(visible).hasSize(3); // root + both children
+    }
+
+    @Test
+    void fromDependencyNodeCountsNodesCorrectly() {
+        var root = rootNode("com.example", "app", "1.0.0");
+        var child = depNode("org.slf4j", "slf4j-api", "2.0.9", "compile");
+        var grandchild = depNode("org.slf4j", "slf4j-impl", "2.0.9", "runtime");
+        child.setChildren(List.of(grandchild));
+        root.setChildren(List.of(child));
+
+        var model = DependencyTreeModel.fromDependencyNode(root);
+
+        assertThat(model.totalNodes).isEqualTo(3);
+    }
+
+    @Test
+    void fromDependencyNodeHandlesCycles() {
+        var root = rootNode("com.example", "app", "1.0.0");
+        var child = depNode("com.example", "lib-a", "1.0", "compile");
+        // Create a cycle: lib-a -> lib-b -> lib-a (same GA:version)
+        var grandchild = depNode("com.example", "lib-b", "1.0", "compile");
+        var cycle = depNode("com.example", "lib-a", "1.0", "compile");
+        grandchild.setChildren(List.of(cycle));
+        child.setChildren(List.of(grandchild));
+        root.setChildren(List.of(child));
+
+        // Should not stack overflow
+        var model = DependencyTreeModel.fromDependencyNode(root);
+        assertThat(model.root).isNotNull();
+        // The cycle node should have no children (cycle broken)
+        var cycleNode = model.root.children.get(0).children.get(0).children.get(0);
+        assertThat(cycleNode.children).isEmpty();
     }
 }

--- a/src/test/java/eu/maveniverse/maven/pilot/DependencyTreeModelTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/DependencyTreeModelTest.java
@@ -19,6 +19,7 @@
 package eu.maveniverse.maven.pilot;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.HashMap;
 import java.util.List;
@@ -334,9 +335,8 @@ class DependencyTreeModelTest {
     void fromDependencyNodeInvalidScopeThrows() {
         var root = rootNode("com.example", "app", "1.0.0");
 
-        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> {
-            DependencyTreeModel.fromDependencyNode(root, "invalid");
-        });
+        assertThatThrownBy(() -> DependencyTreeModel.fromDependencyNode(root, "invalid"))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test

--- a/src/test/java/eu/maveniverse/maven/pilot/ScreenshotTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ScreenshotTest.java
@@ -198,7 +198,7 @@ class ScreenshotTest {
         d5.updateType = VersionComparator.UpdateType.MINOR;
         deps.add(d5);
 
-        UpdatesTui tui = new UpdatesTui(deps, "/tmp/test-pom.xml", "com.example:demo:1.0.0");
+        UpdatesTui tui = new UpdatesTui(deps, "/tmp/test-pom.xml", "com.example:demo:1.0.0", (g, a) -> List.of());
 
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(WIDTH, HEIGHT))) {
             Pilot pilot = testRunner.pilot();

--- a/src/test/java/eu/maveniverse/maven/pilot/UpdatesDemoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UpdatesDemoTest.java
@@ -55,7 +55,7 @@ class UpdatesDemoTest {
         d4.updateType = VersionComparator.UpdateType.MINOR;
         deps.add(d4);
 
-        UpdatesTui tui = new UpdatesTui(deps, "/tmp/test-pom.xml", "com.example:demo:1.0.0");
+        UpdatesTui tui = new UpdatesTui(deps, "/tmp/test-pom.xml", "com.example:demo:1.0.0", (g, a) -> List.of());
 
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
 

--- a/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
@@ -257,4 +257,37 @@ class UpdatesTuiTest {
         assertThat(deps.get(0).newestVersion).isEqualTo("2.0.0");
         assertThat(deps.get(1).newestVersion).isNull();
     }
+
+    @Test
+    void versionsNewestFirstReversesOrder() {
+        var result = UpdatesTui.versionsNewestFirst(List.of("1.0", "2.0", "3.0"));
+        assertThat(result).containsExactly("3.0", "2.0", "1.0");
+    }
+
+    @Test
+    void versionsNewestFirstEmptyList() {
+        var result = UpdatesTui.versionsNewestFirst(List.of());
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void versionsNewestFirstConvertsToString() {
+        // Simulates Version objects that have toString()
+        var result = UpdatesTui.versionsNewestFirst(List.of(1, 2, 3));
+        assertThat(result).containsExactly("3", "2", "1");
+    }
+
+    @Test
+    void applyVersionResultAllPreviews() {
+        var deps = new ArrayList<UpdatesTui.DependencyInfo>();
+        var dep = new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar");
+        deps.add(dep);
+
+        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> List.of());
+        tui.applyVersionResult(dep, List.of("2.0.0-SNAPSHOT", "1.5.0-beta1", "1.2.0-alpha1"));
+
+        assertThat(dep.newestVersion).isNull();
+        assertThat(dep.updateType).isNull();
+        assertThat(tui.loadedCount).isEqualTo(1);
+    }
 }

--- a/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class UpdatesTuiTest {
+
+    @Test
+    void versionResolverInterface() throws Exception {
+        UpdatesTui.VersionResolver resolver = (g, a) -> List.of("2.0", "1.5", "1.0");
+        List<String> versions = resolver.resolveVersions("com.example", "lib");
+        assertThat(versions).containsExactly("2.0", "1.5", "1.0");
+    }
+
+    @Test
+    void versionResolverThrowingException() {
+        UpdatesTui.VersionResolver resolver = (g, a) -> {
+            throw new Exception("repo unavailable");
+        };
+        org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> {
+            resolver.resolveVersions("com.example", "lib");
+        });
+    }
+
+    @Test
+    void updateStatusIfDoneNoFailures() {
+        var deps = new ArrayList<UpdatesTui.DependencyInfo>();
+        deps.add(new UpdatesTui.DependencyInfo("com.example", "a", "1.0", "compile", "jar"));
+        deps.add(new UpdatesTui.DependencyInfo("com.example", "b", "2.0", "compile", "jar"));
+        deps.get(0).newestVersion = "1.1";
+        deps.get(0).updateType = VersionComparator.UpdateType.PATCH;
+
+        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "com.example:app:1.0", (g, a) -> List.of());
+        tui.loadedCount = 2;
+        tui.updateStatusIfDone();
+
+        assertThat(tui.loading).isFalse();
+        assertThat(tui.status).contains("1 update(s) available");
+        assertThat(tui.status).doesNotContain("failed");
+    }
+
+    @Test
+    void updateStatusIfDoneWithFailures() {
+        var deps = new ArrayList<UpdatesTui.DependencyInfo>();
+        deps.add(new UpdatesTui.DependencyInfo("com.example", "a", "1.0", "compile", "jar"));
+        deps.add(new UpdatesTui.DependencyInfo("com.example", "b", "2.0", "compile", "jar"));
+        deps.add(new UpdatesTui.DependencyInfo("com.example", "c", "3.0", "compile", "jar"));
+
+        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "com.example:app:1.0", (g, a) -> List.of());
+        tui.loadedCount = 3;
+        tui.failedCount = 2;
+        tui.updateStatusIfDone();
+
+        assertThat(tui.loading).isFalse();
+        assertThat(tui.status).contains("0 update(s) available");
+        assertThat(tui.status).contains("2 lookup(s) failed");
+    }
+
+    @Test
+    void updateStatusIfDoneNotYetComplete() {
+        var deps = new ArrayList<UpdatesTui.DependencyInfo>();
+        deps.add(new UpdatesTui.DependencyInfo("com.example", "a", "1.0", "compile", "jar"));
+        deps.add(new UpdatesTui.DependencyInfo("com.example", "b", "2.0", "compile", "jar"));
+
+        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "com.example:app:1.0", (g, a) -> List.of());
+        tui.loadedCount = 1; // not all loaded yet
+        tui.updateStatusIfDone();
+
+        assertThat(tui.loading).isTrue(); // still loading
+        assertThat(tui.status).isEqualTo("Loading updates\u2026"); // unchanged
+    }
+
+    @Test
+    void dependencyInfoGa() {
+        var dep = new UpdatesTui.DependencyInfo("org.slf4j", "slf4j-api", "2.0.9", "compile", "jar");
+        assertThat(dep.ga()).isEqualTo("org.slf4j:slf4j-api");
+    }
+
+    @Test
+    void dependencyInfoHasUpdate() {
+        var dep = new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar");
+        assertThat(dep.hasUpdate()).isFalse();
+
+        dep.newestVersion = "1.1";
+        assertThat(dep.hasUpdate()).isTrue();
+
+        dep.newestVersion = "1.0"; // same version
+        assertThat(dep.hasUpdate()).isFalse();
+
+        dep.newestVersion = ""; // empty
+        assertThat(dep.hasUpdate()).isFalse();
+    }
+
+    @Test
+    void dependencyInfoDefaults() {
+        var dep = new UpdatesTui.DependencyInfo("g", "a", null, null, null);
+        assertThat(dep.version).isEqualTo("");
+        assertThat(dep.scope).isEqualTo("compile");
+        assertThat(dep.type).isEqualTo("jar");
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 class UpdatesTuiTest {
 
     @Test
-    void versionResolverInterface() throws Exception {
+    void versionResolverInterface() {
         UpdatesTui.VersionResolver resolver = (g, a) -> List.of("2.0", "1.5", "1.0");
         List<String> versions = resolver.resolveVersions("com.example", "lib");
         assertThat(versions).containsExactly("2.0", "1.5", "1.0");

--- a/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
@@ -38,10 +38,10 @@ class UpdatesTuiTest {
     @Test
     void versionResolverThrowingException() {
         UpdatesTui.VersionResolver resolver = (g, a) -> {
-            throw new Exception("repo unavailable");
+            throw new IllegalStateException("repo unavailable");
         };
         assertThatThrownBy(() -> resolver.resolveVersions("com.example", "lib"))
-                .isInstanceOf(Exception.class)
+                .isInstanceOf(IllegalStateException.class)
                 .hasMessage("repo unavailable");
     }
 
@@ -217,7 +217,7 @@ class UpdatesTuiTest {
         deps.add(new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar"));
 
         var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> {
-            throw new Exception("network error");
+            throw new IllegalStateException("network error");
         });
 
         var executor = Executors.newSingleThreadExecutor();
@@ -240,7 +240,7 @@ class UpdatesTuiTest {
         deps.add(new UpdatesTui.DependencyInfo("com.example", "broken", "1.0", "compile", "jar"));
 
         var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> {
-            if ("broken".equals(a)) throw new Exception("timeout");
+            if ("broken".equals(a)) throw new IllegalStateException("timeout");
             return List.of("2.0.0", "1.0.0");
         });
 

--- a/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
@@ -119,4 +119,70 @@ class UpdatesTuiTest {
         assertThat(dep.scope).isEqualTo("compile");
         assertThat(dep.type).isEqualTo("jar");
     }
+
+    @Test
+    void applyVersionResultFindsNewest() {
+        var deps = new ArrayList<UpdatesTui.DependencyInfo>();
+        var dep = new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar");
+        deps.add(dep);
+
+        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> List.of());
+        tui.applyVersionResult(dep, List.of("2.0.0", "1.5.0", "1.0.0"));
+
+        assertThat(dep.newestVersion).isEqualTo("2.0.0");
+        assertThat(dep.updateType).isEqualTo(VersionComparator.UpdateType.MAJOR);
+        assertThat(tui.loadedCount).isEqualTo(1);
+    }
+
+    @Test
+    void applyVersionResultSkipsPreview() {
+        var deps = new ArrayList<UpdatesTui.DependencyInfo>();
+        var dep = new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar");
+        deps.add(dep);
+
+        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> List.of());
+        tui.applyVersionResult(dep, List.of("2.0.0-beta1", "2.0.0-alpha1", "1.1.0"));
+
+        assertThat(dep.newestVersion).isEqualTo("1.1.0");
+        assertThat(dep.updateType).isEqualTo(VersionComparator.UpdateType.MINOR);
+    }
+
+    @Test
+    void applyVersionResultNoUpdate() {
+        var deps = new ArrayList<UpdatesTui.DependencyInfo>();
+        var dep = new UpdatesTui.DependencyInfo("com.example", "lib", "2.0", "compile", "jar");
+        deps.add(dep);
+
+        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> List.of());
+        tui.applyVersionResult(dep, List.of("1.5.0", "1.0.0"));
+
+        assertThat(dep.newestVersion).isNull();
+        assertThat(dep.updateType).isNull();
+    }
+
+    @Test
+    void applyVersionResultEmptyVersions() {
+        var deps = new ArrayList<UpdatesTui.DependencyInfo>();
+        var dep = new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar");
+        deps.add(dep);
+
+        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> List.of());
+        tui.applyVersionResult(dep, List.of());
+
+        assertThat(dep.newestVersion).isNull();
+        assertThat(tui.loadedCount).isEqualTo(1);
+    }
+
+    @Test
+    void applyVersionResultWithEmptyCurrentVersion() {
+        var deps = new ArrayList<UpdatesTui.DependencyInfo>();
+        var dep = new UpdatesTui.DependencyInfo("com.example", "lib", null, "compile", "jar");
+        deps.add(dep);
+
+        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> List.of());
+        tui.applyVersionResult(dep, List.of("2.0.0", "1.0.0"));
+
+        // Empty version should accept any non-preview version
+        assertThat(dep.newestVersion).isEqualTo("2.0.0");
+    }
 }

--- a/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 
 class UpdatesTuiTest {
@@ -184,5 +185,77 @@ class UpdatesTuiTest {
 
         // Empty version should accept any non-preview version
         assertThat(dep.newestVersion).isEqualTo("2.0.0");
+    }
+
+    @Test
+    void fetchUpdatesSuccess() {
+        var deps = new ArrayList<UpdatesTui.DependencyInfo>();
+        deps.add(new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar"));
+        deps.add(new UpdatesTui.DependencyInfo("com.example", "other", "2.0", "compile", "jar"));
+
+        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> {
+            if ("lib".equals(a)) return List.of("2.0.0", "1.5.0", "1.0.0");
+            return List.of("2.0.0");
+        });
+
+        var executor = Executors.newSingleThreadExecutor();
+        try {
+            tui.fetchUpdates(Runnable::run, executor).join();
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(deps.get(0).newestVersion).isEqualTo("2.0.0");
+        assertThat(deps.get(0).updateType).isEqualTo(VersionComparator.UpdateType.MAJOR);
+        assertThat(tui.loadedCount).isEqualTo(2);
+        assertThat(tui.loading).isFalse();
+        assertThat(tui.status).contains("update(s) available");
+    }
+
+    @Test
+    void fetchUpdatesWithFailure() {
+        var deps = new ArrayList<UpdatesTui.DependencyInfo>();
+        deps.add(new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar"));
+
+        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> {
+            throw new Exception("network error");
+        });
+
+        var executor = Executors.newSingleThreadExecutor();
+        try {
+            tui.fetchUpdates(Runnable::run, executor).join();
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(tui.failedCount).isEqualTo(1);
+        assertThat(tui.loadedCount).isEqualTo(1);
+        assertThat(tui.loading).isFalse();
+        assertThat(tui.status).contains("1 lookup(s) failed");
+    }
+
+    @Test
+    void fetchUpdatesMixedSuccessAndFailure() {
+        var deps = new ArrayList<UpdatesTui.DependencyInfo>();
+        deps.add(new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar"));
+        deps.add(new UpdatesTui.DependencyInfo("com.example", "broken", "1.0", "compile", "jar"));
+
+        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> {
+            if ("broken".equals(a)) throw new Exception("timeout");
+            return List.of("2.0.0", "1.0.0");
+        });
+
+        var executor = Executors.newSingleThreadExecutor();
+        try {
+            tui.fetchUpdates(Runnable::run, executor).join();
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(tui.loadedCount).isEqualTo(2);
+        assertThat(tui.failedCount).isEqualTo(1);
+        assertThat(tui.loading).isFalse();
+        assertThat(deps.get(0).newestVersion).isEqualTo("2.0.0");
+        assertThat(deps.get(1).newestVersion).isNull();
     }
 }

--- a/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
@@ -19,6 +19,7 @@
 package eu.maveniverse.maven.pilot;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,9 +40,9 @@ class UpdatesTuiTest {
         UpdatesTui.VersionResolver resolver = (g, a) -> {
             throw new Exception("repo unavailable");
         };
-        org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () -> {
-            resolver.resolveVersions("com.example", "lib");
-        });
+        assertThatThrownBy(() -> resolver.resolveVersions("com.example", "lib"))
+                .isInstanceOf(Exception.class)
+                .hasMessage("repo unavailable");
     }
 
     @Test
@@ -57,8 +58,7 @@ class UpdatesTuiTest {
         tui.updateStatusIfDone();
 
         assertThat(tui.loading).isFalse();
-        assertThat(tui.status).contains("1 update(s) available");
-        assertThat(tui.status).doesNotContain("failed");
+        assertThat(tui.status).contains("1 update(s) available").doesNotContain("failed");
     }
 
     @Test
@@ -74,8 +74,7 @@ class UpdatesTuiTest {
         tui.updateStatusIfDone();
 
         assertThat(tui.loading).isFalse();
-        assertThat(tui.status).contains("0 update(s) available");
-        assertThat(tui.status).contains("2 lookup(s) failed");
+        assertThat(tui.status).contains("0 update(s) available").contains("2 lookup(s) failed");
     }
 
     @Test
@@ -116,7 +115,7 @@ class UpdatesTuiTest {
     @Test
     void dependencyInfoDefaults() {
         var dep = new UpdatesTui.DependencyInfo("g", "a", null, null, null);
-        assertThat(dep.version).isEqualTo("");
+        assertThat(dep.version).isEmpty();
         assertThat(dep.scope).isEqualTo("compile");
         assertThat(dep.type).isEqualTo("jar");
     }


### PR DESCRIPTION
## Summary

- **Dependency tree**: scope-aware filtering (`compile`/`runtime`/`test`) and conflict detection using Resolver's `conflict.originalVersion` node data
- **Updates**: integrated Maven Resolver (`resolveVersionRange`) for version lookups instead of direct metadata fetching, with async error handling and failure reporting
- **Analyze**: classifier-aware dependency identity (`groupId:artifactId[:classifier]`)
- **Tests**: comprehensive coverage for tree model (scope filtering, conflicts, cycles), updates TUI (version resolution, async fetch, edge cases), and utility methods

## Changes

| Area | Details |
|---|---|
| `DependencyTreeModel` | Scope constants + `SCOPE_INCLUSIONS` map, `fromDependencyNode(root, scope)` overload with validation, conflict attribution from `conflict.originalVersion` node data, cycle detection |
| `UpdatesTui` | `VersionResolver` interface, extracted `fetchUpdates`/`applyVersionResult`/`updateStatusIfDone` for testability, `versionsNewestFirst` utility, failure counting |
| `UpdatesMojo` | Constructor injection of `RepositorySystem`, version resolver lambda using `resolveVersionRange` |
| `AnalyzeMojo`/`AnalyzeTui` | Classifier-aware `DepEntry.ga()` formatting |
| `TreeMojo` | Passes scope parameter to `fromDependencyNode` |
| Tests | 472 new test lines: `DependencyTreeModelTest` (16 tests), `UpdatesTuiTest` (20 tests) |

## Test plan

- [x] All 108 tests pass (103 run + 5 skipped screenshot tests)
- [x] SonarCloud quality gate: coverage on new code >= 80%
- [x] SonarCloud: 0 open issues
- [x] CodeRabbit review addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>