### PR TITLE
feat: deferred write mode, diff preview, and property-linked selection (#12)

### DIFF
--- a/src/main/java/eu/maveniverse/maven/pilot/AlignMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignMojo.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.maven.PomEditor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Interactive TUI for detecting and aligning dependency conventions across the POM.
+ *
+ * <p>Detects the project's current version style (inline vs managed), version source
+ * (literal vs property), and property naming convention, then lets the user choose
+ * a target convention and preview/apply the changes.</p>
+ *
+ * <p>Usage:</p>
+ * <pre>
+ * mvn pilot:align
+ * </pre>
+ *
+ * @since 0.2.0
+ */
+@Mojo(name = "align", requiresProject = true, threadSafe = true)
+public class AlignMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            String pomPath = project.getFile().getAbsolutePath();
+            String pomContent = Files.readString(Path.of(pomPath));
+            PomEditor editor = new PomEditor(Document.of(pomContent));
+            var detectedOptions = editor.dependencies().detectConventions();
+
+            String gav = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
+
+            AlignTui tui = new AlignTui(pomPath, gav, pomContent, detectedOptions);
+            tui.run();
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to run alignment TUI: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
@@ -1,0 +1,421 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.tui.TuiRunner;
+import dev.tamboui.tui.event.Event;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import dev.tamboui.widgets.table.Row;
+import dev.tamboui.widgets.table.Table;
+import dev.tamboui.widgets.table.TableState;
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.maven.AlignOptions;
+import eu.maveniverse.domtrip.maven.PomEditor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Interactive TUI for dependency convention alignment.
+ */
+class AlignTui {
+
+    enum Phase {
+        SELECT,
+        PREVIEW
+    }
+
+    private static final int ROW_VERSION_STYLE = 0;
+    private static final int ROW_VERSION_SOURCE = 1;
+    private static final int ROW_PROPERTY_NAMING = 2;
+    private static final int ROW_COUNT = 3;
+
+    private final String pomPath;
+    private final String projectGav;
+    private final String originalPomContent;
+    private final AlignOptions detectedOptions;
+
+    // User-selected convention values (start matching detected)
+    private AlignOptions.VersionStyle selectedStyle;
+    private AlignOptions.VersionSource selectedSource;
+    private AlignOptions.PropertyNamingConvention selectedNaming;
+
+    private Phase phase = Phase.SELECT;
+    private final TableState tableState = new TableState();
+    private String status;
+
+    // Preview state
+    private List<UnifiedDiff.DiffLine> diffLines;
+    private int diffScroll;
+    private String alignedPomContent;
+
+    private TuiRunner runner;
+
+    AlignTui(String pomPath, String projectGav, String originalPomContent, AlignOptions detectedOptions) {
+        this.pomPath = pomPath;
+        this.projectGav = projectGav;
+        this.originalPomContent = originalPomContent;
+        this.detectedOptions = detectedOptions;
+        this.selectedStyle = detectedOptions.versionStyle();
+        this.selectedSource = detectedOptions.versionSource();
+        this.selectedNaming = detectedOptions.namingConvention();
+        this.status = "Detected conventions from POM";
+        tableState.select(0);
+    }
+
+    void run() throws Exception {
+        var configured = TuiRunner.builder()
+                .eventHandler(this::handleEvent)
+                .renderer(this::render)
+                .tickRate(Duration.ofMillis(100))
+                .build();
+        try {
+            runner = configured.runner();
+            configured.run();
+        } finally {
+            configured.close();
+        }
+    }
+
+    boolean handleEvent(Event event, TuiRunner runner) {
+        if (!(event instanceof KeyEvent key)) {
+            return true;
+        }
+
+        if (key.isCtrlC() || key.isCharIgnoreCase('q')) {
+            runner.quit();
+            return true;
+        }
+
+        if (phase == Phase.PREVIEW) {
+            return handlePreviewEvent(key);
+        }
+        return handleSelectEvent(key);
+    }
+
+    private boolean handleSelectEvent(KeyEvent key) {
+        if (key.isKey(KeyCode.ESCAPE)) {
+            runner.quit();
+            return true;
+        }
+
+        if (key.isUp()) {
+            tableState.selectPrevious();
+            return true;
+        }
+        if (key.isDown()) {
+            tableState.selectNext(ROW_COUNT);
+            return true;
+        }
+
+        if (key.isRight() || key.isKey(KeyCode.ENTER)) {
+            cycleForward();
+            return true;
+        }
+        if (key.isLeft()) {
+            cycleBackward();
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('p')) {
+            showPreview();
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('w')) {
+            applyAlignment();
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean handlePreviewEvent(KeyEvent key) {
+        if (key.isKey(KeyCode.ESCAPE)) {
+            phase = Phase.SELECT;
+            diffLines = null;
+            diffScroll = 0;
+            return true;
+        }
+
+        if (key.isUp()) {
+            if (diffScroll > 0) diffScroll--;
+            return true;
+        }
+        if (key.isDown()) {
+            if (diffLines != null) {
+                diffScroll = Math.min(diffScroll + 1, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+            }
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            diffScroll = Math.max(0, diffScroll - 10);
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            if (diffLines != null) {
+                diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+            }
+            return true;
+        }
+
+        if (key.isKey(KeyCode.ENTER) || key.isCharIgnoreCase('w')) {
+            writeAlignedPom();
+            return true;
+        }
+
+        return false;
+    }
+
+    // -- Convention cycling --
+
+    void cycleForward() {
+        int row = selectedRow();
+        switch (row) {
+            case ROW_VERSION_STYLE -> selectedStyle = nextEnum(AlignOptions.VersionStyle.values(), selectedStyle);
+            case ROW_VERSION_SOURCE -> selectedSource = nextEnum(AlignOptions.VersionSource.values(), selectedSource);
+            case ROW_PROPERTY_NAMING ->
+                selectedNaming = nextEnum(AlignOptions.PropertyNamingConvention.values(), selectedNaming);
+        }
+    }
+
+    void cycleBackward() {
+        int row = selectedRow();
+        switch (row) {
+            case ROW_VERSION_STYLE -> selectedStyle = prevEnum(AlignOptions.VersionStyle.values(), selectedStyle);
+            case ROW_VERSION_SOURCE -> selectedSource = prevEnum(AlignOptions.VersionSource.values(), selectedSource);
+            case ROW_PROPERTY_NAMING ->
+                selectedNaming = prevEnum(AlignOptions.PropertyNamingConvention.values(), selectedNaming);
+        }
+    }
+
+    static <E extends Enum<E>> E nextEnum(E[] values, E current) {
+        int idx = current.ordinal();
+        return values[(idx + 1) % values.length];
+    }
+
+    static <E extends Enum<E>> E prevEnum(E[] values, E current) {
+        int idx = current.ordinal();
+        return values[(idx - 1 + values.length) % values.length];
+    }
+
+    private int selectedRow() {
+        Integer sel = tableState.selected();
+        return sel != null ? sel : 0;
+    }
+
+    AlignOptions buildSelectedOptions() {
+        return AlignOptions.builder()
+                .versionStyle(selectedStyle)
+                .versionSource(selectedSource)
+                .namingConvention(selectedNaming)
+                .build();
+    }
+
+    // -- Actions --
+
+    private void showPreview() {
+        try {
+            String currentPom = Files.readString(Path.of(pomPath));
+            PomEditor editor = new PomEditor(Document.of(currentPom));
+            int count = editor.dependencies().alignAllDependencies(buildSelectedOptions());
+            alignedPomContent = editor.toXml();
+
+            var fullDiff = UnifiedDiff.compute(currentPom, alignedPomContent);
+            long changes = UnifiedDiff.changeCount(fullDiff);
+
+            if (changes == 0) {
+                status = "No changes needed \u2014 POM already aligned";
+                return;
+            }
+
+            diffLines = UnifiedDiff.filterContext(fullDiff, 3);
+            diffScroll = 0;
+            phase = Phase.PREVIEW;
+            status = count + " dependency(ies) aligned, " + changes + " line(s) changed";
+        } catch (Exception e) {
+            status = "Failed to compute preview: " + e.getMessage();
+        }
+    }
+
+    private void applyAlignment() {
+        try {
+            String currentPom = Files.readString(Path.of(pomPath));
+            PomEditor editor = new PomEditor(Document.of(currentPom));
+            int count = editor.dependencies().alignAllDependencies(buildSelectedOptions());
+            Files.writeString(Path.of(pomPath), editor.toXml());
+            status = "Aligned " + count + " dependency(ies) in POM";
+        } catch (Exception e) {
+            status = "Failed to apply alignment: " + e.getMessage();
+        }
+    }
+
+    private void writeAlignedPom() {
+        if (alignedPomContent == null) return;
+        try {
+            Files.writeString(Path.of(pomPath), alignedPomContent);
+            status = "Changes written to POM";
+            phase = Phase.SELECT;
+            diffLines = null;
+            diffScroll = 0;
+            alignedPomContent = null;
+        } catch (Exception e) {
+            status = "Failed to write POM: " + e.getMessage();
+        }
+    }
+
+    // -- Rendering --
+
+    private int lastContentHeight;
+
+    void render(Frame frame) {
+        var zones = Layout.vertical()
+                .constraints(Constraint.length(3), Constraint.fill(), Constraint.length(3))
+                .split(frame.area());
+
+        renderHeader(frame, zones.get(0));
+        lastContentHeight = zones.get(1).height();
+
+        if (phase == Phase.PREVIEW && diffLines != null) {
+            UnifiedDiff.render(frame, zones.get(1), diffLines, diffScroll, " POM Changes Preview ");
+        } else {
+            renderConventionTable(frame, zones.get(1));
+        }
+
+        renderInfoBar(frame, zones.get(2));
+    }
+
+    private void renderHeader(Frame frame, Rect area) {
+        String title =
+                phase == Phase.PREVIEW ? " Pilot \u2014 Alignment Preview " : " Pilot \u2014 Convention Alignment ";
+        Block block = Block.builder()
+                .title(title)
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().cyan())
+                .build();
+
+        List<Span> spans = new ArrayList<>();
+        spans.add(Span.raw(" " + projectGav).bold().cyan());
+
+        Paragraph header = Paragraph.builder()
+                .text(dev.tamboui.text.Text.from(Line.from(spans)))
+                .block(block)
+                .build();
+        frame.renderWidget(header, area);
+    }
+
+    private void renderConventionTable(Frame frame, Rect area) {
+        Block block = Block.builder()
+                .title(" Dependency Conventions ")
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().fg(Color.DARK_GRAY))
+                .build();
+
+        Row header = Row.from("Convention", "Detected", "Selected")
+                .style(Style.create().bold().yellow());
+
+        List<Row> rows = new ArrayList<>();
+        rows.add(createConventionRow(
+                "Version Style",
+                detectedOptions.versionStyle().name(),
+                selectedStyle.name(),
+                selectedStyle != detectedOptions.versionStyle()));
+        rows.add(createConventionRow(
+                "Version Source",
+                detectedOptions.versionSource().name(),
+                selectedSource.name(),
+                selectedSource != detectedOptions.versionSource()));
+        rows.add(createConventionRow(
+                "Property Naming",
+                detectedOptions.namingConvention().name(),
+                selectedNaming.name(),
+                selectedNaming != detectedOptions.namingConvention()));
+
+        Table table = Table.builder()
+                .header(header)
+                .rows(rows)
+                .widths(Constraint.percentage(30), Constraint.percentage(35), Constraint.percentage(35))
+                .highlightStyle(Style.create().reversed().bold())
+                .highlightSymbol("\u25B8 ")
+                .block(block)
+                .build();
+
+        frame.renderStatefulWidget(table, area, tableState);
+    }
+
+    private Row createConventionRow(String name, String detected, String selected, boolean changed) {
+        Style style = changed ? Style.create().fg(Color.YELLOW) : Style.create();
+        String selectedDisplay = changed ? selected + " \u2190" : selected;
+        return Row.from(name, detected, selectedDisplay).style(style);
+    }
+
+    private void renderInfoBar(Frame frame, Rect area) {
+        var rows = Layout.vertical()
+                .constraints(Constraint.length(1), Constraint.length(1), Constraint.length(1))
+                .split(area);
+
+        // Status
+        List<Span> statusSpans = new ArrayList<>();
+        statusSpans.add(Span.raw(" " + status).fg(Color.GREEN));
+        frame.renderWidget(Paragraph.from(Line.from(statusSpans)), rows.get(1));
+
+        // Key bindings
+        List<Span> spans = new ArrayList<>();
+        spans.add(Span.raw(" "));
+        if (phase == Phase.PREVIEW) {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Scroll  "));
+            spans.add(Span.raw("PgUp/PgDn").bold());
+            spans.add(Span.raw(":Page  "));
+            spans.add(Span.raw("Enter/w").bold());
+            spans.add(Span.raw(":Apply  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Back  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        } else {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Navigate  "));
+            spans.add(Span.raw("\u2190\u2192/Enter").bold());
+            spans.add(Span.raw(":Cycle  "));
+            spans.add(Span.raw("p").bold());
+            spans.add(Span.raw(":Preview  "));
+            spans.add(Span.raw("w").bold());
+            spans.add(Span.raw(":Apply  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        }
+
+        frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(2));
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -107,6 +107,14 @@ class ConflictsTui {
     private boolean showDetails = false;
     private String status;
 
+    private final String originalPomContent;
+    private final PomEditor editor;
+    private boolean dirty;
+    private boolean pendingQuit;
+    private List<UnifiedDiff.DiffLine> diffLines;
+    private int diffScroll;
+    private int lastContentHeight;
+
     private TuiRunner runner;
 
     /**
@@ -134,6 +142,14 @@ class ConflictsTui {
         this.pomPath = pomPath;
         this.projectGav = projectGav;
         this.status = conflicts.size() + " dependency group(s) with version variance";
+        String pom;
+        try {
+            pom = Files.readString(Path.of(pomPath));
+        } catch (Exception e) {
+            pom = "<project/>";
+        }
+        this.originalPomContent = pom;
+        this.editor = new PomEditor(Document.of(pom));
         if (!conflicts.isEmpty()) {
             tableState.select(0);
         }
@@ -166,8 +182,52 @@ class ConflictsTui {
             return true;
         }
 
-        if (key.isCtrlC() || key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q')) {
-            runner.quit();
+        // Save prompt mode
+        if (pendingQuit) {
+            if (key.isCharIgnoreCase('y')) {
+                saveAndQuit();
+                return true;
+            }
+            if (key.isCharIgnoreCase('n')) {
+                runner.quit();
+                return true;
+            }
+            if (key.isKey(KeyCode.ESCAPE)) {
+                pendingQuit = false;
+                status = "Quit cancelled";
+                return true;
+            }
+            return false;
+        }
+
+        // Diff overlay mode — Esc closes overlay first
+        if (diffLines != null) {
+            if (key.isKey(KeyCode.ESCAPE)) {
+                diffLines = null;
+                diffScroll = 0;
+                return true;
+            }
+            if (key.isUp()) {
+                if (diffScroll > 0) diffScroll--;
+                return true;
+            }
+            if (key.isDown()) {
+                diffScroll = Math.min(diffScroll + 1, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            if (key.isKey(KeyCode.PAGE_UP)) {
+                diffScroll = Math.max(0, diffScroll - 10);
+                return true;
+            }
+            if (key.isKey(KeyCode.PAGE_DOWN)) {
+                diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            return false;
+        }
+
+        if (key.isCtrlC() || key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
+            requestQuit();
             return true;
         }
 
@@ -190,6 +250,11 @@ class ConflictsTui {
             return true;
         }
 
+        if (key.isCharIgnoreCase('d')) {
+            toggleDiffView();
+            return true;
+        }
+
         return false;
     }
 
@@ -207,19 +272,47 @@ class ConflictsTui {
         var group = conflicts.get(sel);
 
         try {
-            String pomContent = Files.readString(Path.of(pomPath));
-            PomEditor editor = new PomEditor(Document.of(pomContent));
-
-            // Pin the resolved version in dependencyManagement
             String resolvedVersion = group.resolvedVersion();
             var coords = Coordinates.of(group.entries.get(0).groupId, group.entries.get(0).artifactId, resolvedVersion);
             editor.dependencies().updateManagedDependency(true, coords);
 
-            Files.writeString(Path.of(pomPath), editor.toXml());
-            status = "Pinned " + group.ga + " to " + resolvedVersion + " in dependencyManagement";
+            dirty = true;
+            status = "Pinned " + group.ga + " to " + resolvedVersion + " \u2014 save on exit";
         } catch (Exception e) {
             status = "Failed to pin version: " + e.getMessage();
         }
+    }
+
+    private void requestQuit() {
+        if (dirty) {
+            pendingQuit = true;
+            status = "Save changes to POM?";
+        } else {
+            runner.quit();
+        }
+    }
+
+    private void saveAndQuit() {
+        try {
+            Files.writeString(Path.of(pomPath), editor.toXml());
+            runner.quit();
+        } catch (Exception e) {
+            pendingQuit = false;
+            status = "Failed to save: " + e.getMessage();
+        }
+    }
+
+    private void toggleDiffView() {
+        String modifiedPom = editor.toXml();
+        var fullDiff = UnifiedDiff.compute(originalPomContent, modifiedPom);
+        long changes = UnifiedDiff.changeCount(fullDiff);
+        if (changes == 0) {
+            status = "No changes to show";
+            return;
+        }
+        diffLines = UnifiedDiff.filterContext(fullDiff, 3);
+        diffScroll = 0;
+        status = changes + " line(s) changed";
     }
 
     // -- Rendering --
@@ -229,15 +322,20 @@ class ConflictsTui {
                 .constraints(
                         Constraint.length(3),
                         Constraint.fill(),
-                        showDetails ? Constraint.percentage(30) : Constraint.length(0),
+                        showDetails && diffLines == null ? Constraint.percentage(30) : Constraint.length(0),
                         Constraint.length(3))
                 .split(frame.area());
 
         renderHeader(frame, zones.get(0));
-        renderConflicts(frame, zones.get(1));
+        lastContentHeight = zones.get(1).height();
 
-        if (showDetails) {
-            renderDetails(frame, zones.get(2));
+        if (diffLines != null) {
+            UnifiedDiff.render(frame, zones.get(1), diffLines, diffScroll, " POM Changes ");
+        } else {
+            renderConflicts(frame, zones.get(1));
+            if (showDetails) {
+                renderDetails(frame, zones.get(2));
+            }
         }
 
         renderInfoBar(frame, zones.get(3));
@@ -252,6 +350,9 @@ class ConflictsTui {
 
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" " + projectGav).bold().cyan());
+        if (dirty) {
+            spans.add(Span.raw("  [modified]").fg(Color.YELLOW));
+        }
 
         Paragraph header = Paragraph.builder()
                 .text(dev.tamboui.text.Text.from(Line.from(spans)))
@@ -371,19 +472,37 @@ class ConflictsTui {
                 .split(area);
 
         List<Span> statusSpans = new ArrayList<>();
-        statusSpans.add(Span.raw(" " + status).fg(Color.GREEN));
+        statusSpans.add(Span.raw(" " + status).fg(pendingQuit ? Color.YELLOW : Color.GREEN));
         frame.renderWidget(Paragraph.from(Line.from(statusSpans)), rows.get(1));
 
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" "));
-        spans.add(Span.raw("\u2191\u2193").bold());
-        spans.add(Span.raw(":Navigate  "));
-        spans.add(Span.raw("Enter").bold());
-        spans.add(Span.raw(":Details  "));
-        spans.add(Span.raw("p").bold());
-        spans.add(Span.raw(":Pin version  "));
-        spans.add(Span.raw("q").bold());
-        spans.add(Span.raw(":Quit"));
+        if (pendingQuit) {
+            spans.add(Span.raw("y").bold());
+            spans.add(Span.raw(":Save and quit  "));
+            spans.add(Span.raw("n").bold());
+            spans.add(Span.raw(":Discard and quit  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Cancel"));
+        } else if (diffLines != null) {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Scroll  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Close  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        } else {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Navigate  "));
+            spans.add(Span.raw("Enter").bold());
+            spans.add(Span.raw(":Details  "));
+            spans.add(Span.raw("p").bold());
+            spans.add(Span.raw(":Pin version  "));
+            spans.add(Span.raw("d").bold());
+            spans.add(Span.raw(":Diff  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        }
 
         frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(2));
     }

--- a/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -199,6 +199,19 @@ class DependenciesTui {
 
     private View view = View.DECLARED;
     private String status;
+    private final String originalPomContent;
+    private final PomEditor editor;
+    private boolean dirty;
+    private boolean pendingQuit;
+    private List<UnifiedDiff.DiffLine> diffLines;
+    private int diffScroll;
+    private int lastContentHeight;
+    private TuiRunner runner;
+
+    /** Returns the current in-memory POM content (package-private for testing). */
+    String currentPomContent() {
+        return editor.toXml();
+    }
 
     /**
      * Get the currently selected table row index.
@@ -237,6 +250,14 @@ class DependenciesTui {
         this.pomPath = pomPath;
         this.projectGav = projectGav;
         this.bytecodeAnalyzed = bytecodeAnalyzed;
+        String pom;
+        try {
+            pom = Files.readString(Path.of(pomPath));
+        } catch (Exception e) {
+            pom = "<project/>";
+        }
+        this.originalPomContent = pom;
+        this.editor = new PomEditor(Document.of(pom));
         updateStatus();
         if (!declared.isEmpty()) {
             tableState.select(0);
@@ -265,6 +286,7 @@ class DependenciesTui {
                 .tickRate(Duration.ofMillis(100))
                 .build();
         try {
+            runner = configured.runner();
             configured.run();
         } finally {
             configured.close();
@@ -276,8 +298,52 @@ class DependenciesTui {
             return true;
         }
 
-        if (key.isCtrlC() || key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q')) {
-            runner.quit();
+        // Save prompt mode
+        if (pendingQuit) {
+            if (key.isCharIgnoreCase('y')) {
+                saveAndQuit();
+                return true;
+            }
+            if (key.isCharIgnoreCase('n')) {
+                runner.quit();
+                return true;
+            }
+            if (key.isKey(KeyCode.ESCAPE)) {
+                pendingQuit = false;
+                status = "Quit cancelled";
+                return true;
+            }
+            return false;
+        }
+
+        // Diff overlay mode — Esc closes overlay first
+        if (diffLines != null) {
+            if (key.isKey(KeyCode.ESCAPE)) {
+                diffLines = null;
+                diffScroll = 0;
+                return true;
+            }
+            if (key.isUp()) {
+                if (diffScroll > 0) diffScroll--;
+                return true;
+            }
+            if (key.isDown()) {
+                diffScroll = Math.min(diffScroll + 1, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            if (key.isKey(KeyCode.PAGE_UP)) {
+                diffScroll = Math.max(0, diffScroll - 10);
+                return true;
+            }
+            if (key.isKey(KeyCode.PAGE_DOWN)) {
+                diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            return false;
+        }
+
+        if (key.isCtrlC() || key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
+            requestQuit();
             return true;
         }
 
@@ -301,7 +367,7 @@ class DependenciesTui {
             return true;
         }
 
-        if (key.isCharIgnoreCase('d')) {
+        if (key.isCharIgnoreCase('x')) {
             removeDeclared();
             return true;
         }
@@ -313,6 +379,11 @@ class DependenciesTui {
 
         if (key.isCharIgnoreCase('s')) {
             changeScope();
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('d')) {
+            toggleDiffView();
             return true;
         }
 
@@ -351,10 +422,8 @@ class DependenciesTui {
         var dep = declared.get(sel);
 
         try {
-            String pomContent = Files.readString(Path.of(pomPath));
-            PomEditor editor = new PomEditor(Document.of(pomContent));
             editor.dependencies().deleteDependency(Coordinates.of(dep.groupId, dep.artifactId, dep.version));
-            Files.writeString(Path.of(pomPath), editor.toXml());
+            dirty = true;
             declared.remove(sel);
             updateStatus();
             if (sel >= declared.size() && !declared.isEmpty()) {
@@ -378,10 +447,22 @@ class DependenciesTui {
         var dep = transitive.get(sel);
 
         try {
-            String pomContent = Files.readString(Path.of(pomPath));
-            String updated = addDependencyAligned(
-                    pomContent, dep.groupId, dep.artifactId, dep.version, dep.classifier, dep.scope);
-            Files.writeString(Path.of(pomPath), updated);
+            Coordinates coords = (dep.hasClassifier())
+                    ? Coordinates.of(dep.groupId, dep.artifactId, dep.version, dep.classifier, "jar")
+                    : Coordinates.of(dep.groupId, dep.artifactId, dep.version);
+            if (!COMPILE_SCOPE.equals(dep.scope)) {
+                AlignOptions detected = editor.dependencies().detectConventions();
+                AlignOptions options = AlignOptions.builder()
+                        .versionStyle(detected.versionStyle())
+                        .versionSource(detected.versionSource())
+                        .namingConvention(detected.namingConvention())
+                        .scope(dep.scope)
+                        .build();
+                editor.dependencies().addAligned(coords, options);
+            } else {
+                editor.dependencies().addAligned(coords);
+            }
+            dirty = true;
 
             // Move from transitive to declared
             transitive.remove(sel);
@@ -430,9 +511,7 @@ class DependenciesTui {
         var dep = declared.get(sel);
 
         try {
-            String pomContent = Files.readString(Path.of(pomPath));
-            Document doc = Document.of(pomContent);
-
+            Document doc = editor.document();
             List<String> scopes = getScopesForModel(doc);
             if (!scopes.contains(dep.scope)) {
                 // Unknown scope (e.g. "system") — include it in the cycling list
@@ -441,7 +520,6 @@ class DependenciesTui {
             }
             int current = scopes.indexOf(dep.scope);
             String newScope = scopes.get((current + 1) % scopes.size());
-            PomEditor editor = new PomEditor(doc);
             Coordinates coords = Coordinates.of(dep.groupId, dep.artifactId, dep.version);
 
             // Find the <dependency> element matching this GA
@@ -459,8 +537,8 @@ class DependenciesTui {
                                     } else {
                                         editor.updateOrCreateChildElement(el, COL_SCOPE, newScope);
                                     }
-                                    Files.writeString(Path.of(pomPath), doc.toXml());
                                     dep.scope = newScope;
+                                    dirty = true;
                                     updateStatus();
                                 } catch (Exception e) {
                                     status = "Failed to change scope: " + e.getMessage();
@@ -470,6 +548,38 @@ class DependenciesTui {
         } catch (Exception e) {
             status = "Failed to change scope: " + e.getMessage();
         }
+    }
+
+    private void requestQuit() {
+        if (dirty) {
+            pendingQuit = true;
+            status = "Save changes to POM?";
+        } else {
+            runner.quit();
+        }
+    }
+
+    private void saveAndQuit() {
+        try {
+            Files.writeString(Path.of(pomPath), editor.toXml());
+            runner.quit();
+        } catch (Exception e) {
+            pendingQuit = false;
+            status = "Failed to save: " + e.getMessage();
+        }
+    }
+
+    private void toggleDiffView() {
+        String modifiedPom = editor.toXml();
+        var fullDiff = UnifiedDiff.compute(originalPomContent, modifiedPom);
+        long changes = UnifiedDiff.changeCount(fullDiff);
+        if (changes == 0) {
+            status = "No changes to show";
+            return;
+        }
+        diffLines = UnifiedDiff.filterContext(fullDiff, 3);
+        diffScroll = 0;
+        status = changes + " line(s) changed";
     }
 
     /**
@@ -525,7 +635,12 @@ class DependenciesTui {
                 .split(frame.area());
 
         renderHeader(frame, zones.get(0));
-        renderTable(frame, zones.get(1));
+        lastContentHeight = zones.get(1).height();
+        if (diffLines != null) {
+            UnifiedDiff.render(frame, zones.get(1), diffLines, diffScroll, " POM Changes ");
+        } else {
+            renderTable(frame, zones.get(1));
+        }
         renderInfoBar(frame, zones.get(2));
     }
 
@@ -564,6 +679,10 @@ class DependenciesTui {
         }
         spans.add(Span.raw("[" + (view == View.TRANSITIVE ? HIGHLIGHT_SYMBOL : "  ") + transitiveLabel + "]")
                 .fg(view == View.TRANSITIVE ? Color.YELLOW : Color.DARK_GRAY));
+
+        if (dirty) {
+            spans.add(Span.raw("  [modified]").fg(Color.YELLOW));
+        }
 
         Paragraph header = Paragraph.builder()
                 .text(dev.tamboui.text.Text.from(Line.from(spans)))
@@ -672,27 +791,45 @@ class DependenciesTui {
 
         // Status
         List<Span> statusSpans = new ArrayList<>();
-        statusSpans.add(Span.raw(" " + status).fg(Color.GREEN));
+        statusSpans.add(Span.raw(" " + status).fg(pendingQuit ? Color.YELLOW : Color.GREEN));
         frame.renderWidget(Paragraph.from(Line.from(statusSpans)), rows.get(1));
 
         // Key bindings
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" "));
-        spans.add(Span.raw("\u2191\u2193").bold());
-        spans.add(Span.raw(":Navigate  "));
-        spans.add(Span.raw("Tab").bold());
-        spans.add(Span.raw(":Switch view  "));
-        if (view == View.DECLARED) {
-            spans.add(Span.raw("d/Enter").bold());
-            spans.add(Span.raw(":Delete  "));
-            spans.add(Span.raw("s").bold());
-            spans.add(Span.raw(":Change scope  "));
+        if (pendingQuit) {
+            spans.add(Span.raw("y").bold());
+            spans.add(Span.raw(":Save and quit  "));
+            spans.add(Span.raw("n").bold());
+            spans.add(Span.raw(":Discard and quit  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Cancel"));
+        } else if (diffLines != null) {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Scroll  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Close  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
         } else {
-            spans.add(Span.raw("a/Enter").bold());
-            spans.add(Span.raw(":Add to POM  "));
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Navigate  "));
+            spans.add(Span.raw("Tab").bold());
+            spans.add(Span.raw(":Switch view  "));
+            if (view == View.DECLARED) {
+                spans.add(Span.raw("x/Enter").bold());
+                spans.add(Span.raw(":Delete  "));
+                spans.add(Span.raw("s").bold());
+                spans.add(Span.raw(":Change scope  "));
+            } else {
+                spans.add(Span.raw("a/Enter").bold());
+                spans.add(Span.raw(":Add to POM  "));
+            }
+            spans.add(Span.raw("d").bold());
+            spans.add(Span.raw(":Diff  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
         }
-        spans.add(Span.raw("q").bold());
-        spans.add(Span.raw(":Quit"));
 
         frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(2));
     }

--- a/src/main/java/eu/maveniverse/maven/pilot/UnifiedDiff.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UnifiedDiff.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Line-based unified diff computation and TUI rendering.
+ */
+class UnifiedDiff {
+
+    enum Type {
+        CONTEXT,
+        ADDED,
+        REMOVED
+    }
+
+    record DiffLine(Type type, String text) {}
+
+    /**
+     * Compute a line-based diff between two strings.
+     *
+     * @param original the original text
+     * @param modified the modified text
+     * @return list of diff lines with type annotations
+     */
+    static List<DiffLine> compute(String original, String modified) {
+        String[] oldLines = original.isEmpty() ? new String[0] : original.split("\n", -1);
+        String[] newLines = modified.isEmpty() ? new String[0] : modified.split("\n", -1);
+
+        // LCS table
+        int m = oldLines.length;
+        int n = newLines.length;
+        int[][] lcs = new int[m + 1][n + 1];
+        for (int i = m - 1; i >= 0; i--) {
+            for (int j = n - 1; j >= 0; j--) {
+                if (oldLines[i].equals(newLines[j])) {
+                    lcs[i][j] = lcs[i + 1][j + 1] + 1;
+                } else {
+                    lcs[i][j] = Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+                }
+            }
+        }
+
+        // Backtrack to produce diff
+        List<DiffLine> result = new ArrayList<>();
+        int i = 0, j = 0;
+        while (i < m || j < n) {
+            if (i < m && j < n && oldLines[i].equals(newLines[j])) {
+                result.add(new DiffLine(Type.CONTEXT, oldLines[i]));
+                i++;
+                j++;
+            } else if (i < m && (j >= n || lcs[i + 1][j] >= lcs[i][j + 1])) {
+                result.add(new DiffLine(Type.REMOVED, oldLines[i]));
+                i++;
+            } else if (j < n) {
+                result.add(new DiffLine(Type.ADDED, newLines[j]));
+                j++;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Render a diff into a bordered area with scrolling support.
+     *
+     * @param frame the TUI frame to render into
+     * @param area the rectangular area to use
+     * @param lines the diff lines to display
+     * @param scroll the scroll offset (number of lines to skip)
+     * @param title the title for the diff block
+     */
+    static void render(Frame frame, Rect area, List<DiffLine> lines, int scroll, String title) {
+        Block block = Block.builder()
+                .title(title)
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().yellow())
+                .build();
+
+        if (lines.isEmpty()) {
+            Paragraph empty = Paragraph.builder()
+                    .text("No changes")
+                    .block(block)
+                    .centered()
+                    .build();
+            frame.renderWidget(empty, area);
+            return;
+        }
+
+        // Build visible lines within the bordered area
+        int innerHeight = area.height() - 2; // borders top/bottom
+        if (innerHeight <= 0) {
+            frame.renderWidget(Paragraph.builder().text("").block(block).build(), area);
+            return;
+        }
+
+        List<Line> visibleLines = new ArrayList<>();
+        int end = Math.min(scroll + innerHeight, lines.size());
+        for (int idx = scroll; idx < end; idx++) {
+            DiffLine dl = lines.get(idx);
+            String prefix;
+            Style style;
+            switch (dl.type()) {
+                case ADDED -> {
+                    prefix = "+ ";
+                    style = Style.create().fg(Color.GREEN);
+                }
+                case REMOVED -> {
+                    prefix = "- ";
+                    style = Style.create().fg(Color.RED);
+                }
+                default -> {
+                    prefix = "  ";
+                    style = Style.create().dim();
+                }
+            }
+            visibleLines.add(Line.from(Span.raw(prefix + dl.text()).style(style)));
+        }
+
+        // Build a single Text block from all visible lines
+        dev.tamboui.text.Text text = dev.tamboui.text.Text.from(visibleLines);
+        Paragraph paragraph = Paragraph.builder().text(text).block(block).build();
+        frame.renderWidget(paragraph, area);
+    }
+
+    /**
+     * Compute the maximum scroll offset for the given diff lines and visible area height.
+     */
+    static int maxScroll(List<DiffLine> lines, int areaHeight) {
+        int innerHeight = areaHeight - 2;
+        return Math.max(0, lines.size() - innerHeight);
+    }
+
+    /**
+     * Filter diff lines to only show changes (added/removed) with surrounding context.
+     *
+     * @param lines the full diff lines
+     * @param contextLines number of context lines to show around changes
+     * @return filtered list with only relevant lines
+     */
+    static List<DiffLine> filterContext(List<DiffLine> lines, int contextLines) {
+        if (lines.isEmpty()) return lines;
+
+        boolean[] show = new boolean[lines.size()];
+        // Mark all non-context lines and their surrounding context
+        for (int i = 0; i < lines.size(); i++) {
+            if (lines.get(i).type() != Type.CONTEXT) {
+                for (int j = Math.max(0, i - contextLines); j <= Math.min(lines.size() - 1, i + contextLines); j++) {
+                    show[j] = true;
+                }
+            }
+        }
+
+        List<DiffLine> result = new ArrayList<>();
+        for (int i = 0; i < lines.size(); i++) {
+            if (show[i]) {
+                result.add(lines.get(i));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Count the number of changes (added + removed lines) in the diff.
+     */
+    static long changeCount(List<DiffLine> lines) {
+        return lines.stream().filter(l -> l.type() != Type.CONTEXT).count();
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -81,6 +81,7 @@ class UpdatesTui {
         VersionComparator.UpdateType updateType;
         boolean selected;
         boolean managed;
+        String versionProperty; // shared property name, e.g. "mavenVersion" from "${mavenVersion}"
 
         DependencyInfo(String groupId, String artifactId, String version, String scope, String type) {
             this.groupId = groupId;
@@ -120,6 +121,13 @@ class UpdatesTui {
     boolean loading = true;
     int loadedCount = 0;
     int failedCount = 0;
+    private final String originalPomContent;
+    private final PomEditor editor;
+    private boolean dirty;
+    private boolean pendingQuit;
+    private List<UnifiedDiff.DiffLine> diffLines;
+    private int diffScroll;
+    private int lastContentHeight;
 
     private TuiRunner runner;
 
@@ -149,9 +157,47 @@ class UpdatesTui {
         this.pomPath = pomPath;
         this.projectGav = projectGav;
         this.versionResolver = versionResolver;
+        String pom;
+        try {
+            pom = Files.readString(Path.of(pomPath));
+        } catch (Exception e) {
+            pom = "<project/>";
+        }
+        this.originalPomContent = pom;
+        this.editor = new PomEditor(Document.of(pom));
+        detectPropertyGroups();
         if (!displayDeps.isEmpty()) {
             tableState.select(0);
         }
+    }
+
+    private void detectPropertyGroups() {
+        try {
+            eu.maveniverse.domtrip.Element root = editor.document().root();
+            scanDependencyVersions(root.childElement("dependencies").orElse(null));
+            root.childElement("dependencyManagement")
+                    .flatMap(dm -> dm.childElement("dependencies"))
+                    .ifPresent(this::scanDependencyVersions);
+        } catch (Exception ignored) {
+            // best-effort
+        }
+    }
+
+    private void scanDependencyVersions(eu.maveniverse.domtrip.Element deps) {
+        if (deps == null) return;
+        deps.childElements("dependency").forEach(dep -> {
+            String gid = dep.childTextOr("groupId", "");
+            String aid = dep.childTextOr("artifactId", "");
+            String rawVersion = dep.childTextOr("version", null);
+            if (rawVersion != null && rawVersion.startsWith("${") && rawVersion.endsWith("}")) {
+                String prop = rawVersion.substring(2, rawVersion.length() - 1);
+                for (DependencyInfo di : allDeps) {
+                    if (di.groupId.equals(gid) && di.artifactId.equals(aid)) {
+                        di.versionProperty = prop;
+                    }
+                }
+            }
+        });
     }
 
     void run() throws Exception {
@@ -249,8 +295,52 @@ class UpdatesTui {
             return true;
         }
 
-        if (key.isCtrlC() || key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q')) {
-            runner.quit();
+        // Save prompt mode
+        if (pendingQuit) {
+            if (key.isCharIgnoreCase('y')) {
+                saveAndQuit();
+                return true;
+            }
+            if (key.isCharIgnoreCase('n')) {
+                runner.quit();
+                return true;
+            }
+            if (key.isKey(KeyCode.ESCAPE)) {
+                pendingQuit = false;
+                status = "Quit cancelled";
+                return true;
+            }
+            return false;
+        }
+
+        // Diff overlay mode — Esc closes overlay first
+        if (diffLines != null) {
+            if (key.isKey(KeyCode.ESCAPE)) {
+                diffLines = null;
+                diffScroll = 0;
+                return true;
+            }
+            if (key.isUp()) {
+                if (diffScroll > 0) diffScroll--;
+                return true;
+            }
+            if (key.isDown()) {
+                diffScroll = Math.min(diffScroll + 1, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            if (key.isKey(KeyCode.PAGE_UP)) {
+                diffScroll = Math.max(0, diffScroll - 10);
+                return true;
+            }
+            if (key.isKey(KeyCode.PAGE_DOWN)) {
+                diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            return false;
+        }
+
+        if (key.isCtrlC() || key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
+            requestQuit();
             return true;
         }
 
@@ -306,6 +396,11 @@ class UpdatesTui {
             return true;
         }
 
+        if (key.isCharIgnoreCase('d')) {
+            toggleDiffView();
+            return true;
+        }
+
         return false;
     }
 
@@ -320,9 +415,68 @@ class UpdatesTui {
         if (sel >= 0 && sel < displayDeps.size()) {
             var dep = displayDeps.get(sel);
             if (dep.hasUpdate()) {
-                dep.selected = !dep.selected;
+                boolean newState = !dep.selected;
+                dep.selected = newState;
+                if (dep.versionProperty != null) {
+                    for (var other : allDeps) {
+                        if (other != dep && dep.versionProperty.equals(other.versionProperty)) {
+                            other.selected = newState;
+                        }
+                    }
+                }
             }
         }
+    }
+
+    private void requestQuit() {
+        if (dirty) {
+            pendingQuit = true;
+            status = "Save changes to POM?";
+        } else {
+            runner.quit();
+        }
+    }
+
+    private void saveAndQuit() {
+        try {
+            Files.writeString(Path.of(pomPath), editor.toXml());
+            runner.quit();
+        } catch (Exception e) {
+            pendingQuit = false;
+            status = "Failed to save: " + e.getMessage();
+        }
+    }
+
+    private void toggleDiffView() {
+        // Include both staged changes and currently selected (not yet applied) updates
+        List<DependencyInfo> pendingSelected =
+                displayDeps.stream().filter(d -> d.selected && d.hasUpdate()).toList();
+
+        String modifiedPom;
+        if (pendingSelected.isEmpty()) {
+            modifiedPom = editor.toXml();
+        } else {
+            PomEditor preview = new PomEditor(Document.of(editor.toXml()));
+            for (var dep : pendingSelected) {
+                var coords = Coordinates.of(dep.groupId, dep.artifactId, dep.newestVersion);
+                if (dep.managed) {
+                    preview.dependencies().updateManagedDependency(true, coords);
+                } else {
+                    preview.dependencies().updateDependency(true, coords);
+                }
+            }
+            modifiedPom = preview.toXml();
+        }
+
+        var fullDiff = UnifiedDiff.compute(originalPomContent, modifiedPom);
+        long changes = UnifiedDiff.changeCount(fullDiff);
+        if (changes == 0) {
+            status = "No changes to show";
+            return;
+        }
+        diffLines = UnifiedDiff.filterContext(fullDiff, 3);
+        diffScroll = 0;
+        status = changes + " line(s) changed";
     }
 
     private void selectAll() {
@@ -361,9 +515,6 @@ class UpdatesTui {
         }
 
         try {
-            String pomContent = Files.readString(Path.of(pomPath));
-            PomEditor editor = new PomEditor(Document.of(pomContent));
-
             for (var dep : toUpdate) {
                 var coords = Coordinates.of(dep.groupId, dep.artifactId, dep.newestVersion);
                 if (dep.managed) {
@@ -373,10 +524,9 @@ class UpdatesTui {
                 }
             }
 
-            Files.writeString(Path.of(pomPath), editor.toXml());
-            status = "Updated " + toUpdate.size() + " dependencies in POM";
+            dirty = true;
+            status = "Staged " + toUpdate.size() + " update(s) \u2014 save on exit";
 
-            // Update model
             for (var dep : toUpdate) {
                 dep.version = dep.newestVersion;
                 dep.newestVersion = null;
@@ -385,7 +535,7 @@ class UpdatesTui {
             }
             applyFilter();
         } catch (Exception e) {
-            status = "Failed to update POM: " + e.getMessage();
+            status = "Failed to update: " + e.getMessage();
         }
     }
 
@@ -397,7 +547,12 @@ class UpdatesTui {
                 .split(frame.area());
 
         renderHeader(frame, zones.get(0));
-        renderUpdatesTable(frame, zones.get(1));
+        lastContentHeight = zones.get(1).height();
+        if (diffLines != null) {
+            UnifiedDiff.render(frame, zones.get(1), diffLines, diffScroll, " POM Changes ");
+        } else {
+            renderUpdatesTable(frame, zones.get(1));
+        }
         renderInfoBar(frame, zones.get(2));
     }
 
@@ -414,6 +569,9 @@ class UpdatesTui {
         if (loading) {
             spans.add(Span.raw("  Checking " + loadedCount + "/" + allDeps.size() + "\u2026")
                     .dim());
+        }
+        if (dirty) {
+            spans.add(Span.raw("  [modified]").fg(Color.YELLOW));
         }
 
         Paragraph header = Paragraph.builder()
@@ -494,26 +652,44 @@ class UpdatesTui {
 
         // Status
         List<Span> statusSpans = new ArrayList<>();
-        statusSpans.add(Span.raw(" " + status).fg(Color.GREEN));
+        statusSpans.add(Span.raw(" " + status).fg(pendingQuit ? Color.YELLOW : Color.GREEN));
         frame.renderWidget(Paragraph.from(Line.from(statusSpans)), rows.get(1));
 
         // Key bindings
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" "));
-        spans.add(Span.raw("\u2191\u2193").bold());
-        spans.add(Span.raw(":Nav  "));
-        spans.add(Span.raw("Space").bold());
-        spans.add(Span.raw(":Toggle  "));
-        spans.add(Span.raw("a").bold());
-        spans.add(Span.raw(":All  "));
-        spans.add(Span.raw("n").bold());
-        spans.add(Span.raw(":None  "));
-        spans.add(Span.raw("Enter").bold());
-        spans.add(Span.raw(":Apply  "));
-        spans.add(Span.raw("1-4").bold());
-        spans.add(Span.raw(":Filter  "));
-        spans.add(Span.raw("q").bold());
-        spans.add(Span.raw(":Quit"));
+        if (pendingQuit) {
+            spans.add(Span.raw("y").bold());
+            spans.add(Span.raw(":Save and quit  "));
+            spans.add(Span.raw("n").bold());
+            spans.add(Span.raw(":Discard and quit  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Cancel"));
+        } else if (diffLines != null) {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Scroll  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Close  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        } else {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Nav  "));
+            spans.add(Span.raw("Space").bold());
+            spans.add(Span.raw(":Toggle  "));
+            spans.add(Span.raw("a").bold());
+            spans.add(Span.raw(":All  "));
+            spans.add(Span.raw("n").bold());
+            spans.add(Span.raw(":None  "));
+            spans.add(Span.raw("Enter").bold());
+            spans.add(Span.raw(":Apply  "));
+            spans.add(Span.raw("1-4").bold());
+            spans.add(Span.raw(":Filter  "));
+            spans.add(Span.raw("d").bold());
+            spans.add(Span.raw(":Diff  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        }
 
         frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(2));
     }

--- a/src/test/java/eu/maveniverse/maven/pilot/AlignTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AlignTuiTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import eu.maveniverse.domtrip.maven.AlignOptions;
+import org.junit.jupiter.api.Test;
+
+class AlignTuiTest {
+
+    @Test
+    void nextEnumWrapsAround() {
+        var values = AlignOptions.VersionStyle.values();
+        assertThat(AlignTui.nextEnum(values, AlignOptions.VersionStyle.INLINE))
+                .isEqualTo(AlignOptions.VersionStyle.MANAGED);
+        assertThat(AlignTui.nextEnum(values, AlignOptions.VersionStyle.MANAGED))
+                .isEqualTo(AlignOptions.VersionStyle.INLINE);
+    }
+
+    @Test
+    void prevEnumWrapsAround() {
+        var values = AlignOptions.VersionStyle.values();
+        assertThat(AlignTui.prevEnum(values, AlignOptions.VersionStyle.INLINE))
+                .isEqualTo(AlignOptions.VersionStyle.MANAGED);
+        assertThat(AlignTui.prevEnum(values, AlignOptions.VersionStyle.MANAGED))
+                .isEqualTo(AlignOptions.VersionStyle.INLINE);
+    }
+
+    @Test
+    void nextEnumCyclesAllPropertyNamingValues() {
+        var values = AlignOptions.PropertyNamingConvention.values();
+        var current = AlignOptions.PropertyNamingConvention.DOT_SUFFIX;
+        current = AlignTui.nextEnum(values, current);
+        assertThat(current).isEqualTo(AlignOptions.PropertyNamingConvention.DASH_SUFFIX);
+        current = AlignTui.nextEnum(values, current);
+        assertThat(current).isEqualTo(AlignOptions.PropertyNamingConvention.CAMEL_CASE);
+        current = AlignTui.nextEnum(values, current);
+        assertThat(current).isEqualTo(AlignOptions.PropertyNamingConvention.DOT_PREFIX);
+        current = AlignTui.nextEnum(values, current);
+        assertThat(current).isEqualTo(AlignOptions.PropertyNamingConvention.DOT_SUFFIX);
+    }
+
+    @Test
+    void buildSelectedOptionsReflectsDefaults() {
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.PROPERTY)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+
+        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", "<project/>", detected);
+        var options = tui.buildSelectedOptions();
+
+        assertThat(options.versionStyle()).isEqualTo(AlignOptions.VersionStyle.MANAGED);
+        assertThat(options.versionSource()).isEqualTo(AlignOptions.VersionSource.PROPERTY);
+        assertThat(options.namingConvention()).isEqualTo(AlignOptions.PropertyNamingConvention.DOT_SUFFIX);
+    }
+
+    @Test
+    void cycleForwardChangesSelectedStyle() {
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.INLINE)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+
+        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", "<project/>", detected);
+        tui.cycleForward(); // row 0 = VersionStyle
+
+        var options = tui.buildSelectedOptions();
+        assertThat(options.versionStyle()).isEqualTo(AlignOptions.VersionStyle.MANAGED);
+    }
+
+    @Test
+    void cycleBackwardChangesSelectedStyle() {
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+
+        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", "<project/>", detected);
+        tui.cycleBackward(); // row 0 = VersionStyle
+
+        var options = tui.buildSelectedOptions();
+        assertThat(options.versionStyle()).isEqualTo(AlignOptions.VersionStyle.INLINE);
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/DependenciesDemoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/DependenciesDemoTest.java
@@ -190,28 +190,28 @@ class DependenciesDemoTest {
             pilot.press('s');
             pilot.pause();
 
-            String pomContent = Files.readString(pomFile);
+            String pomContent = tui.currentPomContent();
             assertThat(pomContent).contains("<scope>provided</scope>");
 
             // Press 's' again to cycle scope from provided -> runtime
             pilot.press('s');
             pilot.pause();
 
-            pomContent = Files.readString(pomFile);
+            pomContent = tui.currentPomContent();
             assertThat(pomContent).contains("<scope>runtime</scope>");
 
             // Press 's' again: runtime -> test
             pilot.press('s');
             pilot.pause();
 
-            pomContent = Files.readString(pomFile);
+            pomContent = tui.currentPomContent();
             assertThat(pomContent).contains("<scope>test</scope>");
 
             // Press 's' again: test -> compile (removes <scope> element)
             pilot.press('s');
             pilot.pause();
 
-            pomContent = Files.readString(pomFile);
+            pomContent = tui.currentPomContent();
             assertThat(pomContent).doesNotContain("<scope>");
 
             pilot.press('q');
@@ -248,11 +248,11 @@ class DependenciesDemoTest {
             Pilot pilot = testRunner.pilot();
             pilot.pause();
 
-            // Press 'd' to remove the selected dependency
-            pilot.press('d');
+            // Press 'x' to remove the selected dependency
+            pilot.press('x');
             pilot.pause();
 
-            String pomContent = Files.readString(pomFile);
+            String pomContent = tui.currentPomContent();
             assertThat(pomContent).doesNotContain("guava");
 
             pilot.press('q');
@@ -295,7 +295,7 @@ class DependenciesDemoTest {
             pilot.press('a');
             pilot.pause();
 
-            String pomContent = Files.readString(pomFile);
+            String pomContent = tui.currentPomContent();
             assertThat(pomContent).contains("guava");
 
             pilot.press('q');

--- a/src/test/java/eu/maveniverse/maven/pilot/UnifiedDiffTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UnifiedDiffTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class UnifiedDiffTest {
+
+    @Test
+    void identicalInputsProduceAllContext() {
+        String text = "line1\nline2\nline3";
+        var result = UnifiedDiff.compute(text, text);
+
+        assertThat(result).hasSize(3);
+        assertThat(result).allMatch(dl -> dl.type() == UnifiedDiff.Type.CONTEXT);
+        assertThat(result.get(0).text()).isEqualTo("line1");
+        assertThat(result.get(1).text()).isEqualTo("line2");
+        assertThat(result.get(2).text()).isEqualTo("line3");
+    }
+
+    @Test
+    void emptyOriginalProducesAllAdded() {
+        var result = UnifiedDiff.compute("", "line1\nline2");
+
+        assertThat(result).hasSize(2);
+        assertThat(result).allMatch(dl -> dl.type() == UnifiedDiff.Type.ADDED);
+        assertThat(result.get(0).text()).isEqualTo("line1");
+        assertThat(result.get(1).text()).isEqualTo("line2");
+    }
+
+    @Test
+    void emptyModifiedProducesAllRemoved() {
+        var result = UnifiedDiff.compute("line1\nline2", "");
+
+        assertThat(result).hasSize(2);
+        assertThat(result).allMatch(dl -> dl.type() == UnifiedDiff.Type.REMOVED);
+    }
+
+    @Test
+    void singleLineChange() {
+        var result = UnifiedDiff.compute("hello", "world");
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "hello"));
+        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "world"));
+    }
+
+    @Test
+    void multiLineChangesWithContext() {
+        String original = "a\nb\nc\nd";
+        String modified = "a\nB\nc\nd";
+
+        var result = UnifiedDiff.compute(original, modified);
+
+        assertThat(result).hasSize(5);
+        assertThat(result.get(0)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "a"));
+        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "b"));
+        assertThat(result.get(2)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "B"));
+        assertThat(result.get(3)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "c"));
+        assertThat(result.get(4)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "d"));
+    }
+
+    @Test
+    void addedLinesInMiddle() {
+        String original = "a\nc";
+        String modified = "a\nb\nc";
+
+        var result = UnifiedDiff.compute(original, modified);
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).type()).isEqualTo(UnifiedDiff.Type.CONTEXT);
+        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "b"));
+        assertThat(result.get(2).type()).isEqualTo(UnifiedDiff.Type.CONTEXT);
+    }
+
+    @Test
+    void removedLinesInMiddle() {
+        String original = "a\nb\nc";
+        String modified = "a\nc";
+
+        var result = UnifiedDiff.compute(original, modified);
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).type()).isEqualTo(UnifiedDiff.Type.CONTEXT);
+        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "b"));
+        assertThat(result.get(2).type()).isEqualTo(UnifiedDiff.Type.CONTEXT);
+    }
+
+    @Test
+    void changeCountReturnsNonContextLines() {
+        var lines = List.of(
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "a"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "b"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "B"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "c"));
+
+        assertThat(UnifiedDiff.changeCount(lines)).isEqualTo(2);
+    }
+
+    @Test
+    void changeCountZeroForIdentical() {
+        var lines = List.of(
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "a"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "b"));
+
+        assertThat(UnifiedDiff.changeCount(lines)).isZero();
+    }
+
+    @Test
+    void filterContextKeepsSurroundingLines() {
+        var lines = List.of(
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "1"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "2"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "3"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "4"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "4x"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "5"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "6"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "7"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "8"));
+
+        var filtered = UnifiedDiff.filterContext(lines, 1);
+
+        // Should keep lines 2-5 (1 context before/after the change at indices 3-4)
+        assertThat(filtered).hasSize(4);
+        assertThat(filtered.get(0).text()).isEqualTo("3");
+        assertThat(filtered.get(1).text()).isEqualTo("4");
+        assertThat(filtered.get(2).text()).isEqualTo("4x");
+        assertThat(filtered.get(3).text()).isEqualTo("5");
+    }
+
+    @Test
+    void maxScrollCalculation() {
+        var lines = List.of(
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "a"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "b"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "c"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "d"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "e"));
+
+        // area height 5 = 3 inner lines (minus 2 for borders)
+        assertThat(UnifiedDiff.maxScroll(lines, 5)).isEqualTo(2);
+        // area height 10 = 8 inner lines > 5 lines → 0
+        assertThat(UnifiedDiff.maxScroll(lines, 10)).isZero();
+    }
+
+    @Test
+    void bothEmptyProducesEmptyResult() {
+        var result = UnifiedDiff.compute("", "");
+        assertThat(result).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary

- **Deferred write mode**: All POM-editing TUIs (Dependencies, Updates, Conflicts) now accumulate changes in-memory via `PomEditor` instead of writing to disk immediately. On quit, a nano-style save prompt (`y`:Save / `n`:Discard / `Esc`:Cancel) lets users confirm or discard changes.
- **Diff preview (`d` key)**: Press `d` in any editing TUI to preview accumulated POM changes as a unified diff overlay with scroll support. Esc closes the overlay before triggering quit.
- **Property-linked selection** (Updates TUI): Dependencies sharing a version property (e.g., `${mavenVersion}`) are toggled together — selecting `maven-plugin-api` auto-selects `maven-core`.
- **Align goal + UnifiedDiff utility**: Adds `pilot:align` for detecting/applying dependency conventions and a reusable LCS-based diff utility.

Closes #12

## Test plan

- [ ] `mvn install -B` — all 173 tests pass (0 failures)
- [ ] Run `mvn pilot:updates` → select deps → press `d` to preview diff → Esc to close → `q`/`y` to save
- [ ] Run `mvn pilot:conflicts` → pin a version → press `d` to preview → quit with save prompt
- [ ] Run `mvn pilot:dependencies` → remove/add/change scope → press `d` → verify diff shows changes
- [ ] Run `mvn pilot:align` → cycle conventions → preview → apply
- [ ] Verify property-linked selection: in updates TUI, select a dep using a shared property and confirm siblings toggle together

🤖 Generated with [Claude Code](https://claude.com/claude-code)