### PR TITLE
feat: align added dependencies with project conventions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@ under the License.
     <maven.compiler.release>17</maven.compiler.release>
     <mavenVersion>3.9.9</mavenVersion>
     <tamboui.version>0.1.0</tamboui.version>
-    <domtrip.version>1.0.0</domtrip.version>
+    <domtrip.version>1.1.0-SNAPSHOT</domtrip.version>
 
     <!-- SonarCloud -->
     <sonar.projectKey>maveniverse_pilot</sonar.projectKey>
@@ -157,6 +157,19 @@ under the License.
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <repositories>
+    <repository>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>ossrh-snapshots</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+    </repository>
+  </repositories>
 
   <build>
     <plugins>

--- a/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -37,6 +37,7 @@ import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
 import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.maven.AlignOptions;
 import eu.maveniverse.domtrip.maven.Coordinates;
 import eu.maveniverse.domtrip.maven.PomEditor;
 import java.nio.file.Files;
@@ -378,9 +379,9 @@ class DependenciesTui {
 
         try {
             String pomContent = Files.readString(Path.of(pomPath));
-            PomEditor editor = new PomEditor(Document.of(pomContent));
-            editor.dependencies().updateDependency(true, Coordinates.of(dep.groupId, dep.artifactId, dep.version));
-            Files.writeString(Path.of(pomPath), editor.toXml());
+            String updated = addDependencyAligned(
+                    pomContent, dep.groupId, dep.artifactId, dep.version, dep.classifier, dep.scope);
+            Files.writeString(Path.of(pomPath), updated);
 
             // Move from transitive to declared
             transitive.remove(sel);
@@ -480,6 +481,40 @@ class DependenciesTui {
                 .map(e -> e.textContentTrimmedOr("4.0.0"))
                 .orElse("4.0.0");
         return modelVersion.compareTo("4.1.0") >= 0 ? SCOPES_4X : SCOPES_3X;
+    }
+
+    /**
+     * Add a dependency to the POM using convention-aligned placement.
+     * Detects the project's existing conventions (managed vs inline, literal vs property,
+     * property naming pattern) and follows them.
+     *
+     * @param pomContent the current POM XML content
+     * @param groupId the dependency groupId
+     * @param artifactId the dependency artifactId
+     * @param version the dependency version
+     * @param classifier the dependency classifier (may be null or empty)
+     * @param scope the dependency scope (may be null or empty; "compile" is the default)
+     * @return the updated POM XML content
+     */
+    static String addDependencyAligned(
+            String pomContent, String groupId, String artifactId, String version, String classifier, String scope) {
+        PomEditor editor = new PomEditor(Document.of(pomContent));
+        Coordinates coords = (classifier != null && !classifier.isEmpty())
+                ? Coordinates.of(groupId, artifactId, version, classifier, "jar")
+                : Coordinates.of(groupId, artifactId, version);
+        if (scope != null && !scope.isEmpty() && !COMPILE_SCOPE.equals(scope)) {
+            AlignOptions detected = editor.dependencies().detectConventions();
+            AlignOptions options = AlignOptions.builder()
+                    .versionStyle(detected.versionStyle())
+                    .versionSource(detected.versionSource())
+                    .namingConvention(detected.namingConvention())
+                    .scope(scope)
+                    .build();
+            editor.dependencies().addAligned(coords, options);
+        } else {
+            editor.dependencies().addAligned(coords);
+        }
+        return editor.toXml();
     }
 
     // -- Rendering --

--- a/src/test/java/eu/maveniverse/maven/pilot/DependenciesTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/DependenciesTuiTest.java
@@ -208,4 +208,161 @@ class DependenciesTuiTest {
         assertThat(classified).isPresent();
         assertThat(classified.orElseThrow().classifier).isEqualTo("test-fixtures");
     }
+
+    // -- addDependencyAligned tests --
+
+    @Test
+    void addAlignedFollowsInlineLiteralConvention() {
+        String pom = """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>app</artifactId>
+                  <version>1.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.slf4j</groupId>
+                      <artifactId>slf4j-api</artifactId>
+                      <version>2.0.9</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+        String result = DependenciesTui.addDependencyAligned(pom, "com.google.guava", "guava", "33.0", null, null);
+        // Should add with inline literal version (matching existing convention)
+        assertThat(result)
+                .contains("<artifactId>guava</artifactId>")
+                .contains("<version>33.0</version>")
+                .doesNotContain("<dependencyManagement>");
+    }
+
+    @Test
+    void addAlignedFollowsManagedConvention() {
+        String pom = """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>app</artifactId>
+                  <version>1.0</version>
+                  <dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                        <version>2.0.9</version>
+                      </dependency>
+                    </dependencies>
+                  </dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.slf4j</groupId>
+                      <artifactId>slf4j-api</artifactId>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+        String result = DependenciesTui.addDependencyAligned(pom, "com.google.guava", "guava", "33.0", null, null);
+        // Managed entry should contain version
+        String mgmt =
+                result.substring(result.indexOf("<dependencyManagement>"), result.indexOf("</dependencyManagement>"));
+        assertThat(mgmt).contains("<artifactId>guava</artifactId>").contains("<version>33.0</version>");
+        // Dependency in <dependencies> should be version-less
+        String deps = result.substring(result.lastIndexOf("<dependencies>"));
+        assertThat(deps).contains("<artifactId>guava</artifactId>").doesNotContain("<version>33.0</version>");
+    }
+
+    @Test
+    void addAlignedFollowsPropertyConvention() {
+        String pom = """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>app</artifactId>
+                  <version>1.0</version>
+                  <properties>
+                    <slf4j.version>2.0.9</slf4j.version>
+                  </properties>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.slf4j</groupId>
+                      <artifactId>slf4j-api</artifactId>
+                      <version>${slf4j.version}</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+        String result = DependenciesTui.addDependencyAligned(pom, "com.google.guava", "guava", "33.0", null, null);
+        // Should create a version property and reference it via ${...} in the dependency version
+        assertThat(result)
+                .contains("<artifactId>guava</artifactId>")
+                .contains("33.0</")
+                .containsPattern("<version>\\$\\{[^}]+\\}</version>");
+    }
+
+    @Test
+    void addAlignedWithScope() {
+        String pom = """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>app</artifactId>
+                  <version>1.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.slf4j</groupId>
+                      <artifactId>slf4j-api</artifactId>
+                      <version>2.0.9</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+        String result = DependenciesTui.addDependencyAligned(pom, "junit", "junit", "4.13.2", null, "test");
+        assertThat(result).contains("<artifactId>junit</artifactId>").contains("<scope>test</scope>");
+    }
+
+    @Test
+    void addAlignedWithClassifier() {
+        String pom = """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>app</artifactId>
+                  <version>1.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.slf4j</groupId>
+                      <artifactId>slf4j-api</artifactId>
+                      <version>2.0.9</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+        String result = DependenciesTui.addDependencyAligned(
+                pom, "dev.tamboui", "tamboui-core", "0.1.0", "test-fixtures", "test");
+        assertThat(result)
+                .contains("<artifactId>tamboui-core</artifactId>")
+                .contains("<classifier>test-fixtures</classifier>")
+                .contains("<scope>test</scope>");
+    }
+
+    @Test
+    void addAlignedCompileScopeOmitted() {
+        String pom = """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>app</artifactId>
+                  <version>1.0</version>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.slf4j</groupId>
+                      <artifactId>slf4j-api</artifactId>
+                      <version>2.0.9</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+        String result = DependenciesTui.addDependencyAligned(pom, "com.google.guava", "guava", "33.0", null, "compile");
+        assertThat(result).contains("<artifactId>guava</artifactId>").doesNotContain("<scope>");
+    }
 }


### PR DESCRIPTION
## Summary

- Use DomTrip's `addAligned()` instead of `updateDependency()` when promoting transitive dependencies to declared in `pilot:analyze`
- Added dependencies now follow the project's existing conventions: managed vs inline, literal vs property, property naming pattern (`.version`, `-version`, `Version`, `version.`)
- Bump DomTrip from 1.0.0 to 1.1.0-SNAPSHOT for the new alignment API

Closes #11

## Changes

- **`pom.xml`**: bump `domtrip.version` to `1.1.0-SNAPSHOT`
- **`AnalyzeTui.java`**: extract `addDependencyAligned()` static method, wire `addAligned()` in `addTransitive()`
- **`AnalyzeTuiTest.java`**: 3 new tests covering inline-literal, managed, and property conventions

## Test plan

- [x] All 17 tests pass (`mvn test -Dtest=AnalyzeTuiTest`)
- [x] `addAlignedFollowsInlineLiteralConvention` — inline `<version>` preserved, no `<dependencyManagement>` created
- [x] `addAlignedFollowsManagedConvention` — managed entry + version-less dep
- [x] `addAlignedFollowsPropertyConvention` — property created in `<properties>`, referenced with `${...}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved dependency insertion to follow project conventions (inline versions, managed sections, or property-based versions) and added a helper to produce convention-aligned POM updates.

* **Tests**
  * Added tests verifying aligned insertion across inline versions, dependency-management usage, property-based versions, scope handling, and classifier inclusion.

* **Chores**
  * Bumped domtrip to 1.1.0-SNAPSHOT and enabled a snapshot repository for resolving snapshot artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->