### PR TITLE
fix: display classifier in analyze TUI

### DIFF
--- a/src/main/java/eu/maveniverse/maven/pilot/AnalyzeMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AnalyzeMojo.java
@@ -75,10 +75,12 @@ public class AnalyzeMojo extends AbstractMojo {
             Set<String> declaredGAs = new HashSet<>();
             List<AnalyzeTui.DepEntry> declared = new ArrayList<>();
             for (Dependency dep : project.getDependencies()) {
-                String ga = dep.getGroupId() + ":" + dep.getArtifactId();
-                declaredGAs.add(ga);
+                String classifier = dep.getClassifier() != null ? dep.getClassifier() : "";
+                String key =
+                        dep.getGroupId() + ":" + dep.getArtifactId() + (classifier.isEmpty() ? "" : ":" + classifier);
+                declaredGAs.add(key);
                 declared.add(new AnalyzeTui.DepEntry(
-                        dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), true));
+                        dep.getGroupId(), dep.getArtifactId(), classifier, dep.getVersion(), dep.getScope(), true));
             }
 
             // Resolve full transitive tree
@@ -121,9 +123,10 @@ public class AnalyzeMojo extends AbstractMojo {
         for (DependencyNode child : node.getChildren()) {
             if (child.getDependency() == null) continue;
             var art = child.getDependency().getArtifact();
-            String ga = art.getGroupId() + ":" + art.getArtifactId();
+            String classifier = art.getClassifier() != null ? art.getClassifier() : "";
+            String key = art.getGroupId() + ":" + art.getArtifactId() + (classifier.isEmpty() ? "" : ":" + classifier);
 
-            if (!declaredGAs.contains(ga) && seen.add(ga)) {
+            if (!declaredGAs.contains(key) && seen.add(key)) {
                 String via = "";
                 if (node.getDependency() != null) {
                     via = node.getDependency().getArtifact().getGroupId() + ":"
@@ -132,6 +135,7 @@ public class AnalyzeMojo extends AbstractMojo {
                 var entry = new AnalyzeTui.DepEntry(
                         art.getGroupId(),
                         art.getArtifactId(),
+                        classifier,
                         art.getVersion(),
                         child.getDependency().getScope(),
                         false);
@@ -139,7 +143,7 @@ public class AnalyzeMojo extends AbstractMojo {
                 result.add(entry);
             }
 
-            collectTransitive(child, declaredGAs, seen, result, ga);
+            collectTransitive(child, declaredGAs, seen, result, key);
         }
     }
 }

--- a/src/main/java/eu/maveniverse/maven/pilot/AnalyzeMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AnalyzeMojo.java
@@ -61,9 +61,7 @@ public class AnalyzeMojo extends AbstractMojo {
     private RepositorySystem repoSystem;
 
     /**
-     * Collects declared dependencies from the project POM, resolves the full transitive
-     * dependency tree, and presents a side-by-side view of declared vs transitive dependencies
-     * using the Analyze TUI.
+     * Analyze the project's declared dependencies against the full transitive dependency tree and launch the interactive Analyze TUI.
      *
      * @throws MojoExecutionException if dependency collection, traversal, or the TUI run fails
      */

--- a/src/main/java/eu/maveniverse/maven/pilot/AnalyzeMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AnalyzeMojo.java
@@ -33,7 +33,6 @@ import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.collection.CollectResult;
-import org.eclipse.aether.graph.DependencyNode;
 
 /**
  * Interactive TUI showing declared vs transitive dependency overview.
@@ -75,15 +74,14 @@ public class AnalyzeMojo extends AbstractMojo {
             Set<String> declaredGAs = new HashSet<>();
             List<AnalyzeTui.DepEntry> declared = new ArrayList<>();
             for (Dependency dep : project.getDependencies()) {
-                var entry = new AnalyzeTui.DepEntry(
+                AnalyzeTui.addDeclaredEntry(
+                        declaredGAs,
+                        declared,
                         dep.getGroupId(),
                         dep.getArtifactId(),
                         dep.getClassifier(),
                         dep.getVersion(),
-                        dep.getScope(),
-                        true);
-                declaredGAs.add(entry.ga());
-                declared.add(entry);
+                        dep.getScope());
             }
 
             // Resolve full transitive tree
@@ -92,7 +90,7 @@ public class AnalyzeMojo extends AbstractMojo {
             // Find transitive (undeclared) dependencies
             Set<String> transitiveGAs = new HashSet<>();
             List<AnalyzeTui.DepEntry> transitive = new ArrayList<>();
-            collectTransitive(result.getRoot(), declaredGAs, transitiveGAs, transitive, "");
+            AnalyzeTui.collectTransitive(result.getRoot(), declaredGAs, transitiveGAs, transitive);
 
             String pomPath = project.getFile().getAbsolutePath();
             String gav = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
@@ -101,48 +99,6 @@ public class AnalyzeMojo extends AbstractMojo {
             tui.run();
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to analyze dependencies: " + e.getMessage(), e);
-        }
-    }
-
-    /**
-     * Traverse a resolved dependency tree and collect dependencies that are present in the tree
-     * but not declared in the project's POM.
-     *
-     * For each discovered undeclared dependency this method adds an AnalyzeTui.DepEntry to
-     * {@code result} and records its GA in {@code seen} to avoid duplicates.
-     *
-     * @param node the dependency tree node to traverse
-     * @param declaredGAs set of declared `groupId:artifactId` values to skip
-     * @param seen mutable set used to deduplicate discovered GAs; entries will be added as discovered
-     * @param result mutable list that will be populated with undeclared dependency entries
-     * @param pulledBy the `groupId:artifactId` of the dependency that pulled the current node (recursion context)
-     */
-    private void collectTransitive(
-            DependencyNode node,
-            Set<String> declaredGAs,
-            Set<String> seen,
-            List<AnalyzeTui.DepEntry> result,
-            String pulledBy) {
-        for (DependencyNode child : node.getChildren()) {
-            if (child.getDependency() == null) continue;
-            var art = child.getDependency().getArtifact();
-            var entry = new AnalyzeTui.DepEntry(
-                    art.getGroupId(),
-                    art.getArtifactId(),
-                    art.getClassifier(),
-                    art.getVersion(),
-                    child.getDependency().getScope(),
-                    false);
-
-            if (!declaredGAs.contains(entry.ga()) && seen.add(entry.ga())) {
-                if (node.getDependency() != null) {
-                    entry.pulledBy = node.getDependency().getArtifact().getGroupId() + ":"
-                            + node.getDependency().getArtifact().getArtifactId();
-                }
-                result.add(entry);
-            }
-
-            collectTransitive(child, declaredGAs, seen, result, entry.ga());
         }
     }
 }

--- a/src/main/java/eu/maveniverse/maven/pilot/AnalyzeMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AnalyzeMojo.java
@@ -75,12 +75,15 @@ public class AnalyzeMojo extends AbstractMojo {
             Set<String> declaredGAs = new HashSet<>();
             List<AnalyzeTui.DepEntry> declared = new ArrayList<>();
             for (Dependency dep : project.getDependencies()) {
-                String classifier = dep.getClassifier() != null ? dep.getClassifier() : "";
-                String key =
-                        dep.getGroupId() + ":" + dep.getArtifactId() + (classifier.isEmpty() ? "" : ":" + classifier);
-                declaredGAs.add(key);
-                declared.add(new AnalyzeTui.DepEntry(
-                        dep.getGroupId(), dep.getArtifactId(), classifier, dep.getVersion(), dep.getScope(), true));
+                var entry = new AnalyzeTui.DepEntry(
+                        dep.getGroupId(),
+                        dep.getArtifactId(),
+                        dep.getClassifier(),
+                        dep.getVersion(),
+                        dep.getScope(),
+                        true);
+                declaredGAs.add(entry.ga());
+                declared.add(entry);
             }
 
             // Resolve full transitive tree
@@ -123,27 +126,23 @@ public class AnalyzeMojo extends AbstractMojo {
         for (DependencyNode child : node.getChildren()) {
             if (child.getDependency() == null) continue;
             var art = child.getDependency().getArtifact();
-            String classifier = art.getClassifier() != null ? art.getClassifier() : "";
-            String key = art.getGroupId() + ":" + art.getArtifactId() + (classifier.isEmpty() ? "" : ":" + classifier);
+            var entry = new AnalyzeTui.DepEntry(
+                    art.getGroupId(),
+                    art.getArtifactId(),
+                    art.getClassifier(),
+                    art.getVersion(),
+                    child.getDependency().getScope(),
+                    false);
 
-            if (!declaredGAs.contains(key) && seen.add(key)) {
-                String via = "";
+            if (!declaredGAs.contains(entry.ga()) && seen.add(entry.ga())) {
                 if (node.getDependency() != null) {
-                    via = node.getDependency().getArtifact().getGroupId() + ":"
+                    entry.pulledBy = node.getDependency().getArtifact().getGroupId() + ":"
                             + node.getDependency().getArtifact().getArtifactId();
                 }
-                var entry = new AnalyzeTui.DepEntry(
-                        art.getGroupId(),
-                        art.getArtifactId(),
-                        classifier,
-                        art.getVersion(),
-                        child.getDependency().getScope(),
-                        false);
-                entry.pulledBy = via;
                 result.add(entry);
             }
 
-            collectTransitive(child, declaredGAs, seen, result, key);
+            collectTransitive(child, declaredGAs, seen, result, entry.ga());
         }
     }
 }

--- a/src/main/java/eu/maveniverse/maven/pilot/AnalyzeTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AnalyzeTui.java
@@ -44,6 +44,8 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import org.eclipse.aether.graph.DependencyNode;
 
 /**
  * Interactive TUI showing declared vs transitive dependency overview.
@@ -69,11 +71,57 @@ class AnalyzeTui {
         }
 
         String ga() {
-            return classifier.isEmpty() ? groupId + ":" + artifactId : groupId + ":" + artifactId + ":" + classifier;
+            return hasClassifier() ? groupId + ":" + artifactId + ":" + classifier : groupId + ":" + artifactId;
         }
 
         String gav() {
             return ga() + ":" + version;
+        }
+
+        boolean hasClassifier() {
+            return !classifier.isEmpty();
+        }
+    }
+
+    /**
+     * Create a declared dependency entry and register it.
+     */
+    static void addDeclaredEntry(
+            Set<String> declaredGAs,
+            List<DepEntry> declared,
+            String groupId,
+            String artifactId,
+            String classifier,
+            String version,
+            String scope) {
+        var entry = new DepEntry(groupId, artifactId, classifier, version, scope, true);
+        declaredGAs.add(entry.ga());
+        declared.add(entry);
+    }
+
+    /**
+     * Recursively collect transitive dependencies from the resolved dependency tree.
+     */
+    static void collectTransitive(
+            DependencyNode node, Set<String> declaredGAs, Set<String> seen, List<DepEntry> result) {
+        for (DependencyNode child : node.getChildren()) {
+            if (child.getDependency() == null) continue;
+            var art = child.getDependency().getArtifact();
+            var entry = new DepEntry(
+                    art.getGroupId(),
+                    art.getArtifactId(),
+                    art.getClassifier(),
+                    art.getVersion(),
+                    child.getDependency().getScope(),
+                    false);
+            if (!declaredGAs.contains(entry.ga()) && seen.add(entry.ga())) {
+                if (node.getDependency() != null) {
+                    entry.pulledBy = node.getDependency().getArtifact().getGroupId() + ":"
+                            + node.getDependency().getArtifact().getArtifactId();
+                }
+                result.add(entry);
+            }
+            collectTransitive(child, declaredGAs, seen, result);
         }
     }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/AnalyzeTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AnalyzeTui.java
@@ -59,7 +59,16 @@ class AnalyzeTui {
         final String version;
         final String scope;
         final boolean declared;
-        String pulledBy; // for transitive deps: who pulled this in
+        String pulledBy; /**
+         * Creates a DepEntry representing a dependency row in the TUI.
+         *
+         * @param groupId    the dependency groupId
+         * @param artifactId the dependency artifactId
+         * @param classifier the dependency classifier; null is normalized to an empty string
+         * @param version    the dependency version; null is normalized to an empty string
+         * @param scope      the dependency scope; null is normalized to "compile"
+         * @param declared   true if this entry corresponds to a declared dependency in the POM UI, false for a transitive entry
+         */
 
         DepEntry(String groupId, String artifactId, String classifier, String version, String scope, boolean declared) {
             this.groupId = groupId;
@@ -70,21 +79,47 @@ class AnalyzeTui {
             this.declared = declared;
         }
 
+        /**
+         * Format the dependency's group and artifact (including the classifier when present).
+         *
+         * @return `groupId:artifactId:classifier` if `classifier` is non-empty, otherwise `groupId:artifactId`.
+         */
         String ga() {
             return hasClassifier() ? groupId + ":" + artifactId + ":" + classifier : groupId + ":" + artifactId;
         }
 
+        /**
+         * Build the dependency coordinates string including version.
+         *
+         * @return the coordinates in the form `groupId:artifactId:version`, with an extra `:classifier` inserted between `artifactId` and `version` when the classifier is non-empty
+         */
         String gav() {
             return ga() + ":" + version;
         }
 
+        /**
+         * Indicates whether this dependency includes a classifier.
+         *
+         * @return {@code true} if the {@code classifier} is not empty, {@code false} otherwise.
+         */
         boolean hasClassifier() {
             return !classifier.isEmpty();
         }
     }
 
     /**
-     * Create a declared dependency entry and register it.
+     * Create and register a declared dependency entry.
+     *
+     * Adds a DepEntry marked as declared to the provided list and records its
+     * groupId:artifactId[:classifier] identifier in the provided set.
+     *
+     * @param declaredGAs set where the dependency's GA (`groupId:artifactId[:classifier]`) will be recorded
+     * @param declared list to append the new declared DepEntry to
+     * @param groupId dependency groupId
+     * @param artifactId dependency artifactId
+     * @param classifier dependency classifier (may be empty)
+     * @param version dependency version
+     * @param scope dependency scope
      */
     static void addDeclaredEntry(
             Set<String> declaredGAs,
@@ -100,7 +135,17 @@ class AnalyzeTui {
     }
 
     /**
-     * Recursively collect transitive dependencies from the resolved dependency tree.
+     * Traverse the resolved dependency tree and add transitive dependencies to {@code result}.
+     *
+     * Each discovered transitive dependency that is not present in {@code declaredGAs} and
+     * has not been seen before (by its GA) is appended to {@code result}. When a dependency
+     * is discovered from a parent node, its {@code pulledBy} field is set to the parent's
+     * {@code groupId:artifactId}.
+     *
+     * @param node the current dependency tree node to traverse
+     * @param declaredGAs set of declared dependency GAs (groupId:artifactId[:classifier]) to exclude
+     * @param seen set used to deduplicate discovered GAs; entries are added as they are recorded
+     * @param result list that will receive new transitive {@code DepEntry} instances
      */
     static void collectTransitive(
             DependencyNode node, Set<String> declaredGAs, Set<String> seen, List<DepEntry> result) {
@@ -278,11 +323,11 @@ class AnalyzeTui {
     }
 
     /**
-     * Adds the currently selected transitive dependency to the project's POM and moves it into the declared list.
+     * Add the selected transitive dependency to the project's POM and mark it as declared in memory.
      *
-     * Updates the POM file to declare the dependency, removes the entry from the transitive list, clears its
-     * `pulledBy` field, appends a new declared `DepEntry`, updates the status message, and adjusts the table
-     * selection if the previously selected index becomes out of range.
+     * Updates the POM to declare the dependency, moves the entry from the transitive list into the declared list
+     * (clearing its `pulledBy`), updates the status message, and adjusts the table selection if the previous index
+     * becomes out of range.
      */
     private void addTransitive() {
         int sel = selectedIndex();

--- a/src/main/java/eu/maveniverse/maven/pilot/AnalyzeTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AnalyzeTui.java
@@ -53,25 +53,27 @@ class AnalyzeTui {
     static class DepEntry {
         final String groupId;
         final String artifactId;
+        final String classifier;
         final String version;
         final String scope;
         final boolean declared;
         String pulledBy; // for transitive deps: who pulled this in
 
-        DepEntry(String groupId, String artifactId, String version, String scope, boolean declared) {
+        DepEntry(String groupId, String artifactId, String classifier, String version, String scope, boolean declared) {
             this.groupId = groupId;
             this.artifactId = artifactId;
+            this.classifier = classifier != null ? classifier : "";
             this.version = version != null ? version : "";
             this.scope = scope != null ? scope : "compile";
             this.declared = declared;
         }
 
         String ga() {
-            return groupId + ":" + artifactId;
+            return classifier.isEmpty() ? groupId + ":" + artifactId : groupId + ":" + artifactId + ":" + classifier;
         }
 
         String gav() {
-            return groupId + ":" + artifactId + ":" + version;
+            return ga() + ":" + version;
         }
     }
 
@@ -248,7 +250,7 @@ class AnalyzeTui {
             // Move from transitive to declared
             transitive.remove(sel);
             dep.pulledBy = null;
-            declared.add(new DepEntry(dep.groupId, dep.artifactId, dep.version, dep.scope, true));
+            declared.add(new DepEntry(dep.groupId, dep.artifactId, dep.classifier, dep.version, dep.scope, true));
             status = "Added " + dep.ga() + " to POM";
             if (sel >= transitive.size() && !transitive.isEmpty()) {
                 tableState.select(transitive.size() - 1);

--- a/src/main/java/eu/maveniverse/maven/pilot/AnalyzeTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AnalyzeTui.java
@@ -59,7 +59,9 @@ class AnalyzeTui {
         final String version;
         final String scope;
         final boolean declared;
-        String pulledBy; /**
+        String pulledBy;
+
+        /**
          * Creates a DepEntry representing a dependency row in the TUI.
          *
          * @param groupId    the dependency groupId
@@ -69,7 +71,6 @@ class AnalyzeTui {
          * @param scope      the dependency scope; null is normalized to "compile"
          * @param declared   true if this entry corresponds to a declared dependency in the POM UI, false for a transitive entry
          */
-
         DepEntry(String groupId, String artifactId, String classifier, String version, String scope, boolean declared) {
             this.groupId = groupId;
             this.artifactId = artifactId;

--- a/src/test/java/eu/maveniverse/maven/pilot/AnalyzeDemoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AnalyzeDemoTest.java
@@ -34,15 +34,15 @@ class AnalyzeDemoTest {
     @Test
     void browseDeclaredAndTransitive() throws Exception {
         List<AnalyzeTui.DepEntry> declared = new ArrayList<>();
-        declared.add(new AnalyzeTui.DepEntry("com.google.guava", "guava", "33.0.0-jre", "compile", true));
-        declared.add(new AnalyzeTui.DepEntry("org.slf4j", "slf4j-api", "2.0.9", "compile", true));
-        declared.add(new AnalyzeTui.DepEntry("commons-io", "commons-io", "2.15.1", "compile", true));
+        declared.add(new AnalyzeTui.DepEntry("com.google.guava", "guava", "", "33.0.0-jre", "compile", true));
+        declared.add(new AnalyzeTui.DepEntry("org.slf4j", "slf4j-api", "", "2.0.9", "compile", true));
+        declared.add(new AnalyzeTui.DepEntry("commons-io", "commons-io", "", "2.15.1", "compile", true));
 
         List<AnalyzeTui.DepEntry> transitive = new ArrayList<>();
-        var t1 = new AnalyzeTui.DepEntry("com.google.guava", "failureaccess", "1.0.2", "compile", false);
+        var t1 = new AnalyzeTui.DepEntry("com.google.guava", "failureaccess", "", "1.0.2", "compile", false);
         t1.pulledBy = "guava";
         transitive.add(t1);
-        var t2 = new AnalyzeTui.DepEntry("org.checkerframework", "checker-qual", "3.42.0", "compile", false);
+        var t2 = new AnalyzeTui.DepEntry("org.checkerframework", "checker-qual", "", "3.42.0", "compile", false);
         t2.pulledBy = "guava";
         transitive.add(t2);
 

--- a/src/test/java/eu/maveniverse/maven/pilot/AnalyzeTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AnalyzeTuiTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class AnalyzeTuiTest {
+
+    @Test
+    void depEntryGaWithoutClassifier() {
+        var dep = new AnalyzeTui.DepEntry("org.slf4j", "slf4j-api", "", "2.0.9", "compile", true);
+        assertThat(dep.ga()).isEqualTo("org.slf4j:slf4j-api");
+    }
+
+    @Test
+    void depEntryGaWithClassifier() {
+        var dep = new AnalyzeTui.DepEntry("dev.tamboui", "tamboui-core", "test-fixtures", "0.1.0", "test", true);
+        assertThat(dep.ga()).isEqualTo("dev.tamboui:tamboui-core:test-fixtures");
+    }
+
+    @Test
+    void depEntryGavWithoutClassifier() {
+        var dep = new AnalyzeTui.DepEntry("org.slf4j", "slf4j-api", "", "2.0.9", "compile", true);
+        assertThat(dep.gav()).isEqualTo("org.slf4j:slf4j-api:2.0.9");
+    }
+
+    @Test
+    void depEntryGavWithClassifier() {
+        var dep = new AnalyzeTui.DepEntry("dev.tamboui", "tamboui-core", "test-fixtures", "0.1.0", "test", true);
+        assertThat(dep.gav()).isEqualTo("dev.tamboui:tamboui-core:test-fixtures:0.1.0");
+    }
+
+    @Test
+    void depEntryNullClassifierDefaultsToEmpty() {
+        var dep = new AnalyzeTui.DepEntry("g", "a", null, "1.0", "compile", true);
+        assertThat(dep.classifier).isEmpty();
+        assertThat(dep.ga()).isEqualTo("g:a");
+    }
+
+    @Test
+    void depEntryDefaults() {
+        var dep = new AnalyzeTui.DepEntry("g", "a", null, null, null, false);
+        assertThat(dep.version).isEmpty();
+        assertThat(dep.scope).isEqualTo("compile");
+        assertThat(dep.classifier).isEmpty();
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/AnalyzeTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AnalyzeTuiTest.java
@@ -20,6 +20,13 @@ package eu.maveniverse.maven.pilot;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.Dependency;
 import org.junit.jupiter.api.Test;
 
 class AnalyzeTuiTest {
@@ -61,5 +68,144 @@ class AnalyzeTuiTest {
         assertThat(dep.version).isEmpty();
         assertThat(dep.scope).isEqualTo("compile");
         assertThat(dep.classifier).isEmpty();
+    }
+
+    @Test
+    void depEntryHasClassifier() {
+        assertThat(new AnalyzeTui.DepEntry("g", "a", "tests", "1.0", "test", true).hasClassifier())
+                .isTrue();
+        assertThat(new AnalyzeTui.DepEntry("g", "a", "", "1.0", "compile", true).hasClassifier())
+                .isFalse();
+        assertThat(new AnalyzeTui.DepEntry("g", "a", null, "1.0", "compile", true).hasClassifier())
+                .isFalse();
+    }
+
+    @Test
+    void addDeclaredEntry() {
+        Set<String> gas = new HashSet<>();
+        List<AnalyzeTui.DepEntry> entries = new ArrayList<>();
+        AnalyzeTui.addDeclaredEntry(gas, entries, "org.slf4j", "slf4j-api", "", "2.0.9", "compile");
+        assertThat(entries).hasSize(1);
+        assertThat(entries.get(0).declared).isTrue();
+        assertThat(entries.get(0).ga()).isEqualTo("org.slf4j:slf4j-api");
+        assertThat(gas).contains("org.slf4j:slf4j-api");
+    }
+
+    @Test
+    void addDeclaredEntryWithClassifier() {
+        Set<String> gas = new HashSet<>();
+        List<AnalyzeTui.DepEntry> entries = new ArrayList<>();
+        AnalyzeTui.addDeclaredEntry(gas, entries, "dev.tamboui", "tamboui-core", "test-fixtures", "0.1.0", "test");
+        assertThat(entries.get(0).ga()).isEqualTo("dev.tamboui:tamboui-core:test-fixtures");
+        assertThat(gas).contains("dev.tamboui:tamboui-core:test-fixtures");
+    }
+
+    // -- collectTransitive tests --
+
+    private DefaultDependencyNode depNode(String g, String a, String v, String scope) {
+        var artifact = new DefaultArtifact(g, a, "", "jar", v);
+        return new DefaultDependencyNode(new Dependency(artifact, scope));
+    }
+
+    private DefaultDependencyNode rootNode(String g, String a, String v) {
+        return new DefaultDependencyNode(new DefaultArtifact(g, a, "", "jar", v));
+    }
+
+    @Test
+    void collectTransitiveFindsUndeclared() {
+        var root = rootNode("com.example", "app", "1.0");
+        var child = depNode("org.slf4j", "slf4j-api", "2.0.9", "compile");
+        var grandchild = depNode("org.slf4j", "slf4j-impl", "2.0.9", "runtime");
+        child.setChildren(List.of(grandchild));
+        root.setChildren(List.of(child));
+
+        Set<String> declaredGAs = Set.of("org.slf4j:slf4j-api");
+        Set<String> seen = new HashSet<>();
+        List<AnalyzeTui.DepEntry> result = new ArrayList<>();
+
+        AnalyzeTui.collectTransitive(root, declaredGAs, seen, result);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).ga()).isEqualTo("org.slf4j:slf4j-impl");
+        assertThat(result.get(0).declared).isFalse();
+    }
+
+    @Test
+    void collectTransitiveSetsPulledBy() {
+        var root = rootNode("com.example", "app", "1.0");
+        var child = depNode("com.google.guava", "guava", "33.0", "compile");
+        var grandchild = depNode("com.google.guava", "failureaccess", "1.0.2", "compile");
+        child.setChildren(List.of(grandchild));
+        root.setChildren(List.of(child));
+
+        Set<String> declaredGAs = Set.of("com.google.guava:guava");
+        Set<String> seen = new HashSet<>();
+        List<AnalyzeTui.DepEntry> result = new ArrayList<>();
+
+        AnalyzeTui.collectTransitive(root, declaredGAs, seen, result);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).pulledBy).isEqualTo("com.google.guava:guava");
+    }
+
+    @Test
+    void collectTransitiveSkipsDeclared() {
+        var root = rootNode("com.example", "app", "1.0");
+        var child = depNode("org.slf4j", "slf4j-api", "2.0.9", "compile");
+        root.setChildren(List.of(child));
+
+        Set<String> declaredGAs = Set.of("org.slf4j:slf4j-api");
+        Set<String> seen = new HashSet<>();
+        List<AnalyzeTui.DepEntry> result = new ArrayList<>();
+
+        AnalyzeTui.collectTransitive(root, declaredGAs, seen, result);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void collectTransitiveDeduplicates() {
+        var root = rootNode("com.example", "app", "1.0");
+        var child1 = depNode("com.google.guava", "guava", "33.0", "compile");
+        var child2 = depNode("com.example", "other", "1.0", "compile");
+        // Both pull the same transitive dep
+        var dup1 = depNode("com.google.guava", "failureaccess", "1.0.2", "compile");
+        var dup2 = depNode("com.google.guava", "failureaccess", "1.0.2", "compile");
+        child1.setChildren(List.of(dup1));
+        child2.setChildren(List.of(dup2));
+        root.setChildren(List.of(child1, child2));
+
+        Set<String> declaredGAs = new HashSet<>();
+        Set<String> seen = new HashSet<>();
+        List<AnalyzeTui.DepEntry> result = new ArrayList<>();
+
+        AnalyzeTui.collectTransitive(root, declaredGAs, seen, result);
+
+        long failureAccessCount = result.stream()
+                .filter(e -> e.ga().equals("com.google.guava:failureaccess"))
+                .count();
+        assertThat(failureAccessCount).isEqualTo(1);
+    }
+
+    @Test
+    void collectTransitiveWithClassifier() {
+        var root = rootNode("com.example", "app", "1.0");
+        var child = depNode("com.example", "lib", "1.0", "compile");
+        var artifact = new DefaultArtifact("dev.tamboui", "tamboui-core", "test-fixtures", "jar", "0.1.0");
+        var classifiedChild = new DefaultDependencyNode(new Dependency(artifact, "test"));
+        child.setChildren(List.of(classifiedChild));
+        root.setChildren(List.of(child));
+
+        Set<String> declaredGAs = new HashSet<>();
+        Set<String> seen = new HashSet<>();
+        List<AnalyzeTui.DepEntry> result = new ArrayList<>();
+
+        AnalyzeTui.collectTransitive(root, declaredGAs, seen, result);
+
+        var classified = result.stream()
+                .filter(e -> e.ga().equals("dev.tamboui:tamboui-core:test-fixtures"))
+                .findFirst();
+        assertThat(classified).isPresent();
+        assertThat(classified.get().classifier).isEqualTo("test-fixtures");
     }
 }

--- a/src/test/java/eu/maveniverse/maven/pilot/AnalyzeTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AnalyzeTuiTest.java
@@ -206,6 +206,6 @@ class AnalyzeTuiTest {
                 .filter(e -> e.ga().equals("dev.tamboui:tamboui-core:test-fixtures"))
                 .findFirst();
         assertThat(classified).isPresent();
-        assertThat(classified.get().classifier).isEqualTo("test-fixtures");
+        assertThat(classified.orElseThrow().classifier).isEqualTo("test-fixtures");
     }
 }

--- a/src/test/java/eu/maveniverse/maven/pilot/ScreenshotTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ScreenshotTest.java
@@ -215,16 +215,16 @@ class ScreenshotTest {
     @Test
     void dependencyAnalysis() throws Exception {
         List<AnalyzeTui.DepEntry> declared = new ArrayList<>();
-        declared.add(new AnalyzeTui.DepEntry("com.google.guava", "guava", "33.0.0-jre", "compile", true));
-        declared.add(new AnalyzeTui.DepEntry("org.slf4j", "slf4j-api", "2.0.9", "compile", true));
-        declared.add(new AnalyzeTui.DepEntry("commons-io", "commons-io", "2.15.1", "compile", true));
-        declared.add(new AnalyzeTui.DepEntry("org.apache.commons", "commons-text", "1.11.0", "compile", false));
+        declared.add(new AnalyzeTui.DepEntry("com.google.guava", "guava", "", "33.0.0-jre", "compile", true));
+        declared.add(new AnalyzeTui.DepEntry("org.slf4j", "slf4j-api", "", "2.0.9", "compile", true));
+        declared.add(new AnalyzeTui.DepEntry("commons-io", "commons-io", "", "2.15.1", "compile", true));
+        declared.add(new AnalyzeTui.DepEntry("org.apache.commons", "commons-text", "", "1.11.0", "compile", false));
 
         List<AnalyzeTui.DepEntry> transitive = new ArrayList<>();
-        var t1 = new AnalyzeTui.DepEntry("com.google.guava", "failureaccess", "1.0.2", "compile", false);
+        var t1 = new AnalyzeTui.DepEntry("com.google.guava", "failureaccess", "", "1.0.2", "compile", false);
         t1.pulledBy = "guava";
         transitive.add(t1);
-        var t2 = new AnalyzeTui.DepEntry("org.checkerframework", "checker-qual", "3.42.0", "compile", false);
+        var t2 = new AnalyzeTui.DepEntry("org.checkerframework", "checker-qual", "", "3.42.0", "compile", false);
         t2.pulledBy = "guava";
         transitive.add(t2);
 


### PR DESCRIPTION
## Summary
- Add `classifier` field to `DepEntry` to distinguish artifacts like `tamboui-core` (compile) from `tamboui-core:test-fixtures` (test)
- Use `DepEntry.ga()` for key computation in `AnalyzeMojo` instead of inline string building
- Display classifier in the GA column when non-empty (e.g., `dev.tamboui:tamboui-core:test-fixtures`)

## Test plan
- [x] Added `AnalyzeTuiTest` with 6 tests covering classifier handling in `ga()`, `gav()`, and defaults
- [x] Updated `ScreenshotTest` and `AnalyzeDemoTest` for new constructor signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dependency tracking now records classifiers (e.g., "jre", "sources") and includes them in dependency identifiers and version strings when present.
  * Transitive collection now excludes declared entries, deduplicates transitive results, and preserves which direct dependency pulled each transitive entry.

* **Tests**
  * Added and updated tests validating classifier handling, GA/GAV formatting, declared vs transitive behavior, pulled-by propagation, and deduplication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->