### PR TITLE
feat: reactor-aware dependency updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@ under the License.
     <maven.compiler.release>17</maven.compiler.release>
     <mavenVersion>3.9.9</mavenVersion>
     <tamboui.version>0.1.0</tamboui.version>
-    <domtrip.version>1.1.0-SNAPSHOT</domtrip.version>
+    <domtrip.version>1.1.0</domtrip.version>
 
     <!-- SonarCloud -->
     <sonar.projectKey>maveniverse_pilot</sonar.projectKey>

--- a/src/main/java/eu/maveniverse/maven/pilot/AlignMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignMojo.java
@@ -59,7 +59,7 @@ public class AlignMojo extends AbstractMojo {
 
             String gav = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
 
-            AlignTui tui = new AlignTui(pomPath, gav, pomContent, detectedOptions);
+            AlignTui tui = new AlignTui(pomPath, gav, detectedOptions);
             tui.run();
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to run alignment TUI: " + e.getMessage(), e);

--- a/src/main/java/eu/maveniverse/maven/pilot/AlignMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignMojo.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.maven.PomEditor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Interactive TUI for detecting and aligning dependency conventions across the POM.
+ *
+ * <p>Detects the project's current version style (inline vs managed), version source
+ * (literal vs property), and property naming convention, then lets the user choose
+ * a target convention and preview/apply the changes.</p>
+ *
+ * <p>Usage:</p>
+ * <pre>
+ * mvn pilot:align
+ * </pre>
+ *
+ * @since 0.2.0
+ */
+@Mojo(name = "align", requiresProject = true, threadSafe = true)
+public class AlignMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            String pomPath = project.getFile().getAbsolutePath();
+            String pomContent = Files.readString(Path.of(pomPath));
+            PomEditor editor = new PomEditor(Document.of(pomContent));
+            var detectedOptions = editor.dependencies().detectConventions();
+
+            String gav = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
+
+            AlignTui tui = new AlignTui(pomPath, gav, pomContent, detectedOptions);
+            tui.run();
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to run alignment TUI: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/AlignMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignMojo.java
@@ -22,6 +22,8 @@ import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.maven.PomEditor;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -43,26 +45,50 @@ import org.apache.maven.project.MavenProject;
  *
  * @since 0.2.0
  */
-@Mojo(name = "align", requiresProject = true, threadSafe = true)
+@Mojo(name = "align", requiresProject = true, aggregator = true, threadSafe = true)
 public class AlignMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
 
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
+
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
-            String pomPath = project.getFile().getAbsolutePath();
-            String pomContent = Files.readString(Path.of(pomPath));
-            PomEditor editor = new PomEditor(Document.of(pomContent));
-            var detectedOptions = editor.dependencies().detectConventions();
-
-            String gav = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
-
-            AlignTui tui = new AlignTui(pomPath, gav, detectedOptions);
-            tui.run();
+            List<MavenProject> projects = session.getProjects();
+            if (projects.size() > 1) {
+                executeReactor(projects);
+            } else {
+                executeForProject(project);
+            }
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to run alignment TUI: " + e.getMessage(), e);
         }
+    }
+
+    private void executeReactor(List<MavenProject> projects) throws Exception {
+        ReactorModel reactorModel = ReactorModel.build(projects);
+        MavenProject root = projects.get(0);
+        String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
+
+        while (true) {
+            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "align").pick();
+            if (selected == null) break;
+            executeForProject(selected);
+        }
+    }
+
+    private void executeForProject(MavenProject proj) throws Exception {
+        String pomPath = proj.getFile().getAbsolutePath();
+        String pomContent = Files.readString(Path.of(pomPath));
+        PomEditor editor = new PomEditor(Document.of(pomContent));
+        var detectedOptions = editor.dependencies().detectConventions();
+
+        String gav = proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion();
+
+        AlignTui tui = new AlignTui(pomPath, gav, detectedOptions);
+        tui.run();
     }
 }

--- a/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
@@ -281,9 +281,11 @@ class AlignTui {
     }
 
     private void writeAlignedPom() {
-        if (alignedPomContent == null) return;
         try {
-            Files.writeString(Path.of(pomPath), alignedPomContent);
+            String currentPom = Files.readString(Path.of(pomPath));
+            PomEditor editor = new PomEditor(Document.of(currentPom));
+            editor.dependencies().alignAllDependencies(buildSelectedOptions());
+            Files.writeString(Path.of(pomPath), editor.toXml());
             status = "Changes written to POM";
             phase = Phase.SELECT;
             diffLines = null;

--- a/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
@@ -62,7 +62,6 @@ class AlignTui {
 
     private final String pomPath;
     private final String projectGav;
-    private final String originalPomContent;
     private final AlignOptions detectedOptions;
 
     // User-selected convention values (start matching detected)
@@ -80,10 +79,9 @@ class AlignTui {
 
     private TuiRunner runner;
 
-    AlignTui(String pomPath, String projectGav, String originalPomContent, AlignOptions detectedOptions) {
+    AlignTui(String pomPath, String projectGav, AlignOptions detectedOptions) {
         this.pomPath = pomPath;
         this.projectGav = projectGav;
-        this.originalPomContent = originalPomContent;
         this.detectedOptions = detectedOptions;
         this.selectedStyle = detectedOptions.versionStyle();
         this.selectedSource = detectedOptions.versionSource();

--- a/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
@@ -75,6 +75,7 @@ class AlignTui {
 
     // Preview state
     private final DiffOverlay diffOverlay = new DiffOverlay();
+    private final HelpOverlay helpOverlay = new HelpOverlay();
     private String alignedPomContent;
 
     private TuiRunner runner;
@@ -107,6 +108,15 @@ class AlignTui {
     boolean handleEvent(Event event, TuiRunner runner) {
         if (!(event instanceof KeyEvent key)) {
             return true;
+        }
+
+        if (helpOverlay.isActive()) {
+            if (helpOverlay.handleKey(key)) return true;
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                runner.quit();
+                return true;
+            }
+            return false;
         }
 
         if (key.isCtrlC() || key.isCharIgnoreCase('q')) {
@@ -151,6 +161,11 @@ class AlignTui {
 
         if (key.isCharIgnoreCase('w')) {
             applyAlignment();
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('h')) {
+            helpOverlay.open(buildHelp());
             return true;
         }
 
@@ -254,6 +269,36 @@ class AlignTui {
         }
     }
 
+    private List<HelpOverlay.Section> buildHelp() {
+        return List.of(
+                new HelpOverlay.Section(
+                        "BOM Alignment",
+                        List.of(
+                                new HelpOverlay.Entry("", "Restructures dependency declarations to follow a"),
+                                new HelpOverlay.Entry("", "consistent convention. Configure three options:"),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "Version Style: how versions are expressed \u2014 inline"),
+                                new HelpOverlay.Entry("", "in <version> tags, via <properties>, or managed"),
+                                new HelpOverlay.Entry("", "through <dependencyManagement>."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "Version Source: where version values come from \u2014"),
+                                new HelpOverlay.Entry("", "keep current versions, import from a BOM, etc."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "Property Naming: convention for property names"),
+                                new HelpOverlay.Entry("", "(e.g. groupId.artifactId.version or artifact.version)."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "Preview the diff before applying to verify changes."))),
+                new HelpOverlay.Section(
+                        "Keys",
+                        List.of(
+                                new HelpOverlay.Entry("\u2191 / \u2193", "Move between options"),
+                                new HelpOverlay.Entry("\u2190 / \u2192 / Enter", "Cycle through option values"),
+                                new HelpOverlay.Entry("p", "Preview the POM changes as a diff"),
+                                new HelpOverlay.Entry("w", "Apply alignment and write to POM"),
+                                new HelpOverlay.Entry("h", "Toggle this help screen"),
+                                new HelpOverlay.Entry("q / Esc", "Quit"))));
+    }
+
     private void writeAlignedPom() {
         try {
             String currentPom = Files.readString(Path.of(pomPath));
@@ -281,7 +326,9 @@ class AlignTui {
         renderHeader(frame, zones.get(0));
         lastContentHeight = zones.get(1).height();
 
-        if (phase == Phase.PREVIEW && diffOverlay.isActive()) {
+        if (helpOverlay.isActive()) {
+            helpOverlay.render(frame, zones.get(1));
+        } else if (phase == Phase.PREVIEW && diffOverlay.isActive()) {
             diffOverlay.render(frame, zones.get(1), " POM Changes Preview ");
         } else {
             renderConventionTable(frame, zones.get(1));
@@ -387,6 +434,8 @@ class AlignTui {
             spans.add(Span.raw(":Preview  "));
             spans.add(Span.raw("w").bold());
             spans.add(Span.raw(":Apply  "));
+            spans.add(Span.raw("h").bold());
+            spans.add(Span.raw(":Help  "));
             spans.add(Span.raw("q").bold());
             spans.add(Span.raw(":Quit"));
         }

--- a/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
@@ -1,0 +1,421 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.tui.TuiRunner;
+import dev.tamboui.tui.event.Event;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import dev.tamboui.widgets.table.Row;
+import dev.tamboui.widgets.table.Table;
+import dev.tamboui.widgets.table.TableState;
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.maven.AlignOptions;
+import eu.maveniverse.domtrip.maven.PomEditor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Interactive TUI for dependency convention alignment.
+ */
+class AlignTui {
+
+    enum Phase {
+        SELECT,
+        PREVIEW
+    }
+
+    private static final int ROW_VERSION_STYLE = 0;
+    private static final int ROW_VERSION_SOURCE = 1;
+    private static final int ROW_PROPERTY_NAMING = 2;
+    private static final int ROW_COUNT = 3;
+
+    private final String pomPath;
+    private final String projectGav;
+    private final String originalPomContent;
+    private final AlignOptions detectedOptions;
+
+    // User-selected convention values (start matching detected)
+    private AlignOptions.VersionStyle selectedStyle;
+    private AlignOptions.VersionSource selectedSource;
+    private AlignOptions.PropertyNamingConvention selectedNaming;
+
+    private Phase phase = Phase.SELECT;
+    private final TableState tableState = new TableState();
+    private String status;
+
+    // Preview state
+    private List<UnifiedDiff.DiffLine> diffLines;
+    private int diffScroll;
+    private String alignedPomContent;
+
+    private TuiRunner runner;
+
+    AlignTui(String pomPath, String projectGav, String originalPomContent, AlignOptions detectedOptions) {
+        this.pomPath = pomPath;
+        this.projectGav = projectGav;
+        this.originalPomContent = originalPomContent;
+        this.detectedOptions = detectedOptions;
+        this.selectedStyle = detectedOptions.versionStyle();
+        this.selectedSource = detectedOptions.versionSource();
+        this.selectedNaming = detectedOptions.namingConvention();
+        this.status = "Detected conventions from POM";
+        tableState.select(0);
+    }
+
+    void run() throws Exception {
+        var configured = TuiRunner.builder()
+                .eventHandler(this::handleEvent)
+                .renderer(this::render)
+                .tickRate(Duration.ofMillis(100))
+                .build();
+        try {
+            runner = configured.runner();
+            configured.run();
+        } finally {
+            configured.close();
+        }
+    }
+
+    boolean handleEvent(Event event, TuiRunner runner) {
+        if (!(event instanceof KeyEvent key)) {
+            return true;
+        }
+
+        if (key.isCtrlC() || key.isCharIgnoreCase('q')) {
+            runner.quit();
+            return true;
+        }
+
+        if (phase == Phase.PREVIEW) {
+            return handlePreviewEvent(key);
+        }
+        return handleSelectEvent(key);
+    }
+
+    private boolean handleSelectEvent(KeyEvent key) {
+        if (key.isKey(KeyCode.ESCAPE)) {
+            runner.quit();
+            return true;
+        }
+
+        if (key.isUp()) {
+            tableState.selectPrevious();
+            return true;
+        }
+        if (key.isDown()) {
+            tableState.selectNext(ROW_COUNT);
+            return true;
+        }
+
+        if (key.isRight() || key.isKey(KeyCode.ENTER)) {
+            cycleForward();
+            return true;
+        }
+        if (key.isLeft()) {
+            cycleBackward();
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('p')) {
+            showPreview();
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('w')) {
+            applyAlignment();
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean handlePreviewEvent(KeyEvent key) {
+        if (key.isKey(KeyCode.ESCAPE)) {
+            phase = Phase.SELECT;
+            diffLines = null;
+            diffScroll = 0;
+            return true;
+        }
+
+        if (key.isUp()) {
+            if (diffScroll > 0) diffScroll--;
+            return true;
+        }
+        if (key.isDown()) {
+            if (diffLines != null) {
+                diffScroll = Math.min(diffScroll + 1, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+            }
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            diffScroll = Math.max(0, diffScroll - 10);
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            if (diffLines != null) {
+                diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+            }
+            return true;
+        }
+
+        if (key.isKey(KeyCode.ENTER) || key.isCharIgnoreCase('w')) {
+            writeAlignedPom();
+            return true;
+        }
+
+        return false;
+    }
+
+    // -- Convention cycling --
+
+    void cycleForward() {
+        int row = selectedRow();
+        switch (row) {
+            case ROW_VERSION_STYLE -> selectedStyle = nextEnum(AlignOptions.VersionStyle.values(), selectedStyle);
+            case ROW_VERSION_SOURCE -> selectedSource = nextEnum(AlignOptions.VersionSource.values(), selectedSource);
+            case ROW_PROPERTY_NAMING ->
+                selectedNaming = nextEnum(AlignOptions.PropertyNamingConvention.values(), selectedNaming);
+        }
+    }
+
+    void cycleBackward() {
+        int row = selectedRow();
+        switch (row) {
+            case ROW_VERSION_STYLE -> selectedStyle = prevEnum(AlignOptions.VersionStyle.values(), selectedStyle);
+            case ROW_VERSION_SOURCE -> selectedSource = prevEnum(AlignOptions.VersionSource.values(), selectedSource);
+            case ROW_PROPERTY_NAMING ->
+                selectedNaming = prevEnum(AlignOptions.PropertyNamingConvention.values(), selectedNaming);
+        }
+    }
+
+    static <E extends Enum<E>> E nextEnum(E[] values, E current) {
+        int idx = current.ordinal();
+        return values[(idx + 1) % values.length];
+    }
+
+    static <E extends Enum<E>> E prevEnum(E[] values, E current) {
+        int idx = current.ordinal();
+        return values[(idx - 1 + values.length) % values.length];
+    }
+
+    private int selectedRow() {
+        Integer sel = tableState.selected();
+        return sel != null ? sel : 0;
+    }
+
+    AlignOptions buildSelectedOptions() {
+        return AlignOptions.builder()
+                .versionStyle(selectedStyle)
+                .versionSource(selectedSource)
+                .namingConvention(selectedNaming)
+                .build();
+    }
+
+    // -- Actions --
+
+    private void showPreview() {
+        try {
+            String currentPom = Files.readString(Path.of(pomPath));
+            PomEditor editor = new PomEditor(Document.of(currentPom));
+            int count = editor.dependencies().alignAllDependencies(buildSelectedOptions());
+            alignedPomContent = editor.toXml();
+
+            var fullDiff = UnifiedDiff.compute(currentPom, alignedPomContent);
+            long changes = UnifiedDiff.changeCount(fullDiff);
+
+            if (changes == 0) {
+                status = "No changes needed \u2014 POM already aligned";
+                return;
+            }
+
+            diffLines = UnifiedDiff.filterContext(fullDiff, 3);
+            diffScroll = 0;
+            phase = Phase.PREVIEW;
+            status = count + " dependency(ies) aligned, " + changes + " line(s) changed";
+        } catch (Exception e) {
+            status = "Failed to compute preview: " + e.getMessage();
+        }
+    }
+
+    private void applyAlignment() {
+        try {
+            String currentPom = Files.readString(Path.of(pomPath));
+            PomEditor editor = new PomEditor(Document.of(currentPom));
+            int count = editor.dependencies().alignAllDependencies(buildSelectedOptions());
+            Files.writeString(Path.of(pomPath), editor.toXml());
+            status = "Aligned " + count + " dependency(ies) in POM";
+        } catch (Exception e) {
+            status = "Failed to apply alignment: " + e.getMessage();
+        }
+    }
+
+    private void writeAlignedPom() {
+        if (alignedPomContent == null) return;
+        try {
+            Files.writeString(Path.of(pomPath), alignedPomContent);
+            status = "Changes written to POM";
+            phase = Phase.SELECT;
+            diffLines = null;
+            diffScroll = 0;
+            alignedPomContent = null;
+        } catch (Exception e) {
+            status = "Failed to write POM: " + e.getMessage();
+        }
+    }
+
+    // -- Rendering --
+
+    private int lastContentHeight;
+
+    void render(Frame frame) {
+        var zones = Layout.vertical()
+                .constraints(Constraint.length(3), Constraint.fill(), Constraint.length(3))
+                .split(frame.area());
+
+        renderHeader(frame, zones.get(0));
+        lastContentHeight = zones.get(1).height();
+
+        if (phase == Phase.PREVIEW && diffLines != null) {
+            UnifiedDiff.render(frame, zones.get(1), diffLines, diffScroll, " POM Changes Preview ");
+        } else {
+            renderConventionTable(frame, zones.get(1));
+        }
+
+        renderInfoBar(frame, zones.get(2));
+    }
+
+    private void renderHeader(Frame frame, Rect area) {
+        String title =
+                phase == Phase.PREVIEW ? " Pilot \u2014 Alignment Preview " : " Pilot \u2014 Convention Alignment ";
+        Block block = Block.builder()
+                .title(title)
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().cyan())
+                .build();
+
+        List<Span> spans = new ArrayList<>();
+        spans.add(Span.raw(" " + projectGav).bold().cyan());
+
+        Paragraph header = Paragraph.builder()
+                .text(dev.tamboui.text.Text.from(Line.from(spans)))
+                .block(block)
+                .build();
+        frame.renderWidget(header, area);
+    }
+
+    private void renderConventionTable(Frame frame, Rect area) {
+        Block block = Block.builder()
+                .title(" Dependency Conventions ")
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().fg(Color.DARK_GRAY))
+                .build();
+
+        Row header = Row.from("Convention", "Detected", "Selected")
+                .style(Style.create().bold().yellow());
+
+        List<Row> rows = new ArrayList<>();
+        rows.add(createConventionRow(
+                "Version Style",
+                detectedOptions.versionStyle().name(),
+                selectedStyle.name(),
+                selectedStyle != detectedOptions.versionStyle()));
+        rows.add(createConventionRow(
+                "Version Source",
+                detectedOptions.versionSource().name(),
+                selectedSource.name(),
+                selectedSource != detectedOptions.versionSource()));
+        rows.add(createConventionRow(
+                "Property Naming",
+                detectedOptions.namingConvention().name(),
+                selectedNaming.name(),
+                selectedNaming != detectedOptions.namingConvention()));
+
+        Table table = Table.builder()
+                .header(header)
+                .rows(rows)
+                .widths(Constraint.percentage(30), Constraint.percentage(35), Constraint.percentage(35))
+                .highlightStyle(Style.create().reversed().bold())
+                .highlightSymbol("\u25B8 ")
+                .block(block)
+                .build();
+
+        frame.renderStatefulWidget(table, area, tableState);
+    }
+
+    private Row createConventionRow(String name, String detected, String selected, boolean changed) {
+        Style style = changed ? Style.create().fg(Color.YELLOW) : Style.create();
+        String selectedDisplay = changed ? selected + " \u2190" : selected;
+        return Row.from(name, detected, selectedDisplay).style(style);
+    }
+
+    private void renderInfoBar(Frame frame, Rect area) {
+        var rows = Layout.vertical()
+                .constraints(Constraint.length(1), Constraint.length(1), Constraint.length(1))
+                .split(area);
+
+        // Status
+        List<Span> statusSpans = new ArrayList<>();
+        statusSpans.add(Span.raw(" " + status).fg(Color.GREEN));
+        frame.renderWidget(Paragraph.from(Line.from(statusSpans)), rows.get(1));
+
+        // Key bindings
+        List<Span> spans = new ArrayList<>();
+        spans.add(Span.raw(" "));
+        if (phase == Phase.PREVIEW) {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Scroll  "));
+            spans.add(Span.raw("PgUp/PgDn").bold());
+            spans.add(Span.raw(":Page  "));
+            spans.add(Span.raw("Enter/w").bold());
+            spans.add(Span.raw(":Apply  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Back  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        } else {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Navigate  "));
+            spans.add(Span.raw("\u2190\u2192/Enter").bold());
+            spans.add(Span.raw(":Cycle  "));
+            spans.add(Span.raw("p").bold());
+            spans.add(Span.raw(":Preview  "));
+            spans.add(Span.raw("w").bold());
+            spans.add(Span.raw(":Apply  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        }
+
+        frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(2));
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
@@ -75,8 +75,7 @@ class AlignTui {
     private String status;
 
     // Preview state
-    private List<UnifiedDiff.DiffLine> diffLines;
-    private int diffScroll;
+    private final DiffOverlay diffOverlay = new DiffOverlay();
     private String alignedPomContent;
 
     private TuiRunner runner;
@@ -163,31 +162,11 @@ class AlignTui {
     private boolean handlePreviewEvent(KeyEvent key) {
         if (key.isKey(KeyCode.ESCAPE)) {
             phase = Phase.SELECT;
-            diffLines = null;
-            diffScroll = 0;
+            diffOverlay.close();
             return true;
         }
 
-        if (key.isUp()) {
-            if (diffScroll > 0) diffScroll--;
-            return true;
-        }
-        if (key.isDown()) {
-            if (diffLines != null) {
-                diffScroll = Math.min(diffScroll + 1, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
-            }
-            return true;
-        }
-        if (key.isKey(KeyCode.PAGE_UP)) {
-            diffScroll = Math.max(0, diffScroll - 10);
-            return true;
-        }
-        if (key.isKey(KeyCode.PAGE_DOWN)) {
-            if (diffLines != null) {
-                diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
-            }
-            return true;
-        }
+        if (diffOverlay.handleScrollKey(key, lastContentHeight)) return true;
 
         if (key.isKey(KeyCode.ENTER) || key.isCharIgnoreCase('w')) {
             writeAlignedPom();
@@ -251,16 +230,13 @@ class AlignTui {
             int count = editor.dependencies().alignAllDependencies(buildSelectedOptions());
             alignedPomContent = editor.toXml();
 
-            var fullDiff = UnifiedDiff.compute(currentPom, alignedPomContent);
-            long changes = UnifiedDiff.changeCount(fullDiff);
+            long changes = diffOverlay.open(currentPom, alignedPomContent);
 
             if (changes == 0) {
                 status = "No changes needed \u2014 POM already aligned";
                 return;
             }
 
-            diffLines = UnifiedDiff.filterContext(fullDiff, 3);
-            diffScroll = 0;
             phase = Phase.PREVIEW;
             status = count + " dependency(ies) aligned, " + changes + " line(s) changed";
         } catch (Exception e) {
@@ -288,8 +264,7 @@ class AlignTui {
             Files.writeString(Path.of(pomPath), editor.toXml());
             status = "Changes written to POM";
             phase = Phase.SELECT;
-            diffLines = null;
-            diffScroll = 0;
+            diffOverlay.close();
             alignedPomContent = null;
         } catch (Exception e) {
             status = "Failed to write POM: " + e.getMessage();
@@ -308,8 +283,8 @@ class AlignTui {
         renderHeader(frame, zones.get(0));
         lastContentHeight = zones.get(1).height();
 
-        if (phase == Phase.PREVIEW && diffLines != null) {
-            UnifiedDiff.render(frame, zones.get(1), diffLines, diffScroll, " POM Changes Preview ");
+        if (phase == Phase.PREVIEW && diffOverlay.isActive()) {
+            diffOverlay.render(frame, zones.get(1), " POM Changes Preview ");
         } else {
             renderConventionTable(frame, zones.get(1));
         }

--- a/src/main/java/eu/maveniverse/maven/pilot/AuditMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditMojo.java
@@ -23,6 +23,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -44,11 +45,14 @@ import org.eclipse.aether.graph.DependencyNode;
  *
  * @since 0.1.0
  */
-@Mojo(name = "audit", requiresProject = true, threadSafe = true)
+@Mojo(name = "audit", requiresProject = true, aggregator = true, threadSafe = true)
 public class AuditMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
 
     @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
     private RepositorySystemSession repoSession;
@@ -56,29 +60,52 @@ public class AuditMojo extends AbstractMojo {
     @Inject
     private RepositorySystem repoSystem;
 
-    /**
-     * Runs the interactive license and security audit dashboard for the current Maven project.
-     *
-     * Collects the project's transitive dependencies, builds audit entries, and launches the AuditTui UI.
-     *
-     * @throws MojoExecutionException if dependency collection or the audit UI fails to run
-     */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
-            CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(project));
-
-            // Collect all transitive dependencies
-            List<AuditTui.AuditEntry> entries = new ArrayList<>();
-            Set<String> seen = new HashSet<>();
-            collectEntries(result.getRoot(), entries, seen, true);
-
-            String gav = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
-            AuditTui tui = new AuditTui(entries, gav);
-            tui.run();
+            List<MavenProject> projects = session.getProjects();
+            if (projects.size() > 1) {
+                executeReactor(projects);
+            } else {
+                executeSingleProject(project);
+            }
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to run audit: " + e.getMessage(), e);
         }
+    }
+
+    private void executeSingleProject(MavenProject proj) throws Exception {
+        List<AuditTui.AuditEntry> entries = collectEntriesForProject(proj);
+        String gav = proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion();
+        AuditTui tui = new AuditTui(entries, gav);
+        tui.run();
+    }
+
+    private void executeReactor(List<MavenProject> projects) throws Exception {
+        // Aggregate all transitive deps across modules, deduped by GA
+        List<AuditTui.AuditEntry> entries = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        for (MavenProject proj : projects) {
+            for (var entry : collectEntriesForProject(proj)) {
+                String ga = entry.ga();
+                if (seen.add(ga)) {
+                    entries.add(entry);
+                }
+            }
+        }
+
+        MavenProject root = projects.get(0);
+        String gav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
+        AuditTui tui = new AuditTui(entries, gav + " (reactor: " + projects.size() + " modules)");
+        tui.run();
+    }
+
+    private List<AuditTui.AuditEntry> collectEntriesForProject(MavenProject proj) throws Exception {
+        CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
+        List<AuditTui.AuditEntry> entries = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        collectEntries(result.getRoot(), entries, seen, true);
+        return entries;
     }
 
     /**

--- a/src/main/java/eu/maveniverse/maven/pilot/AuditMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditMojo.java
@@ -75,37 +75,35 @@ public class AuditMojo extends AbstractMojo {
     }
 
     private void executeSingleProject(MavenProject proj) throws Exception {
-        List<AuditTui.AuditEntry> entries = collectEntriesForProject(proj);
+        CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
+        DependencyTreeModel treeModel = DependencyTreeModel.fromDependencyNode(result.getRoot());
+        List<AuditTui.AuditEntry> entries = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        collectEntries(result.getRoot(), entries, seen, true);
         String gav = proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion();
-        AuditTui tui = new AuditTui(entries, gav);
+        String pomPath = proj.getFile().getAbsolutePath();
+        AuditTui tui = new AuditTui(entries, gav, treeModel, pomPath);
         tui.run();
     }
 
     private void executeReactor(List<MavenProject> projects) throws Exception {
         // Aggregate all transitive deps across modules, deduped by GA
+        // Use root project's tree for dependency path tracing
+        MavenProject root = projects.get(0);
+        CollectResult rootResult = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(root));
+        DependencyTreeModel treeModel = DependencyTreeModel.fromDependencyNode(rootResult.getRoot());
+
         List<AuditTui.AuditEntry> entries = new ArrayList<>();
         Set<String> seen = new HashSet<>();
         for (MavenProject proj : projects) {
-            for (var entry : collectEntriesForProject(proj)) {
-                String ga = entry.ga();
-                if (seen.add(ga)) {
-                    entries.add(entry);
-                }
-            }
+            CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
+            collectEntries(result.getRoot(), entries, seen, true);
         }
 
-        MavenProject root = projects.get(0);
         String gav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
-        AuditTui tui = new AuditTui(entries, gav + " (reactor: " + projects.size() + " modules)");
+        String pomPath = root.getFile().getAbsolutePath();
+        AuditTui tui = new AuditTui(entries, gav + " (reactor: " + projects.size() + " modules)", treeModel, pomPath);
         tui.run();
-    }
-
-    private List<AuditTui.AuditEntry> collectEntriesForProject(MavenProject proj) throws Exception {
-        CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
-        List<AuditTui.AuditEntry> entries = new ArrayList<>();
-        Set<String> seen = new HashSet<>();
-        collectEntries(result.getRoot(), entries, seen, true);
-        return entries;
     }
 
     /**

--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -38,10 +38,14 @@ import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Interactive TUI for license and security audit.
@@ -54,6 +58,7 @@ class AuditTui {
         final String version;
         final String scope;
         String license;
+        String licenseUrl;
         List<OsvClient.Vulnerability> vulnerabilities;
         boolean licenseLoaded;
         boolean vulnsLoaded;
@@ -80,20 +85,59 @@ class AuditTui {
 
     private enum View {
         LICENSES,
+        BY_LICENSE,
         VULNERABILITIES
+    }
+
+    /** Row in the by-license view: either a license group header or a dependency. */
+    private static class LicenseRow {
+        final String licenseName;
+        final String licenseUrl;
+        final List<AuditEntry> deps; // non-null for group headers
+        final AuditEntry entry; // non-null for dependency rows
+        boolean expanded;
+
+        static LicenseRow group(String name, String url, List<AuditEntry> deps) {
+            var r = new LicenseRow(name, url, deps, null);
+            return r;
+        }
+
+        static LicenseRow dep(AuditEntry entry) {
+            return new LicenseRow(null, null, null, entry);
+        }
+
+        private LicenseRow(String licenseName, String licenseUrl, List<AuditEntry> deps, AuditEntry entry) {
+            this.licenseName = licenseName;
+            this.licenseUrl = licenseUrl;
+            this.deps = deps;
+            this.entry = entry;
+        }
+
+        boolean isGroup() {
+            return deps != null;
+        }
     }
 
     private final List<AuditEntry> entries;
     private final String projectGav;
     private final TableState tableState = new TableState();
-    private final ExecutorService httpPool = Executors.newFixedThreadPool(5);
+    private final ExecutorService httpPool = MojoHelper.newHttpPool();
     private final OsvClient osvClient = new OsvClient();
+
+    private final HelpOverlay helpOverlay = new HelpOverlay();
+    private final TableState vulnTableState = new TableState();
+    private final TableState byLicenseTableState = new TableState();
 
     private View view = View.LICENSES;
     private int licensesLoaded = 0;
     private int vulnsLoaded = 0;
     private int vulnCount = 0;
     private String status;
+    private List<VulnRow> vulnRows = new ArrayList<>();
+    private List<LicenseRow> byLicenseRows = new ArrayList<>();
+
+    /** Flattened vulnerability row linking back to its parent entry. */
+    private record VulnRow(AuditEntry entry, OsvClient.Vulnerability vuln) {}
 
     private TuiRunner runner;
 
@@ -119,7 +163,7 @@ class AuditTui {
         } finally {
             configured.close();
             httpPool.shutdownNow();
-            httpPool.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS);
+            httpPool.awaitTermination(5, TimeUnit.SECONDS);
         }
     }
 
@@ -132,9 +176,11 @@ class AuditTui {
                     .thenAccept(info -> runner.runOnRenderThread(() -> {
                         if (info != null && info.license != null) {
                             entry.license = info.license;
+                            entry.licenseUrl = info.licenseUrl;
                         }
                         entry.licenseLoaded = true;
                         licensesLoaded++;
+                        rebuildByLicenseRows();
                         updateStatus();
                     }));
 
@@ -154,9 +200,66 @@ class AuditTui {
                         vulnsLoaded++;
                         if (!vulns.isEmpty()) {
                             vulnCount += vulns.size();
+                            rebuildVulnRows();
                         }
                         updateStatus();
                     }));
+        }
+    }
+
+    private void rebuildVulnRows() {
+        vulnRows = new ArrayList<>();
+        for (var entry : entries) {
+            if (entry.hasVulnerabilities()) {
+                for (var vuln : entry.vulnerabilities) {
+                    vulnRows.add(new VulnRow(entry, vuln));
+                }
+            }
+        }
+        if (!vulnRows.isEmpty() && vulnTableState.selected() == null) {
+            vulnTableState.select(0);
+        }
+    }
+
+    private void rebuildByLicenseRows() {
+        // Preserve expansion state
+        var expanded = new HashSet<String>();
+        for (var row : byLicenseRows) {
+            if (row.isGroup() && row.expanded) expanded.add(row.licenseName);
+        }
+
+        // Group entries by normalized license name
+        var groups = new LinkedHashMap<String, List<AuditEntry>>();
+        var urls = new HashMap<String, String>();
+        for (var entry : entries) {
+            if (!entry.licenseLoaded) continue;
+            String key = entry.license != null ? normalizeLicense(entry.license, entry.licenseUrl) : "(not specified)";
+            groups.computeIfAbsent(key, k -> new ArrayList<>()).add(entry);
+            if (entry.licenseUrl != null && !urls.containsKey(key)) {
+                urls.put(key, entry.licenseUrl);
+            }
+        }
+
+        // Sort groups by usage count (descending)
+        var sortedGroups = new ArrayList<>(groups.entrySet());
+        sortedGroups.sort(
+                (a, b) -> Integer.compare(b.getValue().size(), a.getValue().size()));
+
+        // Build flat row list
+        byLicenseRows = new ArrayList<>();
+        for (var e : sortedGroups) {
+            var group = LicenseRow.group(e.getKey(), urls.get(e.getKey()), e.getValue());
+            group.expanded = expanded.contains(e.getKey());
+            byLicenseRows.add(group);
+            if (group.expanded) {
+                for (var dep : e.getValue()) {
+                    byLicenseRows.add(LicenseRow.dep(dep));
+                }
+            }
+        }
+
+        if (!byLicenseRows.isEmpty() && byLicenseTableState.selected() == null) {
+            byLicenseTableState.select(0);
         }
     }
 
@@ -175,22 +278,82 @@ class AuditTui {
             return true;
         }
 
+        if (helpOverlay.isActive()) {
+            if (helpOverlay.handleKey(key)) return true;
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                runner.quit();
+                return true;
+            }
+            return false;
+        }
+
         if (key.isCtrlC() || key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q')) {
             runner.quit();
             return true;
         }
 
         if (key.isUp()) {
-            tableState.selectPrevious();
+            activeTableState().selectPrevious();
             return true;
         }
         if (key.isDown()) {
-            tableState.selectNext(entries.size());
+            activeTableState().selectNext(activeRowCount());
             return true;
         }
 
         if (key.isKey(KeyCode.TAB)) {
-            view = (view == View.LICENSES) ? View.VULNERABILITIES : View.LICENSES;
+            view = switch (view) {
+                case LICENSES -> View.BY_LICENSE;
+                case BY_LICENSE -> View.VULNERABILITIES;
+                case VULNERABILITIES -> View.LICENSES;
+            };
+            return true;
+        }
+
+        // Expand/collapse and navigate license groups in BY_LICENSE view
+        if (view == View.BY_LICENSE && (key.isKey(KeyCode.ENTER) || key.isChar(' '))) {
+            int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
+            if (idx >= 0 && idx < byLicenseRows.size() && byLicenseRows.get(idx).isGroup()) {
+                byLicenseRows.get(idx).expanded = !byLicenseRows.get(idx).expanded;
+                rebuildByLicenseRows();
+            }
+            return true;
+        }
+        if (view == View.BY_LICENSE && key.isRight()) {
+            int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
+            if (idx >= 0 && idx < byLicenseRows.size() && byLicenseRows.get(idx).isGroup()) {
+                if (!byLicenseRows.get(idx).expanded) {
+                    byLicenseRows.get(idx).expanded = true;
+                    rebuildByLicenseRows();
+                } else {
+                    // Move to first child
+                    byLicenseTableState.selectNext(byLicenseRows.size());
+                }
+            }
+            return true;
+        }
+        if (view == View.BY_LICENSE && key.isLeft()) {
+            int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
+            if (idx >= 0 && idx < byLicenseRows.size()) {
+                LicenseRow row = byLicenseRows.get(idx);
+                if (row.isGroup() && row.expanded) {
+                    row.expanded = false;
+                    rebuildByLicenseRows();
+                } else if (!row.isGroup()) {
+                    // Move to parent group: find nearest preceding group row
+                    for (int i = idx - 1; i >= 0; i--) {
+                        if (byLicenseRows.get(i).isGroup()) {
+                            byLicenseTableState.select(i);
+                            break;
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('h')) {
+            helpOverlay.open(buildHelp());
             return true;
         }
 
@@ -206,10 +369,14 @@ class AuditTui {
 
         renderHeader(frame, zones.get(0));
 
-        if (view == View.LICENSES) {
-            renderLicenses(frame, zones.get(1));
+        if (helpOverlay.isActive()) {
+            helpOverlay.render(frame, zones.get(1));
         } else {
-            renderVulnerabilities(frame, zones.get(1));
+            switch (view) {
+                case LICENSES -> renderLicenses(frame, zones.get(1));
+                case BY_LICENSE -> renderByLicense(frame, zones.get(1));
+                case VULNERABILITIES -> renderVulnerabilities(frame, zones.get(1));
+            }
         }
 
         renderInfoBar(frame, zones.get(2));
@@ -228,6 +395,9 @@ class AuditTui {
         spans.add(Span.raw("[" + (view == View.LICENSES ? "\u25B8 " : "  ") + "Licenses]")
                 .fg(view == View.LICENSES ? Color.YELLOW : Color.DARK_GRAY));
         spans.add(Span.raw("  "));
+        spans.add(Span.raw("[" + (view == View.BY_LICENSE ? "\u25B8 " : "  ") + "By License]")
+                .fg(view == View.BY_LICENSE ? Color.YELLOW : Color.DARK_GRAY));
+        spans.add(Span.raw("  "));
         spans.add(Span.raw("[" + (view == View.VULNERABILITIES ? "\u25B8 " : "  ") + "Vulnerabilities"
                         + (vulnCount > 0 ? " (" + vulnCount + ")" : "") + "]")
                 .fg(view == View.VULNERABILITIES ? (vulnCount > 0 ? Color.RED : Color.YELLOW) : Color.DARK_GRAY));
@@ -240,6 +410,11 @@ class AuditTui {
     }
 
     private void renderLicenses(Frame frame, Rect area) {
+        // Split into table + separator + detail pane
+        var zones = Layout.vertical()
+                .constraints(Constraint.fill(), Constraint.length(1), Constraint.length(4))
+                .split(area);
+
         Block block = Block.builder()
                 .title(" Licenses (" + entries.size() + " dependencies) ")
                 .borderType(BorderType.ROUNDED)
@@ -267,24 +442,205 @@ class AuditTui {
                 .block(block)
                 .build();
 
-        frame.renderStatefulWidget(table, area, tableState);
+        frame.renderStatefulWidget(table, zones.get(0), tableState);
+
+        // -- Detail pane --
+        renderLicenseDetail(frame, zones.get(2));
+    }
+
+    private void renderLicenseDetail(Frame frame, Rect area) {
+        Block block = Block.builder()
+                .title(" Details ")
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().fg(Color.DARK_GRAY))
+                .build();
+
+        int idx = tableState.selected() != null ? tableState.selected() : -1;
+        if (idx < 0 || idx >= entries.size()) {
+            frame.renderWidget(Paragraph.builder().text("").block(block).build(), area);
+            return;
+        }
+
+        AuditEntry entry = entries.get(idx);
+        List<Span> spans = new ArrayList<>();
+        String centralUrl = centralUrl(entry.groupId, entry.artifactId);
+        spans.add(Span.raw(entry.gav()).bold().cyan().hyperlink(centralUrl));
+        spans.add(Span.raw("  scope: ").fg(Color.DARK_GRAY));
+        spans.add(Span.raw(entry.scope));
+        spans.add(Span.raw("  \u2197 ").fg(Color.DARK_GRAY));
+        spans.add(Span.raw(centralUrl).fg(Color.BLUE).hyperlink(centralUrl));
+
+        List<Span> licSpans = new ArrayList<>();
+        if (entry.license != null) {
+            licSpans.add(Span.raw("License: ").fg(Color.DARK_GRAY));
+            if (entry.licenseUrl != null && !entry.licenseUrl.isEmpty()) {
+                licSpans.add(Span.raw(entry.license)
+                        .style(getLicenseStyle(entry.license))
+                        .hyperlink(entry.licenseUrl));
+                licSpans.add(Span.raw("  \u2197 ").fg(Color.DARK_GRAY));
+                licSpans.add(Span.raw(entry.licenseUrl).fg(Color.BLUE).hyperlink(entry.licenseUrl));
+            } else {
+                licSpans.add(Span.raw(entry.license).style(getLicenseStyle(entry.license)));
+            }
+        } else if (entry.licenseLoaded) {
+            licSpans.add(Span.raw("License: ").fg(Color.DARK_GRAY));
+            licSpans.add(Span.raw("not specified").fg(Color.DARK_GRAY));
+        } else {
+            licSpans.add(Span.raw("Loading\u2026").fg(Color.DARK_GRAY));
+        }
+
+        Paragraph detail = Paragraph.builder()
+                .text(dev.tamboui.text.Text.from(Line.from(spans), Line.from(licSpans)))
+                .block(block)
+                .build();
+        frame.renderWidget(detail, area);
+    }
+
+    private TableState activeTableState() {
+        return switch (view) {
+            case VULNERABILITIES -> vulnTableState;
+            case BY_LICENSE -> byLicenseTableState;
+            default -> tableState;
+        };
+    }
+
+    private int activeRowCount() {
+        return switch (view) {
+            case VULNERABILITIES -> vulnRows.size();
+            case BY_LICENSE -> byLicenseRows.size();
+            default -> entries.size();
+        };
+    }
+
+    private void renderByLicense(Frame frame, Rect area) {
+        if (byLicenseRows.isEmpty()) {
+            Block block = Block.builder()
+                    .title(" By License ")
+                    .borderType(BorderType.ROUNDED)
+                    .borderStyle(Style.create().fg(Color.DARK_GRAY))
+                    .build();
+            String msg = (licensesLoaded >= entries.size())
+                    ? "No license data available"
+                    : "Loading licenses\u2026 " + licensesLoaded + "/" + entries.size();
+            frame.renderWidget(
+                    Paragraph.builder().text(msg).block(block).centered().build(), area);
+            return;
+        }
+
+        // Split into table + separator + detail pane
+        var zones = Layout.vertical()
+                .constraints(Constraint.fill(), Constraint.length(1), Constraint.length(4))
+                .split(area);
+
+        Block block = Block.builder()
+                .title(" By License (" + countLicenseGroups() + " licenses) ")
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().fg(Color.DARK_GRAY))
+                .build();
+
+        List<Row> rows = new ArrayList<>();
+        for (var row : byLicenseRows) {
+            if (row.isGroup()) {
+                String arrow = row.expanded ? "\u25BE " : "\u25B8 ";
+                String label = arrow + row.licenseName + " (" + row.deps.size() + ")";
+                rows.add(Row.from(label, "", "", "")
+                        .style(getLicenseStyle("(not specified)".equals(row.licenseName) ? null : row.licenseName)
+                                .bold()));
+            } else {
+                rows.add(Row.from("    " + row.entry.ga(), row.entry.version, row.entry.scope, "")
+                        .style(Style.create().fg(Color.DARK_GRAY)));
+            }
+        }
+
+        Row header = Row.from("license / artifact", "version", "scope", "")
+                .style(Style.create().bold().yellow());
+
+        Table table = Table.builder()
+                .header(header)
+                .rows(rows)
+                .widths(
+                        Constraint.percentage(55), Constraint.percentage(20),
+                        Constraint.percentage(15), Constraint.percentage(10))
+                .highlightStyle(Style.create().reversed().bold())
+                .highlightSymbol("\u25B8 ")
+                .block(block)
+                .build();
+
+        frame.renderStatefulWidget(table, zones.get(0), byLicenseTableState);
+
+        // -- Detail pane --
+        renderByLicenseDetail(frame, zones.get(2));
+    }
+
+    private long countLicenseGroups() {
+        return byLicenseRows.stream().filter(LicenseRow::isGroup).count();
+    }
+
+    private void renderByLicenseDetail(Frame frame, Rect area) {
+        Block block = Block.builder()
+                .title(" Details ")
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().fg(Color.DARK_GRAY))
+                .build();
+
+        int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
+        if (idx < 0 || idx >= byLicenseRows.size()) {
+            frame.renderWidget(Paragraph.builder().text("").block(block).build(), area);
+            return;
+        }
+
+        LicenseRow row = byLicenseRows.get(idx);
+        List<Line> lines = new ArrayList<>();
+
+        if (row.isGroup()) {
+            List<Span> titleSpans = new ArrayList<>();
+            titleSpans.add(Span.raw(row.licenseName).bold().cyan());
+            titleSpans.add(Span.raw("  " + row.deps.size() + " dependencies").fg(Color.DARK_GRAY));
+            lines.add(Line.from(titleSpans));
+
+            if (row.licenseUrl != null && !row.licenseUrl.isEmpty()) {
+                lines.add(Line.from(
+                        Span.raw("URL: ").fg(Color.DARK_GRAY),
+                        Span.raw(row.licenseUrl).fg(Color.BLUE).hyperlink(row.licenseUrl)));
+            }
+        } else {
+            String centralUrl = centralUrl(row.entry.groupId, row.entry.artifactId);
+            lines.add(Line.from(
+                    Span.raw(row.entry.gav()).bold().cyan().hyperlink(centralUrl),
+                    Span.raw("  scope: ").fg(Color.DARK_GRAY),
+                    Span.raw(row.entry.scope),
+                    Span.raw("  \u2197 ").fg(Color.DARK_GRAY),
+                    Span.raw(centralUrl).fg(Color.BLUE).hyperlink(centralUrl)));
+            if (row.entry.license != null) {
+                List<Span> licSpans = new ArrayList<>();
+                licSpans.add(Span.raw("License: ").fg(Color.DARK_GRAY));
+                if (row.entry.licenseUrl != null && !row.entry.licenseUrl.isEmpty()) {
+                    licSpans.add(Span.raw(row.entry.license)
+                            .style(getLicenseStyle(row.entry.license))
+                            .hyperlink(row.entry.licenseUrl));
+                    licSpans.add(Span.raw("  \u2197 ").fg(Color.DARK_GRAY));
+                    licSpans.add(Span.raw(row.entry.licenseUrl).fg(Color.BLUE).hyperlink(row.entry.licenseUrl));
+                } else {
+                    licSpans.add(Span.raw(row.entry.license).style(getLicenseStyle(row.entry.license)));
+                }
+                lines.add(Line.from(licSpans));
+            }
+        }
+
+        Paragraph detail = Paragraph.builder()
+                .text(dev.tamboui.text.Text.from(lines))
+                .block(block)
+                .build();
+        frame.renderWidget(detail, area);
     }
 
     private void renderVulnerabilities(Frame frame, Rect area) {
-        Block block = Block.builder()
-                .title(" Vulnerabilities ")
-                .borderType(BorderType.ROUNDED)
-                .borderStyle(
-                        vulnCount > 0
-                                ? Style.create().fg(Color.RED)
-                                : Style.create().fg(Color.DARK_GRAY))
-                .build();
-
-        // Filter to entries with vulnerabilities
-        List<AuditEntry> vulnEntries =
-                entries.stream().filter(AuditEntry::hasVulnerabilities).toList();
-
-        if (vulnEntries.isEmpty()) {
+        if (vulnRows.isEmpty()) {
+            Block block = Block.builder()
+                    .title(" Vulnerabilities ")
+                    .borderType(BorderType.ROUNDED)
+                    .borderStyle(Style.create().fg(Color.DARK_GRAY))
+                    .build();
             String msg = (vulnsLoaded >= entries.size())
                     ? "No known vulnerabilities found \u2713"
                     : "Checking vulnerabilities\u2026 " + vulnsLoaded + "/" + entries.size();
@@ -294,51 +650,331 @@ class AuditTui {
             return;
         }
 
-        List<Row> rows = new ArrayList<>();
-        for (var entry : vulnEntries) {
-            for (var vuln : entry.vulnerabilities) {
-                String aliases = vuln.aliases.isEmpty() ? "" : String.join(", ", vuln.aliases);
-                String summary = vuln.summary.length() > 60 ? vuln.summary.substring(0, 57) + "..." : vuln.summary;
+        // Split into table + separator + detail pane
+        var zones = Layout.vertical()
+                .constraints(Constraint.fill(), Constraint.length(1), Constraint.length(7))
+                .split(area);
 
-                rows.add(Row.from(entry.ga() + ":" + entry.version, vuln.id, summary, aliases)
-                        .style(Style.create().fg(Color.RED)));
-            }
+        // -- Vulnerability table --
+        Block block = Block.builder()
+                .title(" Vulnerabilities (" + vulnRows.size() + ") ")
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().fg(Color.RED))
+                .build();
+
+        List<Row> rows = new ArrayList<>();
+        for (var vr : vulnRows) {
+            String severity = normalizeSeverity(vr.vuln.severity);
+            String summary = vr.vuln.summary.length() > 60 ? vr.vuln.summary.substring(0, 57) + "..." : vr.vuln.summary;
+            rows.add(Row.from(vr.entry.ga() + ":" + vr.entry.version, vr.vuln.id, severity, summary)
+                    .style(getSeverityStyle(severity)));
         }
 
-        Row header = Row.from("artifact", "CVE/ID", "summary", "aliases")
+        Row header = Row.from("artifact", "CVE/ID", "severity", "summary")
                 .style(Style.create().bold().yellow());
 
         Table table = Table.builder()
                 .header(header)
                 .rows(rows)
                 .widths(
-                        Constraint.percentage(30), Constraint.percentage(15),
-                        Constraint.percentage(35), Constraint.percentage(20))
+                        Constraint.percentage(30), Constraint.percentage(18),
+                        Constraint.percentage(10), Constraint.percentage(42))
                 .highlightStyle(Style.create().reversed().bold())
                 .highlightSymbol("\u25B8 ")
                 .block(block)
                 .build();
 
-        frame.renderStatefulWidget(table, area, tableState);
+        frame.renderStatefulWidget(table, zones.get(0), vulnTableState);
+
+        // -- Detail pane --
+        renderVulnDetail(frame, zones.get(2));
+    }
+
+    private void renderVulnDetail(Frame frame, Rect area) {
+        Block block = Block.builder()
+                .title(" Details ")
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().fg(Color.DARK_GRAY))
+                .build();
+
+        int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
+        if (idx < 0 || idx >= vulnRows.size()) {
+            frame.renderWidget(Paragraph.builder().text("").block(block).build(), area);
+            return;
+        }
+
+        VulnRow vr = vulnRows.get(idx);
+        var vuln = vr.vuln;
+        List<Line> lines = new ArrayList<>();
+        String url = vulnUrl(vuln.id);
+        String severity = normalizeSeverity(vuln.severity);
+        String centralUrl = centralUrl(vr.entry.groupId, vr.entry.artifactId);
+        lines.add(Line.from(
+                Span.raw(vuln.id).bold().cyan().hyperlink(url),
+                Span.raw("  "),
+                Span.raw(severity).style(getSeverityStyle(severity).bold()),
+                Span.raw("  "),
+                Span.raw(vr.entry.ga() + ":" + vr.entry.version)
+                        .fg(Color.DARK_GRAY)
+                        .hyperlink(centralUrl)));
+        lines.add(Line.from(
+                Span.raw("\u2197 ").fg(Color.DARK_GRAY),
+                Span.raw(url).fg(Color.BLUE).hyperlink(url)));
+        if (!vuln.aliases.isEmpty()) {
+            List<Span> aliasSpans = new ArrayList<>();
+            aliasSpans.add(Span.raw("Aliases: ").fg(Color.DARK_GRAY));
+            for (int i = 0; i < vuln.aliases.size(); i++) {
+                if (i > 0) aliasSpans.add(Span.raw(", "));
+                String alias = vuln.aliases.get(i);
+                aliasSpans.add(Span.raw(alias).hyperlink(vulnUrl(alias)));
+            }
+            lines.add(Line.from(aliasSpans));
+        }
+        if (vuln.published != null && !vuln.published.isEmpty()) {
+            String pub = vuln.published.length() > 10 ? vuln.published.substring(0, 10) : vuln.published;
+            lines.add(Line.from(Span.raw("Published: ").fg(Color.DARK_GRAY), Span.raw(pub)));
+        }
+        lines.add(Line.from(Span.raw(vuln.summary)));
+
+        Paragraph detail = Paragraph.builder()
+                .text(dev.tamboui.text.Text.from(lines))
+                .block(block)
+                .build();
+        frame.renderWidget(detail, area);
+    }
+
+    private static String centralUrl(String groupId, String artifactId) {
+        return "https://central.sonatype.com/artifact/" + groupId + "/" + artifactId;
+    }
+
+    private static String vulnUrl(String id) {
+        if (id.startsWith("CVE-")) {
+            return "https://nvd.nist.gov/vuln/detail/" + id;
+        }
+        if (id.startsWith("GHSA-")) {
+            return "https://github.com/advisories/" + id;
+        }
+        return "https://osv.dev/vulnerability/" + id;
+    }
+
+    private static String normalizeSeverity(String severity) {
+        if (severity == null) return "UNKNOWN";
+        return severity.toUpperCase();
+    }
+
+    private static Style getSeverityStyle(String severity) {
+        if (severity == null) return Style.create().fg(Color.DARK_GRAY);
+        return switch (severity.toUpperCase()) {
+            case "CRITICAL" -> Style.create().fg(Color.RED).bold();
+            case "HIGH" -> Style.create().fg(Color.RED);
+            case "MEDIUM" -> Style.create().fg(Color.YELLOW);
+            case "LOW" -> Style.create();
+            default -> {
+                if (severity.toUpperCase().startsWith("CVSS")) {
+                    yield Style.create().fg(Color.RED);
+                }
+                yield Style.create().fg(Color.DARK_GRAY);
+            }
+        };
     }
 
     private Style getLicenseStyle(String license) {
-        if (license == null) return Style.create();
-        String lower = license.toLowerCase();
-        // Flag potentially restrictive licenses (check AGPL before GPL since "agpl" contains "gpl")
-        if (lower.contains("agpl")) {
-            return Style.create().fg(Color.RED);
-        }
-        if (lower.contains("gpl") && !lower.contains("lgpl")) {
-            return Style.create().fg(Color.RED);
-        }
-        if (lower.contains("apache") || lower.contains("mit") || lower.contains("bsd")) {
-            return Style.create().fg(Color.GREEN);
-        }
-        if (lower.contains("lgpl") || lower.contains("mpl") || lower.contains("epl") || lower.contains("cddl")) {
+        if (license == null) return Style.create().fg(Color.DARK_GRAY);
+        String normalized = normalizeLicense(license, null);
+        // GPL with classpath exception is weak copyleft
+        if (normalized.equals("GPL-2.0-CE")) {
             return Style.create().fg(Color.YELLOW);
         }
-        return Style.create();
+        // Strong copyleft
+        if (normalized.startsWith("AGPL") || normalized.startsWith("GPL")) {
+            return Style.create().fg(Color.RED);
+        }
+        // Permissive
+        if (normalized.startsWith("Apache")
+                || normalized.equals("MIT")
+                || normalized.startsWith("BSD")
+                || normalized.equals("ISC")
+                || normalized.equals("Unlicense")
+                || normalized.equals("CC0-1.0")
+                || normalized.equals("Public Domain")
+                || normalized.startsWith("EDL")) {
+            return Style.create();
+        }
+        // Weak copyleft
+        if (normalized.startsWith("LGPL")
+                || normalized.startsWith("MPL")
+                || normalized.startsWith("EPL")
+                || normalized.startsWith("CDDL")) {
+            return Style.create().fg(Color.YELLOW);
+        }
+        return Style.create().fg(Color.DARK_GRAY);
+    }
+
+    // -- Well-known license URL → SPDX mapping --
+    private static final Map<String, String> LICENSE_URL_MAP = Map.ofEntries(
+            // Apache
+            Map.entry("apache.org/licenses/license-2.0", "Apache-2.0"),
+            Map.entry("www.apache.org/licenses/license-2.0", "Apache-2.0"),
+            // MIT
+            Map.entry("opensource.org/licenses/mit", "MIT"),
+            Map.entry("mit-license.org", "MIT"),
+            // BSD
+            Map.entry("opensource.org/licenses/bsd-2-clause", "BSD-2-Clause"),
+            Map.entry("opensource.org/licenses/bsd-3-clause", "BSD-3-Clause"),
+            // EPL
+            Map.entry("eclipse.org/legal/epl-2.0", "EPL-2.0"),
+            Map.entry("eclipse.org/legal/epl-v20", "EPL-2.0"),
+            Map.entry("eclipse.org/legal/epl-v10", "EPL-1.0"),
+            Map.entry("eclipse.org/org/documents/epl-2.0", "EPL-2.0"),
+            // EDL
+            Map.entry("eclipse.org/org/documents/edl-v10", "EDL-1.0"),
+            Map.entry("eclipse.org/legal/edl-v10", "EDL-1.0"),
+            // LGPL
+            Map.entry("gnu.org/licenses/lgpl-2.1", "LGPL-2.1"),
+            Map.entry("gnu.org/licenses/lgpl-3.0", "LGPL-3.0"),
+            // GPL
+            Map.entry("gnu.org/licenses/gpl-2.0", "GPL-2.0"),
+            Map.entry("gnu.org/licenses/gpl-3.0", "GPL-3.0"),
+            // AGPL
+            Map.entry("gnu.org/licenses/agpl-3.0", "AGPL-3.0"),
+            // MPL
+            Map.entry("mozilla.org/mpl/2.0", "MPL-2.0"),
+            // CDDL
+            Map.entry("opensource.org/licenses/cddl-1.0", "CDDL-1.0"),
+            Map.entry("glassfish.dev.java.net/public/cddl", "CDDL-1.0"),
+            // CC0
+            Map.entry("creativecommons.org/publicdomain/zero/1.0", "CC0-1.0"),
+            // Unlicense
+            Map.entry("unlicense.org", "Unlicense"),
+            // ISC
+            Map.entry("opensource.org/licenses/isc", "ISC"),
+            // WTFPL
+            Map.entry("sam.zoy.org/wtfpl", "WTFPL"));
+
+    /**
+     * Normalize a license name (and optional URL) to a canonical SPDX-like identifier
+     * for grouping purposes. Uses URL matching first, then name pattern matching.
+     */
+    static String normalizeLicense(String name, String url) {
+        // Try URL match first (most reliable)
+        if (url != null) {
+            String normalizedUrl = url.toLowerCase()
+                    .replaceAll("^https?://", "")
+                    .replaceAll("[/.]$", "")
+                    .replace(".html", "")
+                    .replace(".txt", "")
+                    .replace(".php", "");
+            for (var entry : LICENSE_URL_MAP.entrySet()) {
+                if (normalizedUrl.contains(entry.getKey())) {
+                    return entry.getValue();
+                }
+            }
+        }
+
+        if (name == null) return null;
+        String lower = name.toLowerCase().trim();
+
+        // Dual-license: pick the most permissive option
+        // CDDL + GPL with classpath exception (common in Java EE / Jakarta EE)
+        if ((lower.contains("cddl") && lower.contains("gpl"))
+                || lower.contains("cddl+gpl")
+                || lower.contains("cddl/gpl")) {
+            return "CDDL-1.0";
+        }
+        // Apache OR MIT / BSD — pick Apache
+        if ((lower.contains("apache") || lower.contains("asl"))
+                && (lower.contains(" or ") || lower.contains("/"))
+                && (lower.contains("mit") || lower.contains("bsd"))) {
+            return "Apache-2.0";
+        }
+        // "GPL with classpath exception" alone is weak copyleft (like LGPL)
+        if (lower.contains("classpath exception") || lower.contains("class path exception")) {
+            return "GPL-2.0-CE";
+        }
+
+        // SPDX short identifiers (already normalized)
+        if (lower.equals("apache-2.0") || lower.equals("asl 2.0")) return "Apache-2.0";
+        if (lower.equals("mit")) return "MIT";
+        if (lower.equals("bsd-2-clause")) return "BSD-2-Clause";
+        if (lower.equals("bsd-3-clause")) return "BSD-3-Clause";
+        if (lower.equals("epl-1.0")) return "EPL-1.0";
+        if (lower.equals("epl-2.0")) return "EPL-2.0";
+        if (lower.equals("edl 1.0")) return "EDL-1.0";
+        if (lower.equals("lgpl-2.1") || lower.equals("lgpl-2.1-only")) return "LGPL-2.1";
+        if (lower.equals("lgpl-3.0") || lower.equals("lgpl-3.0-only")) return "LGPL-3.0";
+        if (lower.equals("gpl-2.0") || lower.equals("gpl-2.0-only")) return "GPL-2.0";
+        if (lower.equals("gpl-3.0") || lower.equals("gpl-3.0-only")) return "GPL-3.0";
+        if (lower.equals("agpl-3.0") || lower.equals("agpl-3.0-only")) return "AGPL-3.0";
+        if (lower.equals("mpl-2.0")) return "MPL-2.0";
+        if (lower.equals("cddl-1.0")) return "CDDL-1.0";
+        if (lower.equals("cc0-1.0")) return "CC0-1.0";
+        if (lower.equals("isc")) return "ISC";
+
+        // Pattern matching on common name variations
+        if (lower.contains("apache") && lower.contains("2")) return "Apache-2.0";
+        if (lower.equals("the mit license") || lower.equals("mit license")) return "MIT";
+        if (lower.contains("bsd") && lower.contains("2")) return "BSD-2-Clause";
+        if (lower.contains("bsd") && lower.contains("3")) return "BSD-3-Clause";
+        if (lower.contains("bsd") && !lower.contains("2") && !lower.contains("3")) return "BSD-3-Clause";
+        if (lower.contains("eclipse public") && lower.contains("2")) return "EPL-2.0";
+        if (lower.contains("eclipse public") && lower.contains("1")) return "EPL-1.0";
+        if (lower.contains("eclipse distribution") || lower.equals("edl 1.0")) return "EDL-1.0";
+        if (lower.contains("lesser general public") && lower.contains("2")) return "LGPL-2.1";
+        if (lower.contains("lesser general public") && lower.contains("3")) return "LGPL-3.0";
+        if (lower.contains("lgpl") && lower.contains("2")) return "LGPL-2.1";
+        if (lower.contains("lgpl") && lower.contains("3")) return "LGPL-3.0";
+        if (lower.contains("agpl") || lower.contains("affero")) return "AGPL-3.0";
+        if (lower.contains("general public") && lower.contains("2")) return "GPL-2.0";
+        if (lower.contains("general public") && lower.contains("3")) return "GPL-3.0";
+        if (lower.contains("gpl") && lower.contains("2")) return "GPL-2.0";
+        if (lower.contains("gpl") && lower.contains("3")) return "GPL-3.0";
+        if (lower.contains("mozilla") && lower.contains("2")) return "MPL-2.0";
+        if (lower.contains("common development") || lower.contains("cddl")) return "CDDL-1.0";
+        if (lower.contains("creative commons") && lower.contains("zero")) return "CC0-1.0";
+        if (lower.contains("unlicense") || lower.equals("the unlicense")) return "Unlicense";
+        if (lower.contains("public domain")) return "Public Domain";
+
+        // No match — return original name
+        return name;
+    }
+
+    private List<HelpOverlay.Section> buildHelp() {
+        return List.of(
+                new HelpOverlay.Section(
+                        "License & Security Audit",
+                        List.of(
+                                new HelpOverlay.Entry("", "Audits all resolved dependencies for license"),
+                                new HelpOverlay.Entry("", "compliance and known security vulnerabilities."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "Licenses view: shows each dependency's license"),
+                                new HelpOverlay.Entry("", "(from POM metadata). Review for compatibility"),
+                                new HelpOverlay.Entry("", "with your project's licensing requirements."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "Vulnerabilities view: queries for known CVEs"),
+                                new HelpOverlay.Entry("", "affecting your dependencies. Shows severity,"),
+                                new HelpOverlay.Entry("", "CVE identifier, and affected version range."))),
+                new HelpOverlay.Section(
+                        "License Colors",
+                        List.of(
+                                new HelpOverlay.Entry("default", "Permissive license (Apache, MIT, BSD)"),
+                                new HelpOverlay.Entry("yellow", "Weak copyleft (LGPL, MPL, EPL, CDDL)"),
+                                new HelpOverlay.Entry("red", "Strong copyleft (GPL, AGPL)"),
+                                new HelpOverlay.Entry("dim", "Unknown or not yet loaded"))),
+                new HelpOverlay.Section(
+                        "Vulnerability Colors",
+                        List.of(
+                                new HelpOverlay.Entry("red bold", "Critical severity"),
+                                new HelpOverlay.Entry("red", "High severity"),
+                                new HelpOverlay.Entry("yellow", "Medium severity"),
+                                new HelpOverlay.Entry("default", "Low severity"),
+                                new HelpOverlay.Entry("dim", "Unknown severity"))),
+                new HelpOverlay.Section(
+                        "Keys",
+                        List.of(
+                                new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("Tab", "Switch between Licenses and Vulnerabilities"),
+                                new HelpOverlay.Entry("h", "Toggle this help screen"),
+                                new HelpOverlay.Entry("q / Esc", "Quit"))));
     }
 
     private void renderInfoBar(Frame frame, Rect area) {
@@ -356,6 +992,8 @@ class AuditTui {
         spans.add(Span.raw(":Navigate  "));
         spans.add(Span.raw("Tab").bold());
         spans.add(Span.raw(":Licenses/Vulns  "));
+        spans.add(Span.raw("h").bold());
+        spans.add(Span.raw(":Help  "));
         spans.add(Span.raw("q").bold());
         spans.add(Span.raw(":Quit"));
 

--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -36,6 +36,11 @@ import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.maven.Coordinates;
+import eu.maveniverse.domtrip.maven.PomEditor;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -120,11 +125,16 @@ class AuditTui {
 
     private final List<AuditEntry> entries;
     private final String projectGav;
+    private final DependencyTreeModel treeModel;
+    private final String pomPath;
+    private final String originalPomContent;
+    private final PomEditor editor;
     private final TableState tableState = new TableState();
     private final ExecutorService httpPool = MojoHelper.newHttpPool();
     private final OsvClient osvClient = new OsvClient();
 
     private final HelpOverlay helpOverlay = new HelpOverlay();
+    private final DiffOverlay diffOverlay = new DiffOverlay();
     private final TableState vulnTableState = new TableState();
     private final TableState byLicenseTableState = new TableState();
 
@@ -133,6 +143,9 @@ class AuditTui {
     private int vulnsLoaded = 0;
     private int vulnCount = 0;
     private String status;
+    private boolean dirty;
+    private boolean pendingQuit;
+    private int lastContentHeight;
     private List<VulnRow> vulnRows = new ArrayList<>();
     private List<LicenseRow> byLicenseRows = new ArrayList<>();
 
@@ -141,9 +154,19 @@ class AuditTui {
 
     private TuiRunner runner;
 
-    AuditTui(List<AuditEntry> entries, String projectGav) {
+    AuditTui(List<AuditEntry> entries, String projectGav, DependencyTreeModel treeModel, String pomPath) {
         this.entries = entries;
         this.projectGav = projectGav;
+        this.treeModel = treeModel;
+        this.pomPath = pomPath;
+        String pom;
+        try {
+            pom = Files.readString(Path.of(pomPath));
+        } catch (Exception e) {
+            pom = "";
+        }
+        this.originalPomContent = pom;
+        this.editor = pom.isEmpty() ? null : new PomEditor(Document.of(pom));
         this.status = "Loading license and vulnerability data\u2026";
         if (!entries.isEmpty()) {
             tableState.select(0);
@@ -281,14 +304,46 @@ class AuditTui {
         if (helpOverlay.isActive()) {
             if (helpOverlay.handleKey(key)) return true;
             if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                requestQuit();
+                return true;
+            }
+            return false;
+        }
+
+        // Save prompt mode
+        if (pendingQuit) {
+            if (key.isCharIgnoreCase('y')) {
+                saveAndQuit();
+                return true;
+            }
+            if (key.isCharIgnoreCase('n')) {
                 runner.quit();
+                return true;
+            }
+            if (key.isKey(KeyCode.ESCAPE)) {
+                pendingQuit = false;
+                updateStatus();
+                return true;
+            }
+            return false;
+        }
+
+        // Diff overlay mode
+        if (diffOverlay.isActive()) {
+            if (key.isKey(KeyCode.ESCAPE)) {
+                diffOverlay.close();
+                return true;
+            }
+            if (diffOverlay.handleScrollKey(key, lastContentHeight)) return true;
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                requestQuit();
                 return true;
             }
             return false;
         }
 
         if (key.isCtrlC() || key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q')) {
-            runner.quit();
+            requestQuit();
             return true;
         }
 
@@ -352,12 +407,90 @@ class AuditTui {
             return true;
         }
 
+        if (key.isCharIgnoreCase('m')) {
+            addManagedDependency();
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('d')) {
+            toggleDiffView();
+            return true;
+        }
+
         if (key.isCharIgnoreCase('h')) {
             helpOverlay.open(buildHelp());
             return true;
         }
 
         return false;
+    }
+
+    private AuditEntry selectedEntry() {
+        return switch (view) {
+            case LICENSES -> {
+                int idx = tableState.selected() != null ? tableState.selected() : -1;
+                yield (idx >= 0 && idx < entries.size()) ? entries.get(idx) : null;
+            }
+            case VULNERABILITIES -> {
+                int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
+                yield (idx >= 0 && idx < vulnRows.size()) ? vulnRows.get(idx).entry : null;
+            }
+            case BY_LICENSE -> {
+                int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
+                yield (idx >= 0
+                                && idx < byLicenseRows.size()
+                                && !byLicenseRows.get(idx).isGroup())
+                        ? byLicenseRows.get(idx).entry
+                        : null;
+            }
+        };
+    }
+
+    private void addManagedDependency() {
+        AuditEntry entry = selectedEntry();
+        if (entry == null || editor == null) {
+            status = "No dependency selected";
+            return;
+        }
+        try {
+            var coords = Coordinates.of(entry.groupId, entry.artifactId, entry.version);
+            editor.dependencies().updateManagedDependency(true, coords);
+            dirty = true;
+            status = "Added " + entry.ga() + ":" + entry.version + " to dependencyManagement";
+        } catch (Exception e) {
+            status = "Failed: " + e.getMessage();
+        }
+    }
+
+    private void requestQuit() {
+        if (dirty) {
+            pendingQuit = true;
+            status = "Save changes to POM? (y/n/Esc)";
+        } else {
+            runner.quit();
+        }
+    }
+
+    private void saveAndQuit() {
+        try {
+            String currentOnDisk = Files.readString(Path.of(pomPath));
+            if (!currentOnDisk.equals(originalPomContent)) {
+                pendingQuit = false;
+                status = "POM modified externally \u2014 save aborted";
+                return;
+            }
+            Files.writeString(Path.of(pomPath), editor.toXml());
+            runner.quit();
+        } catch (Exception e) {
+            pendingQuit = false;
+            status = "Failed to save: " + e.getMessage();
+        }
+    }
+
+    private void toggleDiffView() {
+        if (editor == null) return;
+        long changes = diffOverlay.open(originalPomContent, editor.toXml());
+        status = changes == 0 ? "No changes to show" : changes + " line(s) changed";
     }
 
     // -- Rendering --
@@ -369,8 +502,11 @@ class AuditTui {
 
         renderHeader(frame, zones.get(0));
 
+        lastContentHeight = zones.get(1).height();
         if (helpOverlay.isActive()) {
             helpOverlay.render(frame, zones.get(1));
+        } else if (diffOverlay.isActive()) {
+            diffOverlay.render(frame, zones.get(1), " POM Changes ");
         } else {
             switch (view) {
                 case LICENSES -> renderLicenses(frame, zones.get(1));
@@ -391,6 +527,9 @@ class AuditTui {
 
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" " + projectGav).bold().cyan());
+        if (dirty) {
+            spans.add(Span.raw("  [modified]").fg(Color.YELLOW));
+        }
         spans.add(Span.raw("  "));
         spans.add(Span.raw("[" + (view == View.LICENSES ? "\u25B8 " : "  ") + "Licenses]")
                 .fg(view == View.LICENSES ? Color.YELLOW : Color.DARK_GRAY));
@@ -412,7 +551,7 @@ class AuditTui {
     private void renderLicenses(Frame frame, Rect area) {
         // Split into table + separator + detail pane
         var zones = Layout.vertical()
-                .constraints(Constraint.fill(), Constraint.length(1), Constraint.length(4))
+                .constraints(Constraint.fill(), Constraint.length(1), Constraint.length(5))
                 .split(area);
 
         Block block = Block.builder()
@@ -489,11 +628,42 @@ class AuditTui {
             licSpans.add(Span.raw("Loading\u2026").fg(Color.DARK_GRAY));
         }
 
+        List<Line> lines = new ArrayList<>();
+        lines.add(Line.from(spans));
+        lines.add(Line.from(licSpans));
+        Line pathLine = buildPathLine(entry);
+        if (pathLine != null) lines.add(pathLine);
+
         Paragraph detail = Paragraph.builder()
-                .text(dev.tamboui.text.Text.from(Line.from(spans), Line.from(licSpans)))
+                .text(dev.tamboui.text.Text.from(lines))
                 .block(block)
                 .build();
         frame.renderWidget(detail, area);
+    }
+
+    private Line buildPathLine(AuditEntry entry) {
+        if (treeModel == null) return null;
+        var node = treeModel.findByGA(entry.ga());
+        if (node == null) return null;
+        var path = treeModel.pathToRoot(node);
+        if (path.size() <= 1) return null; // root or direct dep — no path to show
+        List<Span> pathSpans = new ArrayList<>();
+        pathSpans.add(Span.raw("Path: ").fg(Color.DARK_GRAY));
+        for (int i = 0; i < path.size(); i++) {
+            if (i > 0) pathSpans.add(Span.raw(" \u2192 ").fg(Color.DARK_GRAY));
+            var n = path.get(i);
+            if (i == 0) {
+                pathSpans.add(Span.raw(n.artifactId).dim());
+            } else if (i == path.size() - 1) {
+                pathSpans.add(Span.raw(n.ga()).bold());
+            } else if (i == 1) {
+                // Direct dependency — highlight
+                pathSpans.add(Span.raw(n.ga()).cyan());
+            } else {
+                pathSpans.add(Span.raw(n.artifactId).dim());
+            }
+        }
+        return Line.from(pathSpans);
     }
 
     private TableState activeTableState() {
@@ -625,6 +795,8 @@ class AuditTui {
                 }
                 lines.add(Line.from(licSpans));
             }
+            Line pathLine = buildPathLine(row.entry);
+            if (pathLine != null) lines.add(pathLine);
         }
 
         Paragraph detail = Paragraph.builder()
@@ -735,6 +907,8 @@ class AuditTui {
             lines.add(Line.from(Span.raw("Published: ").fg(Color.DARK_GRAY), Span.raw(pub)));
         }
         lines.add(Line.from(Span.raw(vuln.summary)));
+        Line pathLine = buildPathLine(vr.entry);
+        if (pathLine != null) lines.add(pathLine);
 
         Paragraph detail = Paragraph.builder()
                 .text(dev.tamboui.text.Text.from(lines))
@@ -972,9 +1146,12 @@ class AuditTui {
                         "Keys",
                         List.of(
                                 new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
-                                new HelpOverlay.Entry("Tab", "Switch between Licenses and Vulnerabilities"),
+                                new HelpOverlay.Entry("\u2190 / \u2192", "Collapse / expand (By License view)"),
+                                new HelpOverlay.Entry("Tab", "Switch between Licenses / By License / Vulns"),
+                                new HelpOverlay.Entry("m", "Add selected dep to dependencyManagement"),
+                                new HelpOverlay.Entry("d", "Preview POM changes as a unified diff"),
                                 new HelpOverlay.Entry("h", "Toggle this help screen"),
-                                new HelpOverlay.Entry("q / Esc", "Quit"))));
+                                new HelpOverlay.Entry("q / Esc", "Quit (prompts to save if modified)"))));
     }
 
     private void renderInfoBar(Frame frame, Rect area) {
@@ -988,14 +1165,34 @@ class AuditTui {
 
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" "));
-        spans.add(Span.raw("\u2191\u2193").bold());
-        spans.add(Span.raw(":Navigate  "));
-        spans.add(Span.raw("Tab").bold());
-        spans.add(Span.raw(":Licenses/Vulns  "));
-        spans.add(Span.raw("h").bold());
-        spans.add(Span.raw(":Help  "));
-        spans.add(Span.raw("q").bold());
-        spans.add(Span.raw(":Quit"));
+        if (pendingQuit) {
+            spans.add(Span.raw("y").bold());
+            spans.add(Span.raw(":Save and quit  "));
+            spans.add(Span.raw("n").bold());
+            spans.add(Span.raw(":Discard and quit  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Cancel"));
+        } else if (diffOverlay.isActive()) {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Scroll  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Close  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        } else {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Navigate  "));
+            spans.add(Span.raw("Tab").bold());
+            spans.add(Span.raw(":Licenses/Vulns  "));
+            spans.add(Span.raw("m").bold());
+            spans.add(Span.raw(":Manage dep  "));
+            spans.add(Span.raw("d").bold());
+            spans.add(Span.raw(":Diff  "));
+            spans.add(Span.raw("h").bold());
+            spans.add(Span.raw(":Help  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        }
 
         frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(2));
     }

--- a/src/main/java/eu/maveniverse/maven/pilot/ConflictsMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ConflictsMojo.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -45,11 +46,14 @@ import org.eclipse.aether.graph.DependencyNode;
  *
  * @since 0.1.0
  */
-@Mojo(name = "conflicts", requiresProject = true, threadSafe = true)
+@Mojo(name = "conflicts", requiresProject = true, aggregator = true, threadSafe = true)
 public class ConflictsMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
 
     @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
     private RepositorySystemSession repoSession;
@@ -57,40 +61,62 @@ public class ConflictsMojo extends AbstractMojo {
     @Inject
     private RepositorySystem repoSystem;
 
-    /**
-     * Analyze the project's dependency graph for version conflicts and launch an interactive TUI to review and resolve them.
-     *
-     * <p>The goal collects dependency information, groups occurrences by groupId:artifactId (GA), detects GAs with
-     * multiple occurrences or where a requested version differs from the resolved version, builds conflict groups,
-     * and starts the ConflictsTui with the project's POM path and GAV.</p>
-     *
-     * @throws MojoExecutionException if dependency collection or conflict analysis fails
-     */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
-            CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(project));
-
-            // Detect conflicts: same GA with different versions requested
-            Map<String, List<ConflictsTui.ConflictEntry>> conflictMap = new HashMap<>();
-            collectConflicts(result.getRoot(), conflictMap, new ArrayList<>());
-
-            List<ConflictsTui.ConflictGroup> conflicts = conflictMap.entrySet().stream()
-                    .filter(e -> e.getValue().size() > 1
-                            || e.getValue().stream()
-                                    .anyMatch(c -> c.requestedVersion != null
-                                            && !c.requestedVersion.equals(c.resolvedVersion)))
-                    .map(e -> new ConflictsTui.ConflictGroup(e.getKey(), e.getValue()))
-                    .collect(Collectors.toList());
-
-            String pomPath = project.getFile().getAbsolutePath();
-            String gav = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
-
-            ConflictsTui tui = new ConflictsTui(conflicts, pomPath, gav);
-            tui.run();
+            List<MavenProject> projects = session.getProjects();
+            if (projects.size() > 1) {
+                executeReactor(projects);
+            } else {
+                executeSingleProject(project);
+            }
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to analyze conflicts: " + e.getMessage(), e);
         }
+    }
+
+    private void executeSingleProject(MavenProject proj) throws Exception {
+        List<ConflictsTui.ConflictGroup> conflicts = collectConflictsForProject(proj);
+        String pomPath = proj.getFile().getAbsolutePath();
+        String gav = proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion();
+        ConflictsTui tui = new ConflictsTui(conflicts, pomPath, gav);
+        tui.run();
+    }
+
+    private void executeReactor(List<MavenProject> projects) throws Exception {
+        // Aggregate conflicts across all modules
+        Map<String, List<ConflictsTui.ConflictEntry>> mergedMap = new HashMap<>();
+        for (MavenProject proj : projects) {
+            CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
+            collectConflicts(result.getRoot(), mergedMap, new ArrayList<>(), proj.getArtifactId());
+        }
+
+        List<ConflictsTui.ConflictGroup> conflicts = mergedMap.entrySet().stream()
+                .filter(e -> e.getValue().size() > 1
+                        || e.getValue().stream()
+                                .anyMatch(c ->
+                                        c.requestedVersion != null && !c.requestedVersion.equals(c.resolvedVersion)))
+                .map(e -> new ConflictsTui.ConflictGroup(e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
+
+        MavenProject root = projects.get(0);
+        String pomPath = root.getFile().getAbsolutePath();
+        String gav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
+        ConflictsTui tui = new ConflictsTui(conflicts, pomPath, gav + " (reactor: " + projects.size() + " modules)");
+        tui.run();
+    }
+
+    private List<ConflictsTui.ConflictGroup> collectConflictsForProject(MavenProject proj) throws Exception {
+        CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
+        Map<String, List<ConflictsTui.ConflictEntry>> conflictMap = new HashMap<>();
+        collectConflicts(result.getRoot(), conflictMap, new ArrayList<>());
+        return conflictMap.entrySet().stream()
+                .filter(e -> e.getValue().size() > 1
+                        || e.getValue().stream()
+                                .anyMatch(c ->
+                                        c.requestedVersion != null && !c.requestedVersion.equals(c.resolvedVersion)))
+                .map(e -> new ConflictsTui.ConflictGroup(e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
     }
 
     /**
@@ -135,5 +161,16 @@ public class ConflictsMojo extends AbstractMojo {
             conflicts.computeIfAbsent(ga, k -> new ArrayList<>()).add(entry);
             collectConflicts(child, conflicts, currentPath);
         }
+    }
+
+    private void collectConflicts(
+            DependencyNode node,
+            Map<String, List<ConflictsTui.ConflictEntry>> conflicts,
+            List<String> path,
+            String moduleName) {
+        List<String> modulePath = new ArrayList<>();
+        modulePath.add("[" + moduleName + "]");
+        modulePath.addAll(path);
+        collectConflicts(node, conflicts, modulePath);
     }
 }

--- a/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -145,8 +145,10 @@ class ConflictsTui {
         String pom;
         try {
             pom = Files.readString(Path.of(pomPath));
-        } catch (Exception e) {
+        } catch (java.nio.file.NoSuchFileException e) {
             pom = "<project/>";
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot read POM: " + pomPath, e);
         }
         this.originalPomContent = pom;
         this.editor = new PomEditor(Document.of(pom));
@@ -221,6 +223,10 @@ class ConflictsTui {
             }
             if (key.isKey(KeyCode.PAGE_DOWN)) {
                 diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                requestQuit();
                 return true;
             }
             return false;

--- a/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -144,8 +144,6 @@ class ConflictsTui {
         String pom;
         try {
             pom = Files.readString(Path.of(pomPath));
-        } catch (java.nio.file.NoSuchFileException e) {
-            pom = "<project/>";
         } catch (Exception e) {
             throw new IllegalStateException("Cannot read POM: " + pomPath, e);
         }
@@ -283,6 +281,12 @@ class ConflictsTui {
 
     private void saveAndQuit() {
         try {
+            String currentOnDisk = Files.readString(Path.of(pomPath));
+            if (!currentOnDisk.equals(originalPomContent)) {
+                pendingQuit = false;
+                status = "POM modified externally \u2014 save aborted";
+                return;
+            }
             Files.writeString(Path.of(pomPath), editor.toXml());
             runner.quit();
         } catch (Exception e) {

--- a/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -111,8 +111,7 @@ class ConflictsTui {
     private final PomEditor editor;
     private boolean dirty;
     private boolean pendingQuit;
-    private List<UnifiedDiff.DiffLine> diffLines;
-    private int diffScroll;
+    private final DiffOverlay diffOverlay = new DiffOverlay();
     private int lastContentHeight;
 
     private TuiRunner runner;
@@ -203,28 +202,12 @@ class ConflictsTui {
         }
 
         // Diff overlay mode — Esc closes overlay first
-        if (diffLines != null) {
+        if (diffOverlay.isActive()) {
             if (key.isKey(KeyCode.ESCAPE)) {
-                diffLines = null;
-                diffScroll = 0;
+                diffOverlay.close();
                 return true;
             }
-            if (key.isUp()) {
-                if (diffScroll > 0) diffScroll--;
-                return true;
-            }
-            if (key.isDown()) {
-                diffScroll = Math.min(diffScroll + 1, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
-                return true;
-            }
-            if (key.isKey(KeyCode.PAGE_UP)) {
-                diffScroll = Math.max(0, diffScroll - 10);
-                return true;
-            }
-            if (key.isKey(KeyCode.PAGE_DOWN)) {
-                diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
-                return true;
-            }
+            if (diffOverlay.handleScrollKey(key, lastContentHeight)) return true;
             if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
                 requestQuit();
                 return true;
@@ -309,16 +292,8 @@ class ConflictsTui {
     }
 
     private void toggleDiffView() {
-        String modifiedPom = editor.toXml();
-        var fullDiff = UnifiedDiff.compute(originalPomContent, modifiedPom);
-        long changes = UnifiedDiff.changeCount(fullDiff);
-        if (changes == 0) {
-            status = "No changes to show";
-            return;
-        }
-        diffLines = UnifiedDiff.filterContext(fullDiff, 3);
-        diffScroll = 0;
-        status = changes + " line(s) changed";
+        long changes = diffOverlay.open(originalPomContent, editor.toXml());
+        status = changes == 0 ? "No changes to show" : changes + " line(s) changed";
     }
 
     // -- Rendering --
@@ -328,15 +303,15 @@ class ConflictsTui {
                 .constraints(
                         Constraint.length(3),
                         Constraint.fill(),
-                        showDetails && diffLines == null ? Constraint.percentage(30) : Constraint.length(0),
+                        showDetails && !diffOverlay.isActive() ? Constraint.percentage(30) : Constraint.length(0),
                         Constraint.length(3))
                 .split(frame.area());
 
         renderHeader(frame, zones.get(0));
         lastContentHeight = zones.get(1).height();
 
-        if (diffLines != null) {
-            UnifiedDiff.render(frame, zones.get(1), diffLines, diffScroll, " POM Changes ");
+        if (diffOverlay.isActive()) {
+            diffOverlay.render(frame, zones.get(1), " POM Changes ");
         } else {
             renderConflicts(frame, zones.get(1));
             if (showDetails) {
@@ -490,7 +465,7 @@ class ConflictsTui {
             spans.add(Span.raw(":Discard and quit  "));
             spans.add(Span.raw("Esc").bold());
             spans.add(Span.raw(":Cancel"));
-        } else if (diffLines != null) {
+        } else if (diffOverlay.isActive()) {
             spans.add(Span.raw("\u2191\u2193").bold());
             spans.add(Span.raw(":Scroll  "));
             spans.add(Span.raw("Esc").bold());

--- a/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -107,6 +107,14 @@ class ConflictsTui {
     private boolean showDetails = false;
     private String status;
 
+    private final String originalPomContent;
+    private final PomEditor editor;
+    private boolean dirty;
+    private boolean pendingQuit;
+    private List<UnifiedDiff.DiffLine> diffLines;
+    private int diffScroll;
+    private int lastContentHeight;
+
     private TuiRunner runner;
 
     /**
@@ -134,6 +142,14 @@ class ConflictsTui {
         this.pomPath = pomPath;
         this.projectGav = projectGav;
         this.status = conflicts.size() + " dependency group(s) with version variance";
+        String pom;
+        try {
+            pom = Files.readString(Path.of(pomPath));
+        } catch (Exception e) {
+            pom = "<project/>";
+        }
+        this.originalPomContent = pom;
+        this.editor = new PomEditor(Document.of(pom));
         if (!conflicts.isEmpty()) {
             tableState.select(0);
         }
@@ -166,8 +182,52 @@ class ConflictsTui {
             return true;
         }
 
-        if (key.isCtrlC() || key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q')) {
-            runner.quit();
+        // Save prompt mode
+        if (pendingQuit) {
+            if (key.isCharIgnoreCase('y')) {
+                saveAndQuit();
+                return true;
+            }
+            if (key.isCharIgnoreCase('n')) {
+                runner.quit();
+                return true;
+            }
+            if (key.isKey(KeyCode.ESCAPE)) {
+                pendingQuit = false;
+                status = "Quit cancelled";
+                return true;
+            }
+            return false;
+        }
+
+        // Diff overlay mode — Esc closes overlay first
+        if (diffLines != null) {
+            if (key.isKey(KeyCode.ESCAPE)) {
+                diffLines = null;
+                diffScroll = 0;
+                return true;
+            }
+            if (key.isUp()) {
+                if (diffScroll > 0) diffScroll--;
+                return true;
+            }
+            if (key.isDown()) {
+                diffScroll = Math.min(diffScroll + 1, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            if (key.isKey(KeyCode.PAGE_UP)) {
+                diffScroll = Math.max(0, diffScroll - 10);
+                return true;
+            }
+            if (key.isKey(KeyCode.PAGE_DOWN)) {
+                diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            return false;
+        }
+
+        if (key.isCtrlC() || key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
+            requestQuit();
             return true;
         }
 
@@ -190,6 +250,11 @@ class ConflictsTui {
             return true;
         }
 
+        if (key.isCharIgnoreCase('d')) {
+            toggleDiffView();
+            return true;
+        }
+
         return false;
     }
 
@@ -207,19 +272,47 @@ class ConflictsTui {
         var group = conflicts.get(sel);
 
         try {
-            String pomContent = Files.readString(Path.of(pomPath));
-            PomEditor editor = new PomEditor(Document.of(pomContent));
-
-            // Pin the resolved version in dependencyManagement
             String resolvedVersion = group.resolvedVersion();
             var coords = Coordinates.of(group.entries.get(0).groupId, group.entries.get(0).artifactId, resolvedVersion);
             editor.dependencies().updateManagedDependency(true, coords);
 
-            Files.writeString(Path.of(pomPath), editor.toXml());
-            status = "Pinned " + group.ga + " to " + resolvedVersion + " in dependencyManagement";
+            dirty = true;
+            status = "Pinned " + group.ga + " to " + resolvedVersion + " \u2014 save on exit";
         } catch (Exception e) {
             status = "Failed to pin version: " + e.getMessage();
         }
+    }
+
+    private void requestQuit() {
+        if (dirty) {
+            pendingQuit = true;
+            status = "Save changes to POM?";
+        } else {
+            runner.quit();
+        }
+    }
+
+    private void saveAndQuit() {
+        try {
+            Files.writeString(Path.of(pomPath), editor.toXml());
+            runner.quit();
+        } catch (Exception e) {
+            pendingQuit = false;
+            status = "Failed to save: " + e.getMessage();
+        }
+    }
+
+    private void toggleDiffView() {
+        String modifiedPom = editor.toXml();
+        var fullDiff = UnifiedDiff.compute(originalPomContent, modifiedPom);
+        long changes = UnifiedDiff.changeCount(fullDiff);
+        if (changes == 0) {
+            status = "No changes to show";
+            return;
+        }
+        diffLines = UnifiedDiff.filterContext(fullDiff, 3);
+        diffScroll = 0;
+        status = changes + " line(s) changed";
     }
 
     // -- Rendering --
@@ -229,15 +322,20 @@ class ConflictsTui {
                 .constraints(
                         Constraint.length(3),
                         Constraint.fill(),
-                        showDetails ? Constraint.percentage(30) : Constraint.length(0),
+                        showDetails && diffLines == null ? Constraint.percentage(30) : Constraint.length(0),
                         Constraint.length(3))
                 .split(frame.area());
 
         renderHeader(frame, zones.get(0));
-        renderConflicts(frame, zones.get(1));
+        lastContentHeight = zones.get(1).height();
 
-        if (showDetails) {
-            renderDetails(frame, zones.get(2));
+        if (diffLines != null) {
+            UnifiedDiff.render(frame, zones.get(1), diffLines, diffScroll, " POM Changes ");
+        } else {
+            renderConflicts(frame, zones.get(1));
+            if (showDetails) {
+                renderDetails(frame, zones.get(2));
+            }
         }
 
         renderInfoBar(frame, zones.get(3));
@@ -252,6 +350,9 @@ class ConflictsTui {
 
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" " + projectGav).bold().cyan());
+        if (dirty) {
+            spans.add(Span.raw("  [modified]").fg(Color.YELLOW));
+        }
 
         Paragraph header = Paragraph.builder()
                 .text(dev.tamboui.text.Text.from(Line.from(spans)))
@@ -371,19 +472,37 @@ class ConflictsTui {
                 .split(area);
 
         List<Span> statusSpans = new ArrayList<>();
-        statusSpans.add(Span.raw(" " + status).fg(Color.GREEN));
+        statusSpans.add(Span.raw(" " + status).fg(pendingQuit ? Color.YELLOW : Color.GREEN));
         frame.renderWidget(Paragraph.from(Line.from(statusSpans)), rows.get(1));
 
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" "));
-        spans.add(Span.raw("\u2191\u2193").bold());
-        spans.add(Span.raw(":Navigate  "));
-        spans.add(Span.raw("Enter").bold());
-        spans.add(Span.raw(":Details  "));
-        spans.add(Span.raw("p").bold());
-        spans.add(Span.raw(":Pin version  "));
-        spans.add(Span.raw("q").bold());
-        spans.add(Span.raw(":Quit"));
+        if (pendingQuit) {
+            spans.add(Span.raw("y").bold());
+            spans.add(Span.raw(":Save and quit  "));
+            spans.add(Span.raw("n").bold());
+            spans.add(Span.raw(":Discard and quit  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Cancel"));
+        } else if (diffLines != null) {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Scroll  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Close  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        } else {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Navigate  "));
+            spans.add(Span.raw("Enter").bold());
+            spans.add(Span.raw(":Details  "));
+            spans.add(Span.raw("p").bold());
+            spans.add(Span.raw(":Pin version  "));
+            spans.add(Span.raw("d").bold());
+            spans.add(Span.raw(":Diff  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        }
 
         frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(2));
     }

--- a/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -104,7 +104,7 @@ class ConflictsTui {
     private final String pomPath;
     private final String projectGav;
     private final TableState tableState = new TableState();
-    private boolean showDetails = false;
+    private boolean showDetails = true;
     private String status;
 
     private final String originalPomContent;
@@ -112,6 +112,7 @@ class ConflictsTui {
     private boolean dirty;
     private boolean pendingQuit;
     private final DiffOverlay diffOverlay = new DiffOverlay();
+    private final HelpOverlay helpOverlay = new HelpOverlay();
     private int lastContentHeight;
 
     private TuiRunner runner;
@@ -213,6 +214,16 @@ class ConflictsTui {
             return false;
         }
 
+        // Help overlay mode
+        if (helpOverlay.isActive()) {
+            if (helpOverlay.handleKey(key)) return true;
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                requestQuit();
+                return true;
+            }
+            return false;
+        }
+
         if (key.isCtrlC() || key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
             requestQuit();
             return true;
@@ -239,6 +250,11 @@ class ConflictsTui {
 
         if (key.isCharIgnoreCase('d')) {
             toggleDiffView();
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('h')) {
+            helpOverlay.open(buildHelp());
             return true;
         }
 
@@ -300,30 +316,75 @@ class ConflictsTui {
         status = changes == 0 ? "No changes to show" : changes + " line(s) changed";
     }
 
+    private List<HelpOverlay.Section> buildHelp() {
+        return List.of(
+                new HelpOverlay.Section(
+                        "Conflict Resolution",
+                        List.of(
+                                new HelpOverlay.Entry("", "When multiple dependencies request different versions"),
+                                new HelpOverlay.Entry("", "of the same artifact, Maven picks one (the 'resolved'"),
+                                new HelpOverlay.Entry("", "version). This screen shows all such groups."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "The details pane shows the dependency path for each"),
+                                new HelpOverlay.Entry("", "request, so you can see which transitive chain"),
+                                new HelpOverlay.Entry("", "asked for which version."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "Use 'p' to pin a group's resolved version into"),
+                                new HelpOverlay.Entry("", "<dependencyManagement>, ensuring all modules use"),
+                                new HelpOverlay.Entry("", "that version explicitly."))),
+                new HelpOverlay.Section(
+                        "Table Columns",
+                        List.of(
+                                new HelpOverlay.Entry(
+                                        "status", "\u26A0 = conflict (versions differ), \u2713 = consistent"),
+                                new HelpOverlay.Entry("dependency", "groupId:artifactId"),
+                                new HelpOverlay.Entry("resolved", "The version Maven selected"),
+                                new HelpOverlay.Entry("versions", "All distinct versions requested"))),
+                new HelpOverlay.Section(
+                        "Colors",
+                        List.of(
+                                new HelpOverlay.Entry("yellow", "Actual conflict \u2014 different versions requested"),
+                                new HelpOverlay.Entry("default", "No conflict \u2014 all requests agree on version"),
+                                new HelpOverlay.Entry("dim", "Dependency path in details pane"))),
+                new HelpOverlay.Section(
+                        "Keys",
+                        List.of(
+                                new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("Enter / Space", "Toggle dependency path details"),
+                                new HelpOverlay.Entry("p", "Pin resolved version in dependencyManagement"),
+                                new HelpOverlay.Entry("d", "Preview POM changes as a unified diff"),
+                                new HelpOverlay.Entry("h", "Toggle this help screen"),
+                                new HelpOverlay.Entry("q / Esc", "Quit (prompts to save if modified)"))));
+    }
+
     // -- Rendering --
 
     void render(Frame frame) {
+        boolean detailsVisible = showDetails && !diffOverlay.isActive() && !helpOverlay.isActive();
         var zones = Layout.vertical()
                 .constraints(
                         Constraint.length(3),
                         Constraint.fill(),
-                        showDetails && !diffOverlay.isActive() ? Constraint.percentage(30) : Constraint.length(0),
+                        detailsVisible ? Constraint.length(1) : Constraint.length(0),
+                        detailsVisible ? Constraint.percentage(30) : Constraint.length(0),
                         Constraint.length(3))
                 .split(frame.area());
 
         renderHeader(frame, zones.get(0));
         lastContentHeight = zones.get(1).height();
 
-        if (diffOverlay.isActive()) {
+        if (helpOverlay.isActive()) {
+            helpOverlay.render(frame, zones.get(1));
+        } else if (diffOverlay.isActive()) {
             diffOverlay.render(frame, zones.get(1), " POM Changes ");
         } else {
             renderConflicts(frame, zones.get(1));
-            if (showDetails) {
-                renderDetails(frame, zones.get(2));
+            if (detailsVisible) {
+                renderDetails(frame, zones.get(3));
             }
         }
 
-        renderInfoBar(frame, zones.get(3));
+        renderInfoBar(frame, zones.get(4));
     }
 
     private void renderHeader(Frame frame, Rect area) {
@@ -386,9 +447,7 @@ class ConflictsTui {
                     .distinct()
                     .collect(Collectors.joining(", "));
 
-            Style style = group.hasConflict()
-                    ? Style.create().fg(Color.YELLOW)
-                    : Style.create().fg(Color.GREEN);
+            Style style = group.hasConflict() ? Style.create().fg(Color.YELLOW) : Style.create();
 
             rows.add(Row.from(icon, group.ga, group.resolvedVersion(), versions).style(style));
         }
@@ -485,6 +544,8 @@ class ConflictsTui {
             spans.add(Span.raw(":Pin version  "));
             spans.add(Span.raw("d").bold());
             spans.add(Span.raw(":Diff  "));
+            spans.add(Span.raw("h").bold());
+            spans.add(Span.raw(":Help  "));
             spans.add(Span.raw("q").bold());
             spans.add(Span.raw(":Quit"));
         }

--- a/src/main/java/eu/maveniverse/maven/pilot/DependenciesMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependenciesMojo.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.inject.Inject;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -59,11 +60,14 @@ import org.eclipse.aether.resolution.DependencyResult;
  *
  * @since 0.1.0
  */
-@Mojo(name = "dependencies", requiresProject = true, threadSafe = true)
+@Mojo(name = "dependencies", requiresProject = true, aggregator = true, threadSafe = true)
 public class DependenciesMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
 
     @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
     private RepositorySystemSession repoSession;
@@ -75,83 +79,97 @@ public class DependenciesMojo extends AbstractMojo {
         this.repoSystem = repoSystem;
     }
 
-    /**
-     * Analyze the project's declared dependencies against the full transitive dependency tree and launch the interactive TUI.
-     *
-     * @throws MojoExecutionException if dependency collection, traversal, or the TUI run fails
-     */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
-            // Collect direct declared dependencies
-            Set<String> declaredGAs = new HashSet<>();
-            List<DependenciesTui.DepEntry> declared = new ArrayList<>();
-            for (Dependency dep : project.getDependencies()) {
-                DependenciesTui.addDeclaredEntry(
-                        declaredGAs,
-                        declared,
-                        dep.getGroupId(),
-                        dep.getArtifactId(),
-                        dep.getClassifier(),
-                        dep.getVersion(),
-                        dep.getScope());
-            }
-
-            // Resolve full transitive tree and artifact files
-            DependencyRequest depRequest = new DependencyRequest(MojoHelper.buildCollectRequest(project), null);
-            DependencyResult depResult = repoSystem.resolveDependencies(repoSession, depRequest);
-
-            // Find transitive (undeclared) dependencies
-            Set<String> transitiveGAs = new HashSet<>();
-            List<DependenciesTui.DepEntry> transitive = new ArrayList<>();
-            DependenciesTui.collectTransitive(depResult.getRoot(), declaredGAs, transitiveGAs, transitive);
-
-            // Build GA-to-JAR map from resolved artifacts
-            Map<String, File> gaToJar = new HashMap<>();
-            for (ArtifactResult ar : depResult.getArtifactResults()) {
-                var art = ar.getArtifact();
-                if (art != null
-                        && art.getFile() != null
-                        && art.getFile().getName().endsWith(".jar")) {
-                    gaToJar.put(art.getGroupId() + ":" + art.getArtifactId(), art.getFile());
-                }
-            }
-
-            // Bytecode usage analysis
-            Path classesDir = Path.of(project.getBuild().getOutputDirectory());
-            Path testClassesDir = Path.of(project.getBuild().getTestOutputDirectory());
-            boolean bytecodeAnalyzed = false;
-
-            if (Files.isDirectory(classesDir)) {
-                bytecodeAnalyzed = true;
-
-                Set<String> mainRefs = ClassFileScanner.scanDirectory(classesDir);
-                Set<String> testRefs =
-                        Files.isDirectory(testClassesDir) ? ClassFileScanner.scanDirectory(testClassesDir) : Set.of();
-
-                Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
-                DependencyUsageAnalyzer.AnalysisResult usage =
-                        DependencyUsageAnalyzer.analyze(mainRefs, testRefs, classIndex, gaToJar, declared, transitive);
-
-                for (var dep : declared) {
-                    dep.usageStatus = usage.declaredUsage()
-                            .getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
-                }
-                for (var dep : transitive) {
-                    dep.usageStatus = usage.transitiveUsage()
-                            .getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
-                }
+            List<MavenProject> projects = session.getProjects();
+            if (projects.size() > 1) {
+                executeReactor(projects);
             } else {
-                getLog().warn("target/classes not found — skipping bytecode analysis. Run 'mvn compile' first.");
+                executeForProject(project);
             }
-
-            String pomPath = project.getFile().getAbsolutePath();
-            String gav = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
-
-            DependenciesTui tui = new DependenciesTui(declared, transitive, pomPath, gav, bytecodeAnalyzed);
-            tui.run();
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to analyze dependencies: " + e.getMessage(), e);
         }
+    }
+
+    private void executeReactor(List<MavenProject> projects) throws Exception {
+        ReactorModel reactorModel = ReactorModel.build(projects);
+        MavenProject root = projects.get(0);
+        String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
+
+        while (true) {
+            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "dependencies").pick();
+            if (selected == null) break;
+            executeForProject(selected);
+        }
+    }
+
+    private void executeForProject(MavenProject proj) throws Exception {
+        // Collect direct declared dependencies
+        Set<String> declaredGAs = new HashSet<>();
+        List<DependenciesTui.DepEntry> declared = new ArrayList<>();
+        for (Dependency dep : proj.getDependencies()) {
+            DependenciesTui.addDeclaredEntry(
+                    declaredGAs,
+                    declared,
+                    dep.getGroupId(),
+                    dep.getArtifactId(),
+                    dep.getClassifier(),
+                    dep.getVersion(),
+                    dep.getScope());
+        }
+
+        // Resolve full transitive tree and artifact files
+        DependencyRequest depRequest = new DependencyRequest(MojoHelper.buildCollectRequest(proj), null);
+        DependencyResult depResult = repoSystem.resolveDependencies(repoSession, depRequest);
+
+        // Find transitive (undeclared) dependencies
+        Set<String> transitiveGAs = new HashSet<>();
+        List<DependenciesTui.DepEntry> transitive = new ArrayList<>();
+        DependenciesTui.collectTransitive(depResult.getRoot(), declaredGAs, transitiveGAs, transitive);
+
+        // Build GA-to-JAR map from resolved artifacts
+        Map<String, File> gaToJar = new HashMap<>();
+        for (ArtifactResult ar : depResult.getArtifactResults()) {
+            var art = ar.getArtifact();
+            if (art != null && art.getFile() != null && art.getFile().getName().endsWith(".jar")) {
+                gaToJar.put(art.getGroupId() + ":" + art.getArtifactId(), art.getFile());
+            }
+        }
+
+        // Bytecode usage analysis
+        Path classesDir = Path.of(proj.getBuild().getOutputDirectory());
+        Path testClassesDir = Path.of(proj.getBuild().getTestOutputDirectory());
+        boolean bytecodeAnalyzed = false;
+
+        if (Files.isDirectory(classesDir)) {
+            bytecodeAnalyzed = true;
+
+            Set<String> mainRefs = ClassFileScanner.scanDirectory(classesDir);
+            Set<String> testRefs =
+                    Files.isDirectory(testClassesDir) ? ClassFileScanner.scanDirectory(testClassesDir) : Set.of();
+
+            Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
+            DependencyUsageAnalyzer.AnalysisResult usage =
+                    DependencyUsageAnalyzer.analyze(mainRefs, testRefs, classIndex, gaToJar, declared, transitive);
+
+            for (var dep : declared) {
+                dep.usageStatus =
+                        usage.declaredUsage().getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
+            }
+            for (var dep : transitive) {
+                dep.usageStatus = usage.transitiveUsage()
+                        .getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
+            }
+        } else {
+            getLog().warn("target/classes not found — skipping bytecode analysis. Run 'mvn compile' first.");
+        }
+
+        String pomPath = proj.getFile().getAbsolutePath();
+        String gav = proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion();
+
+        DependenciesTui tui = new DependenciesTui(declared, transitive, pomPath, gav, bytecodeAnalyzed);
+        tui.run();
     }
 }

--- a/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -199,6 +199,19 @@ class DependenciesTui {
 
     private View view = View.DECLARED;
     private String status;
+    private final String originalPomContent;
+    private final PomEditor editor;
+    private boolean dirty;
+    private boolean pendingQuit;
+    private List<UnifiedDiff.DiffLine> diffLines;
+    private int diffScroll;
+    private int lastContentHeight;
+    private TuiRunner runner;
+
+    /** Returns the current in-memory POM content (package-private for testing). */
+    String currentPomContent() {
+        return editor.toXml();
+    }
 
     /**
      * Get the currently selected table row index.
@@ -237,6 +250,14 @@ class DependenciesTui {
         this.pomPath = pomPath;
         this.projectGav = projectGav;
         this.bytecodeAnalyzed = bytecodeAnalyzed;
+        String pom;
+        try {
+            pom = Files.readString(Path.of(pomPath));
+        } catch (Exception e) {
+            pom = "<project/>";
+        }
+        this.originalPomContent = pom;
+        this.editor = new PomEditor(Document.of(pom));
         updateStatus();
         if (!declared.isEmpty()) {
             tableState.select(0);
@@ -265,6 +286,7 @@ class DependenciesTui {
                 .tickRate(Duration.ofMillis(100))
                 .build();
         try {
+            runner = configured.runner();
             configured.run();
         } finally {
             configured.close();
@@ -276,8 +298,52 @@ class DependenciesTui {
             return true;
         }
 
-        if (key.isCtrlC() || key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q')) {
-            runner.quit();
+        // Save prompt mode
+        if (pendingQuit) {
+            if (key.isCharIgnoreCase('y')) {
+                saveAndQuit();
+                return true;
+            }
+            if (key.isCharIgnoreCase('n')) {
+                runner.quit();
+                return true;
+            }
+            if (key.isKey(KeyCode.ESCAPE)) {
+                pendingQuit = false;
+                status = "Quit cancelled";
+                return true;
+            }
+            return false;
+        }
+
+        // Diff overlay mode — Esc closes overlay first
+        if (diffLines != null) {
+            if (key.isKey(KeyCode.ESCAPE)) {
+                diffLines = null;
+                diffScroll = 0;
+                return true;
+            }
+            if (key.isUp()) {
+                if (diffScroll > 0) diffScroll--;
+                return true;
+            }
+            if (key.isDown()) {
+                diffScroll = Math.min(diffScroll + 1, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            if (key.isKey(KeyCode.PAGE_UP)) {
+                diffScroll = Math.max(0, diffScroll - 10);
+                return true;
+            }
+            if (key.isKey(KeyCode.PAGE_DOWN)) {
+                diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            return false;
+        }
+
+        if (key.isCtrlC() || key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
+            requestQuit();
             return true;
         }
 
@@ -301,7 +367,7 @@ class DependenciesTui {
             return true;
         }
 
-        if (key.isCharIgnoreCase('d')) {
+        if (key.isCharIgnoreCase('x')) {
             removeDeclared();
             return true;
         }
@@ -313,6 +379,11 @@ class DependenciesTui {
 
         if (key.isCharIgnoreCase('s')) {
             changeScope();
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('d')) {
+            toggleDiffView();
             return true;
         }
 
@@ -351,10 +422,8 @@ class DependenciesTui {
         var dep = declared.get(sel);
 
         try {
-            String pomContent = Files.readString(Path.of(pomPath));
-            PomEditor editor = new PomEditor(Document.of(pomContent));
             editor.dependencies().deleteDependency(Coordinates.of(dep.groupId, dep.artifactId, dep.version));
-            Files.writeString(Path.of(pomPath), editor.toXml());
+            dirty = true;
             declared.remove(sel);
             updateStatus();
             if (sel >= declared.size() && !declared.isEmpty()) {
@@ -378,10 +447,22 @@ class DependenciesTui {
         var dep = transitive.get(sel);
 
         try {
-            String pomContent = Files.readString(Path.of(pomPath));
-            String updated = addDependencyAligned(
-                    pomContent, dep.groupId, dep.artifactId, dep.version, dep.classifier, dep.scope);
-            Files.writeString(Path.of(pomPath), updated);
+            Coordinates coords = (dep.hasClassifier())
+                    ? Coordinates.of(dep.groupId, dep.artifactId, dep.version, dep.classifier, "jar")
+                    : Coordinates.of(dep.groupId, dep.artifactId, dep.version);
+            if (!COMPILE_SCOPE.equals(dep.scope)) {
+                AlignOptions detected = editor.dependencies().detectConventions();
+                AlignOptions options = AlignOptions.builder()
+                        .versionStyle(detected.versionStyle())
+                        .versionSource(detected.versionSource())
+                        .namingConvention(detected.namingConvention())
+                        .scope(dep.scope)
+                        .build();
+                editor.dependencies().addAligned(coords, options);
+            } else {
+                editor.dependencies().addAligned(coords);
+            }
+            dirty = true;
 
             // Move from transitive to declared
             transitive.remove(sel);
@@ -430,9 +511,7 @@ class DependenciesTui {
         var dep = declared.get(sel);
 
         try {
-            String pomContent = Files.readString(Path.of(pomPath));
-            Document doc = Document.of(pomContent);
-
+            Document doc = editor.document();
             List<String> scopes = getScopesForModel(doc);
             if (!scopes.contains(dep.scope)) {
                 // Unknown scope (e.g. "system") — include it in the cycling list
@@ -441,7 +520,6 @@ class DependenciesTui {
             }
             int current = scopes.indexOf(dep.scope);
             String newScope = scopes.get((current + 1) % scopes.size());
-            PomEditor editor = new PomEditor(doc);
             Coordinates coords = Coordinates.of(dep.groupId, dep.artifactId, dep.version);
 
             // Find the <dependency> element matching this GA
@@ -459,8 +537,8 @@ class DependenciesTui {
                                     } else {
                                         editor.updateOrCreateChildElement(el, COL_SCOPE, newScope);
                                     }
-                                    Files.writeString(Path.of(pomPath), doc.toXml());
                                     dep.scope = newScope;
+                                    dirty = true;
                                     updateStatus();
                                 } catch (Exception e) {
                                     status = "Failed to change scope: " + e.getMessage();
@@ -470,6 +548,38 @@ class DependenciesTui {
         } catch (Exception e) {
             status = "Failed to change scope: " + e.getMessage();
         }
+    }
+
+    private void requestQuit() {
+        if (dirty) {
+            pendingQuit = true;
+            status = "Save changes to POM?";
+        } else {
+            runner.quit();
+        }
+    }
+
+    private void saveAndQuit() {
+        try {
+            Files.writeString(Path.of(pomPath), editor.toXml());
+            runner.quit();
+        } catch (Exception e) {
+            pendingQuit = false;
+            status = "Failed to save: " + e.getMessage();
+        }
+    }
+
+    private void toggleDiffView() {
+        String modifiedPom = editor.toXml();
+        var fullDiff = UnifiedDiff.compute(originalPomContent, modifiedPom);
+        long changes = UnifiedDiff.changeCount(fullDiff);
+        if (changes == 0) {
+            status = "No changes to show";
+            return;
+        }
+        diffLines = UnifiedDiff.filterContext(fullDiff, 3);
+        diffScroll = 0;
+        status = changes + " line(s) changed";
     }
 
     /**
@@ -525,7 +635,12 @@ class DependenciesTui {
                 .split(frame.area());
 
         renderHeader(frame, zones.get(0));
-        renderTable(frame, zones.get(1));
+        lastContentHeight = zones.get(1).height();
+        if (diffLines != null) {
+            UnifiedDiff.render(frame, zones.get(1), diffLines, diffScroll, " POM Changes ");
+        } else {
+            renderTable(frame, zones.get(1));
+        }
         renderInfoBar(frame, zones.get(2));
     }
 
@@ -564,6 +679,10 @@ class DependenciesTui {
         }
         spans.add(Span.raw("[" + (view == View.TRANSITIVE ? HIGHLIGHT_SYMBOL : "  ") + transitiveLabel + "]")
                 .fg(view == View.TRANSITIVE ? Color.YELLOW : Color.DARK_GRAY));
+
+        if (dirty) {
+            spans.add(Span.raw("  [modified]").fg(Color.YELLOW));
+        }
 
         Paragraph header = Paragraph.builder()
                 .text(dev.tamboui.text.Text.from(Line.from(spans)))
@@ -672,27 +791,45 @@ class DependenciesTui {
 
         // Status
         List<Span> statusSpans = new ArrayList<>();
-        statusSpans.add(Span.raw(" " + status).fg(Color.GREEN));
+        statusSpans.add(Span.raw(" " + status).fg(pendingQuit ? Color.YELLOW : Color.GREEN));
         frame.renderWidget(Paragraph.from(Line.from(statusSpans)), rows.get(1));
 
         // Key bindings
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" "));
-        spans.add(Span.raw("\u2191\u2193").bold());
-        spans.add(Span.raw(":Navigate  "));
-        spans.add(Span.raw("Tab").bold());
-        spans.add(Span.raw(":Switch view  "));
-        if (view == View.DECLARED) {
-            spans.add(Span.raw("d/Enter").bold());
-            spans.add(Span.raw(":Delete  "));
-            spans.add(Span.raw("s").bold());
-            spans.add(Span.raw(":Change scope  "));
+        if (pendingQuit) {
+            spans.add(Span.raw("y").bold());
+            spans.add(Span.raw(":Save and quit  "));
+            spans.add(Span.raw("n").bold());
+            spans.add(Span.raw(":Discard and quit  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Cancel"));
+        } else if (diffLines != null) {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Scroll  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Close  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
         } else {
-            spans.add(Span.raw("a/Enter").bold());
-            spans.add(Span.raw(":Add to POM  "));
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Navigate  "));
+            spans.add(Span.raw("Tab").bold());
+            spans.add(Span.raw(":Switch view  "));
+            if (view == View.DECLARED) {
+                spans.add(Span.raw("x/Enter").bold());
+                spans.add(Span.raw(":Delete  "));
+                spans.add(Span.raw("s").bold());
+                spans.add(Span.raw(":Change scope  "));
+            } else {
+                spans.add(Span.raw("a/Enter").bold());
+                spans.add(Span.raw(":Add to POM  "));
+            }
+            spans.add(Span.raw("d").bold());
+            spans.add(Span.raw(":Diff  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
         }
-        spans.add(Span.raw("q").bold());
-        spans.add(Span.raw(":Quit"));
 
         frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(2));
     }

--- a/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -204,6 +204,7 @@ class DependenciesTui {
     private boolean dirty;
     private boolean pendingQuit;
     private final DiffOverlay diffOverlay = new DiffOverlay();
+    private final HelpOverlay helpOverlay = new HelpOverlay();
     private int lastContentHeight;
     private TuiRunner runner;
 
@@ -329,6 +330,16 @@ class DependenciesTui {
             return false;
         }
 
+        // Help overlay mode
+        if (helpOverlay.isActive()) {
+            if (helpOverlay.handleKey(key)) return true;
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                requestQuit();
+                return true;
+            }
+            return false;
+        }
+
         if (key.isCtrlC() || key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
             requestQuit();
             return true;
@@ -371,6 +382,11 @@ class DependenciesTui {
 
         if (key.isCharIgnoreCase('d')) {
             toggleDiffView();
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('h')) {
+            helpOverlay.open(buildHelp());
             return true;
         }
 
@@ -562,6 +578,53 @@ class DependenciesTui {
         }
     }
 
+    private List<HelpOverlay.Section> buildHelp() {
+        return List.of(
+                new HelpOverlay.Section(
+                        "Dependency Analysis",
+                        List.of(
+                                new HelpOverlay.Entry("", "Uses bytecode analysis to compare what is declared"),
+                                new HelpOverlay.Entry("", "in the POM against what is actually used in code."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "Declared view: dependencies in the POM that are not"),
+                                new HelpOverlay.Entry("", "referenced in compiled bytecode. These may be safe"),
+                                new HelpOverlay.Entry("", "to remove (but check for runtime/reflection use)."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "Transitive view: classes used in your code that come"),
+                                new HelpOverlay.Entry("", "from transitive dependencies. These should be declared"),
+                                new HelpOverlay.Entry("", "explicitly to avoid breakage when transitives change."))),
+                new HelpOverlay.Section(
+                        "Table Columns",
+                        List.of(
+                                new HelpOverlay.Entry("status", "unused (declared) or undeclared (transitive)"),
+                                new HelpOverlay.Entry("dependency", "groupId:artifactId"),
+                                new HelpOverlay.Entry("scope", "Maven scope (compile, test, runtime, provided)"),
+                                new HelpOverlay.Entry("classifier", "Artifact classifier (e.g. test-fixtures)"))),
+                new HelpOverlay.Section(
+                        "Colors",
+                        List.of(
+                                new HelpOverlay.Entry("yellow", "Issue flag \u2014 unused or undeclared dependency"),
+                                new HelpOverlay.Entry("cyan", "Header and view tab indicators"),
+                                new HelpOverlay.Entry("dim", "Informational / secondary text"))),
+                new HelpOverlay.Section(
+                        "Declared View Actions",
+                        List.of(
+                                new HelpOverlay.Entry("x / Enter", "Remove the selected unused dependency"),
+                                new HelpOverlay.Entry(
+                                        "s", "Cycle scope (compile \u2192 test \u2192 runtime \u2192 ...)"))),
+                new HelpOverlay.Section(
+                        "Transitive View Actions",
+                        List.of(new HelpOverlay.Entry("a / Enter", "Add the dependency to the POM"))),
+                new HelpOverlay.Section(
+                        "General",
+                        List.of(
+                                new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("Tab", "Switch between Declared and Transitive views"),
+                                new HelpOverlay.Entry("d", "Preview POM changes as a unified diff"),
+                                new HelpOverlay.Entry("h", "Toggle this help screen"),
+                                new HelpOverlay.Entry("q / Esc", "Quit (prompts to save if modified)"))));
+    }
+
     private void toggleDiffView() {
         long changes = diffOverlay.open(originalPomContent, editor.toXml());
         status = changes == 0 ? "No changes to show" : changes + " line(s) changed";
@@ -621,7 +684,9 @@ class DependenciesTui {
 
         renderHeader(frame, zones.get(0));
         lastContentHeight = zones.get(1).height();
-        if (diffOverlay.isActive()) {
+        if (helpOverlay.isActive()) {
+            helpOverlay.render(frame, zones.get(1));
+        } else if (diffOverlay.isActive()) {
             diffOverlay.render(frame, zones.get(1), " POM Changes ");
         } else {
             renderTable(frame, zones.get(1));
@@ -812,6 +877,8 @@ class DependenciesTui {
             }
             spans.add(Span.raw("d").bold());
             spans.add(Span.raw(":Diff  "));
+            spans.add(Span.raw("h").bold());
+            spans.add(Span.raw(":Help  "));
             spans.add(Span.raw("q").bold());
             spans.add(Span.raw(":Quit"));
         }

--- a/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -253,8 +253,10 @@ class DependenciesTui {
         String pom;
         try {
             pom = Files.readString(Path.of(pomPath));
-        } catch (Exception e) {
+        } catch (java.nio.file.NoSuchFileException e) {
             pom = "<project/>";
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot read POM: " + pomPath, e);
         }
         this.originalPomContent = pom;
         this.editor = new PomEditor(Document.of(pom));
@@ -337,6 +339,10 @@ class DependenciesTui {
             }
             if (key.isKey(KeyCode.PAGE_DOWN)) {
                 diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                requestQuit();
                 return true;
             }
             return false;

--- a/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -203,8 +203,7 @@ class DependenciesTui {
     private final PomEditor editor;
     private boolean dirty;
     private boolean pendingQuit;
-    private List<UnifiedDiff.DiffLine> diffLines;
-    private int diffScroll;
+    private final DiffOverlay diffOverlay = new DiffOverlay();
     private int lastContentHeight;
     private TuiRunner runner;
 
@@ -319,28 +318,12 @@ class DependenciesTui {
         }
 
         // Diff overlay mode — Esc closes overlay first
-        if (diffLines != null) {
+        if (diffOverlay.isActive()) {
             if (key.isKey(KeyCode.ESCAPE)) {
-                diffLines = null;
-                diffScroll = 0;
+                diffOverlay.close();
                 return true;
             }
-            if (key.isUp()) {
-                if (diffScroll > 0) diffScroll--;
-                return true;
-            }
-            if (key.isDown()) {
-                diffScroll = Math.min(diffScroll + 1, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
-                return true;
-            }
-            if (key.isKey(KeyCode.PAGE_UP)) {
-                diffScroll = Math.max(0, diffScroll - 10);
-                return true;
-            }
-            if (key.isKey(KeyCode.PAGE_DOWN)) {
-                diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
-                return true;
-            }
+            if (diffOverlay.handleScrollKey(key, lastContentHeight)) return true;
             if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
                 requestQuit();
                 return true;
@@ -576,16 +559,8 @@ class DependenciesTui {
     }
 
     private void toggleDiffView() {
-        String modifiedPom = editor.toXml();
-        var fullDiff = UnifiedDiff.compute(originalPomContent, modifiedPom);
-        long changes = UnifiedDiff.changeCount(fullDiff);
-        if (changes == 0) {
-            status = "No changes to show";
-            return;
-        }
-        diffLines = UnifiedDiff.filterContext(fullDiff, 3);
-        diffScroll = 0;
-        status = changes + " line(s) changed";
+        long changes = diffOverlay.open(originalPomContent, editor.toXml());
+        status = changes == 0 ? "No changes to show" : changes + " line(s) changed";
     }
 
     /**
@@ -642,8 +617,8 @@ class DependenciesTui {
 
         renderHeader(frame, zones.get(0));
         lastContentHeight = zones.get(1).height();
-        if (diffLines != null) {
-            UnifiedDiff.render(frame, zones.get(1), diffLines, diffScroll, " POM Changes ");
+        if (diffOverlay.isActive()) {
+            diffOverlay.render(frame, zones.get(1), " POM Changes ");
         } else {
             renderTable(frame, zones.get(1));
         }
@@ -810,7 +785,7 @@ class DependenciesTui {
             spans.add(Span.raw(":Discard and quit  "));
             spans.add(Span.raw("Esc").bold());
             spans.add(Span.raw(":Cancel"));
-        } else if (diffLines != null) {
+        } else if (diffOverlay.isActive()) {
             spans.add(Span.raw("\u2191\u2193").bold());
             spans.add(Span.raw(":Scroll  "));
             spans.add(Span.raw("Esc").bold());

--- a/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -252,8 +252,6 @@ class DependenciesTui {
         String pom;
         try {
             pom = Files.readString(Path.of(pomPath));
-        } catch (java.nio.file.NoSuchFileException e) {
-            pom = "<project/>";
         } catch (Exception e) {
             throw new IllegalStateException("Cannot read POM: " + pomPath, e);
         }
@@ -550,6 +548,12 @@ class DependenciesTui {
 
     private void saveAndQuit() {
         try {
+            String currentOnDisk = Files.readString(Path.of(pomPath));
+            if (!currentOnDisk.equals(originalPomContent)) {
+                pendingQuit = false;
+                status = "POM modified externally \u2014 save aborted";
+                return;
+            }
             Files.writeString(Path.of(pomPath), editor.toXml());
             runner.quit();
         } catch (Exception e) {

--- a/src/main/java/eu/maveniverse/maven/pilot/DependencyTreeModel.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependencyTreeModel.java
@@ -221,6 +221,22 @@ class DependencyTreeModel {
     }
 
     /**
+     * Find the first node matching the given groupId:artifactId.
+     */
+    TreeNode findByGA(String ga) {
+        return findByGA(root, ga);
+    }
+
+    private TreeNode findByGA(TreeNode node, String ga) {
+        if (node.ga().equals(ga)) return node;
+        for (TreeNode child : node.children) {
+            TreeNode found = findByGA(child, ga);
+            if (found != null) return found;
+        }
+        return null;
+    }
+
+    /**
      * Filter visible nodes by artifact coordinate substring.
      */
     List<TreeNode> filter(String query) {

--- a/src/main/java/eu/maveniverse/maven/pilot/DiffOverlay.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DiffOverlay.java
@@ -22,7 +22,9 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Reusable diff overlay component for TUI screens.
@@ -62,6 +64,38 @@ class DiffOverlay {
         lines = UnifiedDiff.filterContext(fullDiff, 3);
         scroll = 0;
         return changes;
+    }
+
+    /**
+     * Open the diff overlay with diffs from multiple files.
+     *
+     * @param files ordered map of filename to (original, modified) pairs
+     * @return the total number of changed lines, or 0 if no changes detected
+     */
+    long openMulti(Map<String, Map.Entry<String, String>> files) {
+        List<UnifiedDiff.DiffLine> allLines = new ArrayList<>();
+        long totalChanges = 0;
+        for (var entry : files.entrySet()) {
+            var fullDiff = UnifiedDiff.compute(
+                    entry.getValue().getKey(), entry.getValue().getValue());
+            long changes = UnifiedDiff.changeCount(fullDiff);
+            if (changes > 0) {
+                if (!allLines.isEmpty()) {
+                    allLines.add(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, ""));
+                }
+                allLines.add(new UnifiedDiff.DiffLine(
+                        UnifiedDiff.Type.CONTEXT, "\u2500\u2500 " + entry.getKey() + " \u2500\u2500"));
+                allLines.addAll(UnifiedDiff.filterContext(fullDiff, 3));
+                totalChanges += changes;
+            }
+        }
+        if (totalChanges == 0) {
+            close();
+            return 0;
+        }
+        lines = allLines;
+        scroll = 0;
+        return totalChanges;
     }
 
     void close() {

--- a/src/main/java/eu/maveniverse/maven/pilot/DiffOverlay.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DiffOverlay.java
@@ -56,6 +56,7 @@ class DiffOverlay {
         var fullDiff = UnifiedDiff.compute(original, modified);
         long changes = UnifiedDiff.changeCount(fullDiff);
         if (changes == 0) {
+            close();
             return 0;
         }
         lines = UnifiedDiff.filterContext(fullDiff, 3);

--- a/src/main/java/eu/maveniverse/maven/pilot/DiffOverlay.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DiffOverlay.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import java.util.List;
+
+/**
+ * Reusable diff overlay component for TUI screens.
+ *
+ * <p>Encapsulates the state and behavior for displaying a scrollable
+ * unified diff overlay, including key handling for scrolling.</p>
+ */
+class DiffOverlay {
+
+    private List<UnifiedDiff.DiffLine> lines;
+    private int scroll;
+
+    boolean isActive() {
+        return lines != null;
+    }
+
+    List<UnifiedDiff.DiffLine> lines() {
+        return lines;
+    }
+
+    int scroll() {
+        return scroll;
+    }
+
+    /**
+     * Open the diff overlay by computing a unified diff between two strings.
+     *
+     * @return the number of changed lines, or 0 if no changes detected
+     */
+    long open(String original, String modified) {
+        var fullDiff = UnifiedDiff.compute(original, modified);
+        long changes = UnifiedDiff.changeCount(fullDiff);
+        if (changes == 0) {
+            return 0;
+        }
+        lines = UnifiedDiff.filterContext(fullDiff, 3);
+        scroll = 0;
+        return changes;
+    }
+
+    void close() {
+        lines = null;
+        scroll = 0;
+    }
+
+    /**
+     * Handle scroll keys (up, down, page up, page down).
+     *
+     * @return {@code true} if the key was handled
+     */
+    boolean handleScrollKey(KeyEvent key, int contentHeight) {
+        if (!isActive()) {
+            return false;
+        }
+        if (key.isUp()) {
+            if (scroll > 0) scroll--;
+            return true;
+        }
+        if (key.isDown()) {
+            scroll = Math.min(scroll + 1, UnifiedDiff.maxScroll(lines, contentHeight));
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            scroll = Math.max(0, scroll - 10);
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            scroll = Math.min(scroll + 10, UnifiedDiff.maxScroll(lines, contentHeight));
+            return true;
+        }
+        return false;
+    }
+
+    void render(Frame frame, Rect area, String title) {
+        UnifiedDiff.render(frame, area, lines, scroll, title);
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/HelpOverlay.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/HelpOverlay.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Reusable help overlay component for TUI screens.
+ *
+ * <p>Displays a scrollable help screen with sections, key bindings,
+ * and descriptions. Close with Esc or h.</p>
+ */
+class HelpOverlay {
+
+    record Entry(String key, String description) {}
+
+    record Section(String title, List<Entry> entries) {}
+
+    private List<Line> lines;
+    private int scroll;
+    private int lastHeight;
+
+    boolean isActive() {
+        return lines != null;
+    }
+
+    void open(List<Section> sections) {
+        lines = new ArrayList<>();
+        int maxKeyLen = 0;
+        for (Section section : sections) {
+            for (Entry entry : section.entries) {
+                maxKeyLen = Math.max(maxKeyLen, entry.key.length());
+            }
+        }
+        int pad = maxKeyLen + 2;
+
+        for (Section section : sections) {
+            if (!lines.isEmpty()) {
+                lines.add(Line.from(Span.raw("")));
+            }
+            lines.add(Line.from(Span.raw("  " + section.title).bold().cyan()));
+            lines.add(Line.from(Span.raw("")));
+            for (Entry entry : section.entries) {
+                String paddedKey = String.format("  %-" + pad + "s", entry.key);
+                lines.add(Line.from(Span.raw(paddedKey).bold().yellow(), Span.raw(entry.description)));
+            }
+        }
+
+        // Footer
+        lines.add(Line.from(Span.raw("")));
+        lines.add(Line.from(
+                Span.raw("  Press ").dim(),
+                Span.raw("Esc").bold().yellow(),
+                Span.raw(" or ").dim(),
+                Span.raw("h").bold().yellow(),
+                Span.raw(" to close this help screen").dim()));
+
+        scroll = 0;
+    }
+
+    void close() {
+        lines = null;
+        scroll = 0;
+    }
+
+    /**
+     * Handle key events: close on Esc/h, scroll on up/down/PgUp/PgDn.
+     *
+     * @return {@code true} if the key was handled
+     */
+    boolean handleKey(KeyEvent key) {
+        if (!isActive()) {
+            return false;
+        }
+        if (key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('h')) {
+            close();
+            return true;
+        }
+        if (key.isUp()) {
+            if (scroll > 0) scroll--;
+            return true;
+        }
+        if (key.isDown()) {
+            scroll = Math.min(scroll + 1, maxScroll(lastHeight));
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            scroll = Math.max(0, scroll - 10);
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            scroll = Math.min(scroll + 10, maxScroll(lastHeight));
+            return true;
+        }
+        return false;
+    }
+
+    private int maxScroll(int areaHeight) {
+        int innerHeight = Math.max(0, areaHeight - 2);
+        return lines == null ? 0 : Math.max(0, lines.size() - innerHeight);
+    }
+
+    void render(Frame frame, Rect area) {
+        lastHeight = area.height();
+        Block block = Block.builder()
+                .title(" Help ")
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().cyan())
+                .build();
+
+        if (lines == null || lines.isEmpty()) {
+            frame.renderWidget(Paragraph.builder().text("").block(block).build(), area);
+            return;
+        }
+
+        int innerHeight = area.height() - 2;
+        if (innerHeight <= 0) {
+            frame.renderWidget(Paragraph.builder().text("").block(block).build(), area);
+            return;
+        }
+
+        List<Line> visible = new ArrayList<>();
+        int end = Math.min(scroll + innerHeight, lines.size());
+        for (int idx = scroll; idx < end; idx++) {
+            visible.add(lines.get(idx));
+        }
+
+        Paragraph paragraph =
+                Paragraph.builder().text(Text.from(visible)).block(block).build();
+        frame.renderWidget(paragraph, area);
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/ModulePickerTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ModulePickerTui.java
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.tui.TuiRunner;
+import dev.tamboui.tui.event.Event;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import dev.tamboui.widgets.table.Row;
+import dev.tamboui.widgets.table.Table;
+import dev.tamboui.widgets.table.TableState;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Reusable module picker TUI for reactor-aware goals.
+ *
+ * <p>Displays the reactor module tree and lets the user select a module.
+ * Returns the selected {@link MavenProject} or {@code null} if the user quits.</p>
+ */
+class ModulePickerTui {
+
+    private final ReactorModel reactorModel;
+    private final String reactorGav;
+    private final String goalName;
+    private final TableState tableState = new TableState();
+    private final HelpOverlay helpOverlay = new HelpOverlay();
+    private MavenProject selectedProject;
+
+    ModulePickerTui(ReactorModel reactorModel, String reactorGav, String goalName) {
+        this.reactorModel = reactorModel;
+        this.reactorGav = reactorGav;
+        this.goalName = goalName;
+        tableState.select(0);
+    }
+
+    /**
+     * Run the picker TUI and return the selected project.
+     *
+     * @return the selected MavenProject, or null if the user quit without selecting
+     */
+    MavenProject pick() throws Exception {
+        var configured = TuiRunner.builder()
+                .eventHandler(this::handleEvent)
+                .renderer(this::render)
+                .tickRate(Duration.ofMillis(100))
+                .build();
+        try {
+            configured.run();
+        } finally {
+            configured.close();
+        }
+        return selectedProject;
+    }
+
+    boolean handleEvent(Event event, TuiRunner runner) {
+        if (!(event instanceof KeyEvent key)) {
+            return true;
+        }
+
+        if (helpOverlay.isActive()) {
+            if (helpOverlay.handleKey(key)) return true;
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                runner.quit();
+                return true;
+            }
+            return false;
+        }
+
+        if (key.isCtrlC() || key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
+            runner.quit();
+            return true;
+        }
+
+        List<ReactorModel.ModuleNode> visible = reactorModel.visibleNodes();
+
+        if (key.isUp()) {
+            tableState.selectPrevious();
+            return true;
+        }
+        if (key.isDown()) {
+            tableState.selectNext(visible.size());
+            return true;
+        }
+
+        if (key.isKey(KeyCode.ENTER)) {
+            Integer sel = tableState.selected();
+            if (sel != null && sel >= 0 && sel < visible.size()) {
+                selectedProject = visible.get(sel).project;
+                runner.quit();
+            }
+            return true;
+        }
+
+        // Expand/collapse
+        if (key.isKey(KeyCode.RIGHT) || key.isCharIgnoreCase(' ')) {
+            Integer sel = tableState.selected();
+            if (sel != null && sel >= 0 && sel < visible.size()) {
+                var node = visible.get(sel);
+                if (node.hasChildren() && !node.expanded) {
+                    node.expanded = true;
+                } else {
+                    tableState.selectNext(visible.size());
+                }
+            }
+            return true;
+        }
+        if (key.isKey(KeyCode.LEFT)) {
+            Integer sel = tableState.selected();
+            if (sel != null && sel >= 0 && sel < visible.size()) {
+                var node = visible.get(sel);
+                if (node.expanded && node.hasChildren()) {
+                    node.expanded = false;
+                } else {
+                    // Go to parent node
+                    for (int i = sel - 1; i >= 0; i--) {
+                        if (visible.get(i).depth < node.depth) {
+                            tableState.select(i);
+                            break;
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('e')) {
+            expandNode(reactorModel.root);
+            return true;
+        }
+        if (key.isCharIgnoreCase('w')) {
+            Integer sel = tableState.selected();
+            ReactorModel.ModuleNode selectedNode =
+                    (sel != null && sel >= 0 && sel < visible.size()) ? visible.get(sel) : null;
+            collapseNode(reactorModel.root);
+            reactorModel.root.expanded = true;
+            if (selectedNode != null) {
+                var newVisible = reactorModel.visibleNodes();
+                int newIndex = newVisible.indexOf(selectedNode);
+                if (newIndex < 0) {
+                    // Walk backward in old visible list to find nearest visible ancestor
+                    int targetDepth = selectedNode.depth;
+                    for (int i = sel - 1; i >= 0; i--) {
+                        if (visible.get(i).depth < targetDepth) {
+                            newIndex = newVisible.indexOf(visible.get(i));
+                            if (newIndex >= 0) break;
+                            targetDepth = visible.get(i).depth;
+                        }
+                    }
+                    if (newIndex < 0) newIndex = 0;
+                }
+                tableState.select(newIndex);
+            }
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('h')) {
+            helpOverlay.open(buildHelp());
+            return true;
+        }
+
+        return false;
+    }
+
+    void render(Frame frame) {
+        var zones = Layout.vertical()
+                .constraints(Constraint.length(3), Constraint.fill(), Constraint.length(3))
+                .split(frame.area());
+
+        renderHeader(frame, zones.get(0));
+        if (helpOverlay.isActive()) {
+            helpOverlay.render(frame, zones.get(1));
+        } else {
+            renderModules(frame, zones.get(1));
+        }
+        renderInfoBar(frame, zones.get(2));
+    }
+
+    private void renderHeader(Frame frame, Rect area) {
+        Block block = Block.builder()
+                .title(" Pilot \u2014 " + goalName + " (select module) ")
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().cyan())
+                .build();
+
+        Paragraph header = Paragraph.builder()
+                .text(dev.tamboui.text.Text.from(Line.from(
+                        Span.raw(" " + reactorGav).bold().cyan(),
+                        Span.raw("  reactor: " + reactorModel.allModules.size() + " modules")
+                                .fg(Color.DARK_GRAY))))
+                .block(block)
+                .build();
+        frame.renderWidget(header, area);
+    }
+
+    private void renderModules(Frame frame, Rect area) {
+        Block block = Block.builder()
+                .title(" Modules (" + reactorModel.allModules.size() + ") ")
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().fg(Color.DARK_GRAY))
+                .build();
+
+        List<ReactorModel.ModuleNode> visible = reactorModel.visibleNodes();
+
+        if (visible.isEmpty()) {
+            Paragraph empty = Paragraph.builder()
+                    .text("No modules")
+                    .block(block)
+                    .centered()
+                    .build();
+            frame.renderWidget(empty, area);
+            return;
+        }
+
+        Row header = Row.from("module", "groupId:artifactId")
+                .style(Style.create().bold().yellow());
+
+        List<Row> rows = new ArrayList<>();
+        for (var node : visible) {
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < node.depth; i++) {
+                sb.append("  ");
+            }
+            if (node.hasChildren()) {
+                sb.append(node.expanded ? "\u25BE " : "\u25B8 ");
+            } else {
+                sb.append("  ");
+            }
+            sb.append(node.name);
+
+            rows.add(Row.from(sb.toString(), node.ga()));
+        }
+
+        Table table = Table.builder()
+                .header(header)
+                .rows(rows)
+                .widths(Constraint.percentage(50), Constraint.percentage(50))
+                .highlightStyle(Style.create().reversed().bold())
+                .highlightSymbol("\u25B8 ")
+                .block(block)
+                .build();
+
+        frame.renderStatefulWidget(table, area, tableState);
+    }
+
+    private void expandNode(ReactorModel.ModuleNode node) {
+        node.expanded = true;
+        for (var child : node.children) {
+            expandNode(child);
+        }
+    }
+
+    private void collapseNode(ReactorModel.ModuleNode node) {
+        node.expanded = false;
+        for (var child : node.children) {
+            collapseNode(child);
+        }
+    }
+
+    private List<HelpOverlay.Section> buildHelp() {
+        return List.of(
+                new HelpOverlay.Section(
+                        "Module Picker",
+                        List.of(
+                                new HelpOverlay.Entry("", "Select a module from the reactor build. The tree"),
+                                new HelpOverlay.Entry("", "mirrors the Maven reactor hierarchy \u2014 parent"),
+                                new HelpOverlay.Entry("", "modules contain their child modules as sub-nodes."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "After selecting a module, you will be prompted"),
+                                new HelpOverlay.Entry("", "to choose which tool to run against it."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "The two columns show the module directory name"),
+                                new HelpOverlay.Entry("", "and its Maven coordinates (groupId:artifactId)."))),
+                new HelpOverlay.Section(
+                        "Keys",
+                        List.of(
+                                new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("\u2190 / \u2192", "Collapse / expand tree node"),
+                                new HelpOverlay.Entry("Space", "Expand node or move down"),
+                                new HelpOverlay.Entry("e / w", "Expand all / collapse all"),
+                                new HelpOverlay.Entry("Enter", "Select the highlighted module"),
+                                new HelpOverlay.Entry("h", "Toggle this help screen"),
+                                new HelpOverlay.Entry("q / Esc", "Quit without selecting"))));
+    }
+
+    private void renderInfoBar(Frame frame, Rect area) {
+        var rows = Layout.vertical()
+                .constraints(Constraint.length(1), Constraint.length(1), Constraint.length(1))
+                .split(area);
+
+        List<Span> statusSpans = new ArrayList<>();
+        statusSpans.add(Span.raw(" Select a module to run " + goalName).fg(Color.GREEN));
+        frame.renderWidget(Paragraph.from(Line.from(statusSpans)), rows.get(1));
+
+        List<Span> spans = new ArrayList<>();
+        spans.add(Span.raw(" "));
+        spans.add(Span.raw("\u2191\u2193").bold());
+        spans.add(Span.raw(":Navigate  "));
+        spans.add(Span.raw("\u2190\u2192").bold());
+        spans.add(Span.raw(":Collapse/Expand  "));
+        spans.add(Span.raw("e").bold());
+        spans.add(Span.raw(":Expand All  "));
+        spans.add(Span.raw("w").bold());
+        spans.add(Span.raw(":Collapse All  "));
+        spans.add(Span.raw("Enter").bold());
+        spans.add(Span.raw(":Select  "));
+        spans.add(Span.raw("h").bold());
+        spans.add(Span.raw(":Help  "));
+        spans.add(Span.raw("q").bold());
+        spans.add(Span.raw(":Quit"));
+
+        frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(2));
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/MojoHelper.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/MojoHelper.java
@@ -18,8 +18,11 @@
  */
 package eu.maveniverse.maven.pilot;
 
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.maven.project.MavenProject;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.collection.CollectRequest;
@@ -35,6 +38,19 @@ final class MojoHelper {
      * Private constructor to prevent instantiation of this utility class.
      */
     private MojoHelper() {}
+
+    /**
+     * Create an ExecutorService using virtual threads (Java 21+) if available,
+     * falling back to a fixed thread pool sized at 2x available processors.
+     */
+    static ExecutorService newHttpPool() {
+        try {
+            Method m = Executors.class.getMethod("newVirtualThreadPerTaskExecutor");
+            return (ExecutorService) m.invoke(null);
+        } catch (Exception e) {
+            return Executors.newFixedThreadPool(2 * Runtime.getRuntime().availableProcessors());
+        }
+    }
 
     /**
      * Convert a Maven model Dependency into an Aether Dependency.

--- a/src/main/java/eu/maveniverse/maven/pilot/OsvClient.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/OsvClient.java
@@ -106,7 +106,8 @@ class OsvClient {
                         String summary = vuln.getString("summary", "");
                         String published = vuln.getString("published", "");
 
-                        // Extract severity from database_specific or severity array
+                        // Extract severity: prefer database_specific.severity (human-readable),
+                        // fall back to CVSS vector from severity array
                         String severity = "UNKNOWN";
                         if (vuln.containsKey("database_specific")) {
                             JsonObject dbSpecific = vuln.getJsonObject("database_specific");
@@ -114,10 +115,13 @@ class OsvClient {
                                 severity = dbSpecific.getString("severity");
                             }
                         }
-                        if (vuln.containsKey("severity")) {
+                        if ("UNKNOWN".equals(severity) && vuln.containsKey("severity")) {
                             JsonArray sevArray = vuln.getJsonArray("severity");
                             if (sevArray != null && !sevArray.isEmpty()) {
-                                severity = sevArray.getJsonObject(0).getString("score", severity);
+                                String score = sevArray.getJsonObject(0).getString("score", null);
+                                if (score != null) {
+                                    severity = cvssToSeverity(score);
+                                }
                             }
                         }
 
@@ -138,5 +142,48 @@ class OsvClient {
         } finally {
             conn.disconnect();
         }
+    }
+
+    /**
+     * Convert a CVSS vector string to a human-readable severity level.
+     * Extracts the base score from CVSS v3/v4 vectors and maps to CRITICAL/HIGH/MEDIUM/LOW.
+     */
+    private static String cvssToSeverity(String cvssVector) {
+        // Try to extract numeric base score from the vector
+        // CVSS v3 format: CVSS:3.1/AV:N/AC:L/... — no explicit score in vector
+        // CVSS v4 format: CVSS:4.0/AV:N/AC:L/...
+        // Some sources include a score like "CVSS:3.1/AV:N/.../score:7.5"
+        // For vectors without an explicit score, estimate from impact metrics
+        try {
+            if (cvssVector.startsWith("CVSS:")) {
+                // Parse attack complexity and impact to estimate severity
+                boolean networkAccess = cvssVector.contains("/AV:N");
+                boolean lowComplexity = cvssVector.contains("/AC:L");
+                boolean highConfidentiality = cvssVector.contains("/C:H");
+                boolean highIntegrity = cvssVector.contains("/I:H");
+                boolean highAvailability = cvssVector.contains("/A:H");
+                boolean noneConfidentiality = cvssVector.contains("/C:N");
+                boolean noneIntegrity = cvssVector.contains("/I:N");
+                boolean noneAvailability = cvssVector.contains("/A:N");
+
+                int highCount = (highConfidentiality ? 1 : 0) + (highIntegrity ? 1 : 0) + (highAvailability ? 1 : 0);
+                int noneCount = (noneConfidentiality ? 1 : 0) + (noneIntegrity ? 1 : 0) + (noneAvailability ? 1 : 0);
+
+                if (networkAccess && lowComplexity && highCount == 3) {
+                    return "CRITICAL";
+                } else if (networkAccess && highCount >= 2) {
+                    return "HIGH";
+                } else if (noneCount == 3) {
+                    return "LOW";
+                } else if (highCount >= 1) {
+                    return "MEDIUM";
+                } else {
+                    return "LOW";
+                }
+            }
+        } catch (Exception e) {
+            // fall through
+        }
+        return cvssVector;
     }
 }

--- a/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
@@ -1,0 +1,521 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.Element;
+import eu.maveniverse.domtrip.Node;
+import eu.maveniverse.domtrip.maven.PomEditor;
+import java.io.File;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.InputLocation;
+import org.apache.maven.model.InputLocationTracker;
+import org.apache.maven.model.InputSource;
+import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.collection.CollectResult;
+import org.eclipse.aether.graph.DependencyNode;
+import org.eclipse.aether.resolution.ArtifactRequest;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResult;
+import org.eclipse.aether.resolution.VersionRangeRequest;
+import org.eclipse.aether.resolution.VersionRangeResult;
+
+/**
+ * Interactive launcher that displays the reactor module tree and lets the user
+ * pick a tool to run on a selected module.
+ *
+ * <p>For single-module projects, shows the tool picker directly.
+ * For multi-module reactors, shows the module tree first, then the tool picker.</p>
+ *
+ * <p>Usage:</p>
+ * <pre>
+ * mvn pilot:pilot
+ * </pre>
+ *
+ * @since 0.2.0
+ */
+@Mojo(name = "pilot", requiresProject = true, aggregator = true, threadSafe = true)
+public class PilotMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
+    private RepositorySystemSession repoSession;
+
+    @Inject
+    private RepositorySystem repoSystem;
+
+    @Parameter(property = "scope", defaultValue = "compile")
+    private String scope;
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            List<MavenProject> projects = session.getProjects();
+            if (projects.size() > 1) {
+                executeReactor(projects);
+            } else {
+                executeSingleProject(project);
+            }
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to run pilot: " + e.getMessage(), e);
+        }
+    }
+
+    private void executeSingleProject(MavenProject proj) throws Exception {
+        String gav = gavOf(proj);
+        while (true) {
+            String tool = new ToolPickerTui(gav, false).pick();
+            if (tool == null) break;
+            runTool(tool, proj, List.of(proj));
+        }
+    }
+
+    private void executeReactor(List<MavenProject> projects) throws Exception {
+        ReactorModel reactorModel = ReactorModel.build(projects);
+        MavenProject root = projects.get(0);
+        String reactorGav = gavOf(root);
+
+        while (true) {
+            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "pilot").pick();
+            if (selected == null) break;
+            String tool = new ToolPickerTui(gavOf(selected), true).pick();
+            if (tool == null) continue;
+            runTool(tool, selected, projects);
+        }
+    }
+
+    private void runTool(String tool, MavenProject proj, List<MavenProject> projects) throws Exception {
+        switch (tool) {
+            case "tree" -> runTree(proj);
+            case "dependencies" -> runDependencies(proj);
+            case "pom" -> runPom(proj);
+            case "align" -> runAlign(proj);
+            case "updates" -> runUpdates(proj, projects);
+            case "conflicts" -> runConflicts(proj, projects);
+            case "audit" -> runAudit(proj, projects);
+            default -> getLog().warn("Unknown tool: " + tool);
+        }
+    }
+
+    // ── tree ────────────────────────────────────────────────────────────────
+
+    private void runTree(MavenProject proj) throws Exception {
+        CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
+        DependencyTreeModel model = DependencyTreeModel.fromDependencyNode(result.getRoot(), scope);
+        new TreeTui(model, gavOf(proj)).run();
+    }
+
+    // ── dependencies ────────────────────────────────────────────────────────
+
+    private void runDependencies(MavenProject proj) throws Exception {
+        Set<String> declaredGAs = new HashSet<>();
+        List<DependenciesTui.DepEntry> declared = new ArrayList<>();
+        for (Dependency dep : proj.getDependencies()) {
+            DependenciesTui.addDeclaredEntry(
+                    declaredGAs,
+                    declared,
+                    dep.getGroupId(),
+                    dep.getArtifactId(),
+                    dep.getClassifier(),
+                    dep.getVersion(),
+                    dep.getScope());
+        }
+
+        DependencyRequest depRequest = new DependencyRequest(MojoHelper.buildCollectRequest(proj), null);
+        DependencyResult depResult = repoSystem.resolveDependencies(repoSession, depRequest);
+
+        Set<String> transitiveGAs = new HashSet<>();
+        List<DependenciesTui.DepEntry> transitive = new ArrayList<>();
+        DependenciesTui.collectTransitive(depResult.getRoot(), declaredGAs, transitiveGAs, transitive);
+
+        Map<String, File> gaToJar = new HashMap<>();
+        for (ArtifactResult ar : depResult.getArtifactResults()) {
+            var art = ar.getArtifact();
+            if (art != null && art.getFile() != null && art.getFile().getName().endsWith(".jar")) {
+                gaToJar.put(art.getGroupId() + ":" + art.getArtifactId(), art.getFile());
+            }
+        }
+
+        Path classesDir = Path.of(proj.getBuild().getOutputDirectory());
+        Path testClassesDir = Path.of(proj.getBuild().getTestOutputDirectory());
+        boolean bytecodeAnalyzed = false;
+
+        if (Files.isDirectory(classesDir)) {
+            bytecodeAnalyzed = true;
+            Set<String> mainRefs = ClassFileScanner.scanDirectory(classesDir);
+            Set<String> testRefs =
+                    Files.isDirectory(testClassesDir) ? ClassFileScanner.scanDirectory(testClassesDir) : Set.of();
+            Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
+            DependencyUsageAnalyzer.AnalysisResult usage =
+                    DependencyUsageAnalyzer.analyze(mainRefs, testRefs, classIndex, gaToJar, declared, transitive);
+            for (var dep : declared) {
+                dep.usageStatus =
+                        usage.declaredUsage().getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
+            }
+            for (var dep : transitive) {
+                dep.usageStatus = usage.transitiveUsage()
+                        .getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
+            }
+        } else {
+            getLog().warn("target/classes not found \u2014 skipping bytecode analysis. Run 'mvn compile' first.");
+        }
+
+        String pomPath = proj.getFile().getAbsolutePath();
+        new DependenciesTui(declared, transitive, pomPath, gavOf(proj), bytecodeAnalyzed).run();
+    }
+
+    // ── pom ─────────────────────────────────────────────────────────────────
+
+    private void runPom(MavenProject proj) throws Exception {
+        File pomFile = proj.getFile();
+        String rawPom = Files.readString(pomFile.toPath());
+        String[] rawLines = rawPom.split("\n");
+
+        StringWriter sw = new StringWriter();
+        new MavenXpp3Writer().write(sw, proj.getModel());
+        String effectivePom = sw.toString();
+
+        Map<String, String[]> parentPomContents = readParentPomContents(proj);
+
+        XmlTreeModel effectiveTree = XmlTreeModel.parse(effectivePom);
+        var originMap = new IdentityHashMap<Node, PomTui.OriginInfo>();
+        attachOrigins(originMap, effectiveTree.root, proj.getModel(), rawLines, parentPomContents);
+
+        new PomTui(rawPom, effectiveTree, originMap, pomFile.getName(), parentPomContents).run();
+    }
+
+    private Map<String, String[]> readParentPomContents(MavenProject proj) {
+        Map<String, String[]> contents = new LinkedHashMap<>();
+        MavenProject current = proj;
+        while (current.getParent() != null) {
+            current = current.getParent();
+            String modelId = current.getGroupId() + ":" + current.getArtifactId() + ":" + current.getVersion();
+            File parentFile = current.getFile();
+
+            if (parentFile == null || !parentFile.exists()) {
+                parentFile = resolveParentPom(current.getGroupId(), current.getArtifactId(), current.getVersion());
+            }
+
+            if (parentFile != null && parentFile.exists()) {
+                try {
+                    contents.put(modelId, Files.readString(parentFile.toPath()).split("\n"));
+                } catch (Exception ignored) {
+                }
+            }
+        }
+        return contents;
+    }
+
+    private File resolveParentPom(String groupId, String artifactId, String version) {
+        try {
+            var artifact = new DefaultArtifact(groupId, artifactId, "pom", version);
+            var request = new ArtifactRequest(artifact, project.getRemoteProjectRepositories(), null);
+            var result = repoSystem.resolveArtifact(repoSession, request);
+            return result.getArtifact().getFile();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private void attachOrigins(
+            IdentityHashMap<Node, PomTui.OriginInfo> map,
+            Element xmlElement,
+            InputLocationTracker tracker,
+            String[] rawLines,
+            Map<String, String[]> parentPomContents) {
+        for (Node child : XmlTreeModel.treeChildren(xmlElement)) {
+            if (!(child instanceof Element childElement)) continue;
+
+            InputLocation loc = tracker.getLocation(childElement.name());
+            if (loc != null) {
+                map.put(childElement, buildOriginInfo(loc, rawLines, parentPomContents));
+            }
+
+            try {
+                String name = childElement.name();
+                String getterName = "get" + Character.toUpperCase(name.charAt(0)) + name.substring(1);
+                Method getter = tracker.getClass().getMethod(getterName);
+                Object value = getter.invoke(tracker);
+
+                if (value instanceof InputLocationTracker subTracker) {
+                    attachOrigins(map, childElement, subTracker, rawLines, parentPomContents);
+                } else if (value instanceof List<?> list) {
+                    int listIdx = 0;
+                    for (Node grandchild : XmlTreeModel.treeChildren(childElement)) {
+                        if (grandchild instanceof Element grandchildElement) {
+                            if (listIdx < list.size()
+                                    && list.get(listIdx) instanceof InputLocationTracker itemTracker) {
+                                InputLocation itemLoc = itemTracker.getLocation("");
+                                if (itemLoc != null) {
+                                    map.put(grandchildElement, buildOriginInfo(itemLoc, rawLines, parentPomContents));
+                                }
+                                attachOrigins(map, grandchildElement, itemTracker, rawLines, parentPomContents);
+                            }
+                            listIdx++;
+                        }
+                    }
+                }
+            } catch (NoSuchMethodException ignored) {
+            } catch (Exception ignored) {
+            }
+        }
+    }
+
+    private PomTui.OriginInfo buildOriginInfo(
+            InputLocation location, String[] rawLines, Map<String, String[]> parentPomContents) {
+        InputSource source = location.getSource();
+        String sourceName = (source != null && source.getModelId() != null) ? source.getModelId() : "this POM";
+        int lineNum = location.getLineNumber();
+
+        String[] sourceLines;
+        if ("this POM".equals(sourceName)) {
+            sourceLines = rawLines;
+        } else if (parentPomContents != null && parentPomContents.containsKey(sourceName)) {
+            sourceLines = parentPomContents.get(sourceName);
+        } else {
+            return new PomTui.OriginInfo(sourceName, lineNum, List.of());
+        }
+
+        return new PomTui.OriginInfo(sourceName, lineNum, buildSnippet(sourceLines, lineNum));
+    }
+
+    private List<String> buildSnippet(String[] lines, int targetLine) {
+        if (targetLine <= 0 || lines == null || lines.length == 0) {
+            return List.of();
+        }
+        List<String> snippet = new ArrayList<>();
+        int start = Math.max(0, targetLine - 3);
+        int end = Math.min(lines.length - 1, targetLine + 1);
+        for (int i = start; i <= end; i++) {
+            String prefix = (i == targetLine - 1) ? "\u2192 " : "  ";
+            String lineNum = String.format("%4d", i + 1);
+            snippet.add(prefix + lineNum + " \u2502 " + lines[i]);
+        }
+        return snippet;
+    }
+
+    // ── align ───────────────────────────────────────────────────────────────
+
+    private void runAlign(MavenProject proj) throws Exception {
+        String pomPath = proj.getFile().getAbsolutePath();
+        String pomContent = Files.readString(Path.of(pomPath));
+        PomEditor editor = new PomEditor(Document.of(pomContent));
+        var detectedOptions = editor.dependencies().detectConventions();
+        new AlignTui(pomPath, gavOf(proj), detectedOptions).run();
+    }
+
+    // ── updates ─────────────────────────────────────────────────────────────
+
+    private void runUpdates(MavenProject proj, List<MavenProject> projects) throws Exception {
+        UpdatesTui.VersionResolver versionResolver = createVersionResolver();
+        if (projects.size() > 1) {
+            ReactorCollector.CollectionResult result = ReactorCollector.collect(projects);
+            ReactorModel reactorModel = ReactorModel.build(projects);
+            String reactorGav = gavOf(projects.get(0));
+            new ReactorUpdatesTui(result, reactorModel, reactorGav, versionResolver).run();
+        } else {
+            List<UpdatesTui.DependencyInfo> dependencies = new ArrayList<>();
+            for (Dependency dep : proj.getDependencies()) {
+                dependencies.add(new UpdatesTui.DependencyInfo(
+                        dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType()));
+            }
+            if (proj.getDependencyManagement() != null) {
+                for (Dependency dep : proj.getDependencyManagement().getDependencies()) {
+                    boolean alreadyListed = dependencies.stream()
+                            .anyMatch(d ->
+                                    d.groupId.equals(dep.getGroupId()) && d.artifactId.equals(dep.getArtifactId()));
+                    if (!alreadyListed) {
+                        var info = new UpdatesTui.DependencyInfo(
+                                dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType());
+                        info.managed = true;
+                        dependencies.add(info);
+                    }
+                }
+            }
+            String pomPath = proj.getFile().getAbsolutePath();
+            new UpdatesTui(dependencies, pomPath, gavOf(proj), versionResolver).run();
+        }
+    }
+
+    private UpdatesTui.VersionResolver createVersionResolver() {
+        return (groupId, artifactId) -> {
+            try {
+                VersionRangeRequest request = new VersionRangeRequest();
+                request.setArtifact(new DefaultArtifact(groupId, artifactId, "jar", "[0,)"));
+                request.setRepositories(project.getRemoteProjectRepositories());
+                VersionRangeResult result = repoSystem.resolveVersionRange(repoSession, request);
+                return UpdatesTui.versionsNewestFirst(result.getVersions());
+            } catch (Exception e) {
+                throw new IllegalStateException("Failed to resolve versions for " + groupId + ":" + artifactId, e);
+            }
+        };
+    }
+
+    // ── conflicts ───────────────────────────────────────────────────────────
+
+    private void runConflicts(MavenProject proj, List<MavenProject> projects) throws Exception {
+        if (projects.size() > 1) {
+            Map<String, List<ConflictsTui.ConflictEntry>> mergedMap = new HashMap<>();
+            for (MavenProject p : projects) {
+                CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(p));
+                List<String> modulePath = new ArrayList<>();
+                modulePath.add("[" + p.getArtifactId() + "]");
+                collectConflicts(result.getRoot(), mergedMap, modulePath);
+            }
+            List<ConflictsTui.ConflictGroup> conflicts = mergedMap.entrySet().stream()
+                    .filter(e -> e.getValue().size() > 1
+                            || e.getValue().stream()
+                                    .anyMatch(c -> c.requestedVersion != null
+                                            && !c.requestedVersion.equals(c.resolvedVersion)))
+                    .map(e -> new ConflictsTui.ConflictGroup(e.getKey(), e.getValue()))
+                    .collect(Collectors.toList());
+            MavenProject root = projects.get(0);
+            String pomPath = root.getFile().getAbsolutePath();
+            String gav = gavOf(root) + " (reactor: " + projects.size() + " modules)";
+            new ConflictsTui(conflicts, pomPath, gav).run();
+        } else {
+            CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
+            Map<String, List<ConflictsTui.ConflictEntry>> conflictMap = new HashMap<>();
+            collectConflicts(result.getRoot(), conflictMap, new ArrayList<>());
+            List<ConflictsTui.ConflictGroup> conflicts = conflictMap.entrySet().stream()
+                    .filter(e -> e.getValue().size() > 1
+                            || e.getValue().stream()
+                                    .anyMatch(c -> c.requestedVersion != null
+                                            && !c.requestedVersion.equals(c.resolvedVersion)))
+                    .map(e -> new ConflictsTui.ConflictGroup(e.getKey(), e.getValue()))
+                    .collect(Collectors.toList());
+            String pomPath = proj.getFile().getAbsolutePath();
+            new ConflictsTui(conflicts, pomPath, gavOf(proj)).run();
+        }
+    }
+
+    private void collectConflicts(
+            DependencyNode node, Map<String, List<ConflictsTui.ConflictEntry>> conflicts, List<String> path) {
+        for (DependencyNode child : node.getChildren()) {
+            if (child.getDependency() == null) continue;
+            var art = child.getDependency().getArtifact();
+            String ga = art.getGroupId() + ":" + art.getArtifactId();
+
+            String requestedVersion = art.getVersion();
+            String resolvedVersion = requestedVersion;
+
+            if (child.getData().get("conflict.originalVersion") instanceof String original) {
+                requestedVersion = original;
+            }
+
+            List<String> currentPath = new ArrayList<>(path);
+            currentPath.add(ga);
+
+            var entry = new ConflictsTui.ConflictEntry(
+                    art.getGroupId(),
+                    art.getArtifactId(),
+                    requestedVersion,
+                    resolvedVersion,
+                    String.join(" \u2192 ", currentPath),
+                    child.getDependency().getScope());
+
+            conflicts.computeIfAbsent(ga, k -> new ArrayList<>()).add(entry);
+            collectConflicts(child, conflicts, currentPath);
+        }
+    }
+
+    // ── audit ───────────────────────────────────────────────────────────────
+
+    private void runAudit(MavenProject proj, List<MavenProject> projects) throws Exception {
+        if (projects.size() > 1) {
+            List<AuditTui.AuditEntry> entries = new ArrayList<>();
+            Set<String> seen = new HashSet<>();
+            for (MavenProject p : projects) {
+                for (var entry : collectAuditEntries(p)) {
+                    if (seen.add(entry.ga())) {
+                        entries.add(entry);
+                    }
+                }
+            }
+            MavenProject root = projects.get(0);
+            String gav = gavOf(root) + " (reactor: " + projects.size() + " modules)";
+            new AuditTui(entries, gav).run();
+        } else {
+            List<AuditTui.AuditEntry> entries = collectAuditEntries(proj);
+            new AuditTui(entries, gavOf(proj)).run();
+        }
+    }
+
+    private List<AuditTui.AuditEntry> collectAuditEntries(MavenProject proj) throws Exception {
+        CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
+        List<AuditTui.AuditEntry> entries = new ArrayList<>();
+        Set<String> seen = new HashSet<>();
+        collectAuditNode(result.getRoot(), entries, seen, true);
+        return entries;
+    }
+
+    private void collectAuditNode(
+            DependencyNode node, List<AuditTui.AuditEntry> entries, Set<String> seen, boolean isRoot) {
+        if (!isRoot && node.getDependency() != null) {
+            var art = node.getDependency().getArtifact();
+            String ga = art.getGroupId() + ":" + art.getArtifactId();
+            if (seen.add(ga)) {
+                entries.add(new AuditTui.AuditEntry(
+                        art.getGroupId(),
+                        art.getArtifactId(),
+                        art.getVersion(),
+                        node.getDependency().getScope()));
+            }
+        }
+        for (DependencyNode child : node.getChildren()) {
+            collectAuditNode(child, entries, seen, false);
+        }
+    }
+
+    // ── utils ───────────────────────────────────────────────────────────────
+
+    private static String gavOf(MavenProject proj) {
+        return proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion();
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
@@ -469,30 +469,29 @@ public class PilotMojo extends AbstractMojo {
 
     private void runAudit(MavenProject proj, List<MavenProject> projects) throws Exception {
         if (projects.size() > 1) {
+            MavenProject root = projects.get(0);
+            CollectResult rootResult =
+                    repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(root));
+            DependencyTreeModel treeModel = DependencyTreeModel.fromDependencyNode(rootResult.getRoot());
+
             List<AuditTui.AuditEntry> entries = new ArrayList<>();
             Set<String> seen = new HashSet<>();
             for (MavenProject p : projects) {
-                for (var entry : collectAuditEntries(p)) {
-                    if (seen.add(entry.ga())) {
-                        entries.add(entry);
-                    }
-                }
+                CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(p));
+                collectAuditNode(result.getRoot(), entries, seen, true);
             }
-            MavenProject root = projects.get(0);
             String gav = gavOf(root) + " (reactor: " + projects.size() + " modules)";
-            new AuditTui(entries, gav).run();
+            String pomPath = root.getFile().getAbsolutePath();
+            new AuditTui(entries, gav, treeModel, pomPath).run();
         } else {
-            List<AuditTui.AuditEntry> entries = collectAuditEntries(proj);
-            new AuditTui(entries, gavOf(proj)).run();
+            CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
+            DependencyTreeModel treeModel = DependencyTreeModel.fromDependencyNode(result.getRoot());
+            List<AuditTui.AuditEntry> entries = new ArrayList<>();
+            Set<String> seen = new HashSet<>();
+            collectAuditNode(result.getRoot(), entries, seen, true);
+            String pomPath = proj.getFile().getAbsolutePath();
+            new AuditTui(entries, gavOf(proj), treeModel, pomPath).run();
         }
-    }
-
-    private List<AuditTui.AuditEntry> collectAuditEntries(MavenProject proj) throws Exception {
-        CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
-        List<AuditTui.AuditEntry> entries = new ArrayList<>();
-        Set<String> seen = new HashSet<>();
-        collectAuditNode(result.getRoot(), entries, seen, true);
-        return entries;
     }
 
     private void collectAuditNode(

--- a/src/main/java/eu/maveniverse/maven/pilot/PomMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PomMojo.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.inject.Inject;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.InputLocation;
 import org.apache.maven.model.InputLocationTracker;
 import org.apache.maven.model.InputSource;
@@ -55,11 +56,14 @@ import org.eclipse.aether.resolution.ArtifactRequest;
  *
  * @since 0.1.0
  */
-@Mojo(name = "pom", requiresProject = true, threadSafe = true)
+@Mojo(name = "pom", requiresProject = true, aggregator = true, threadSafe = true)
 public class PomMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
 
     @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
     private RepositorySystemSession repoSession;
@@ -67,45 +71,54 @@ public class PomMojo extends AbstractMojo {
     @Inject
     private RepositorySystem repoSystem;
 
-    /**
-     * Displays the project's effective POM in an interactive terminal UI annotated with source origins.
-     *
-     * <p>The goal reads the project's POM and its resolved parents, constructs the effective model,
-     * maps XML elements to origin locations (including parent POMs when available), and launches the
-     * PomTui to present the annotated POM to the user.</p>
-     *
-     * @throws MojoExecutionException if the POM cannot be read, parsed, or displayed
-     */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
-            File pomFile = project.getFile();
-            String rawPom = Files.readString(pomFile.toPath());
-            String[] rawLines = rawPom.split("\n");
-
-            // Build effective POM as XML string
-            StringWriter sw = new StringWriter();
-            new MavenXpp3Writer().write(sw, project.getModel());
-            String effectivePom = sw.toString();
-
-            // Read parent POM contents for origin snippets
-            Map<String, String[]> parentPomContents = readParentPomContents();
-
-            // Parse effective POM and attach origins by walking Model + XmlTree in parallel
-            XmlTreeModel effectiveTree = XmlTreeModel.parse(effectivePom);
-            var originMap = new IdentityHashMap<Node, PomTui.OriginInfo>();
-            attachOrigins(originMap, effectiveTree.root, project.getModel(), rawLines, parentPomContents);
-
-            PomTui tui = new PomTui(rawPom, effectiveTree, originMap, pomFile.getName(), parentPomContents);
-            tui.run();
+            List<MavenProject> projects = session.getProjects();
+            if (projects.size() > 1) {
+                executeReactor(projects);
+            } else {
+                executeForProject(project);
+            }
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to display POM: " + e.getMessage(), e);
         }
     }
 
-    private Map<String, String[]> readParentPomContents() {
+    private void executeReactor(List<MavenProject> projects) throws Exception {
+        ReactorModel reactorModel = ReactorModel.build(projects);
+        MavenProject root = projects.get(0);
+        String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
+
+        while (true) {
+            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "pom").pick();
+            if (selected == null) break;
+            executeForProject(selected);
+        }
+    }
+
+    private void executeForProject(MavenProject proj) throws Exception {
+        File pomFile = proj.getFile();
+        String rawPom = Files.readString(pomFile.toPath());
+        String[] rawLines = rawPom.split("\n");
+
+        StringWriter sw = new StringWriter();
+        new MavenXpp3Writer().write(sw, proj.getModel());
+        String effectivePom = sw.toString();
+
+        Map<String, String[]> parentPomContents = readParentPomContents(proj);
+
+        XmlTreeModel effectiveTree = XmlTreeModel.parse(effectivePom);
+        var originMap = new IdentityHashMap<Node, PomTui.OriginInfo>();
+        attachOrigins(originMap, effectiveTree.root, proj.getModel(), rawLines, parentPomContents);
+
+        PomTui tui = new PomTui(rawPom, effectiveTree, originMap, pomFile.getName(), parentPomContents);
+        tui.run();
+    }
+
+    private Map<String, String[]> readParentPomContents(MavenProject proj) {
         Map<String, String[]> contents = new LinkedHashMap<>();
-        MavenProject current = project;
+        MavenProject current = proj;
         while (current.getParent() != null) {
             current = current.getParent();
             String modelId = current.getGroupId() + ":" + current.getArtifactId() + ":" + current.getVersion();

--- a/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
@@ -85,6 +85,8 @@ class PomTui {
     private List<Integer> searchMatches = List.of();
     private int searchMatchIndex = -1;
 
+    private final HelpOverlay helpOverlay = new HelpOverlay();
+
     private TuiRunner runner;
 
     /**
@@ -174,6 +176,15 @@ class PomTui {
 
         if (searchMode) {
             return handleSearchKeys(key);
+        }
+
+        if (helpOverlay.isActive()) {
+            if (helpOverlay.handleKey(key)) return true;
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                runner.quit();
+                return true;
+            }
+            return false;
         }
 
         if (key.isKey(KeyCode.ESCAPE)) {
@@ -268,7 +279,56 @@ class PomTui {
             return true;
         }
 
+        if (key.isCharIgnoreCase('h')) {
+            helpOverlay.open(buildHelp());
+            return true;
+        }
+
         return false;
+    }
+
+    private List<HelpOverlay.Section> buildHelp() {
+        return List.of(
+                new HelpOverlay.Section(
+                        "POM Browser",
+                        List.of(
+                                new HelpOverlay.Entry("", "Browse the project's POM as an expandable XML tree."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "Raw POM: the actual pom.xml file content as written."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "Effective POM: the fully resolved POM after parent"),
+                                new HelpOverlay.Entry("", "inheritance, profile activation, and property"),
+                                new HelpOverlay.Entry("", "interpolation. Shows what Maven actually uses."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "The detail pane (bottom) shows origin info: which"),
+                                new HelpOverlay.Entry("", "POM file defines the selected element (useful for"),
+                                new HelpOverlay.Entry("", "understanding inherited configuration)."))),
+                new HelpOverlay.Section(
+                        "Colors",
+                        List.of(
+                                new HelpOverlay.Entry("cyan", "XML element names"),
+                                new HelpOverlay.Entry("yellow", "Attribute values and search highlights"),
+                                new HelpOverlay.Entry("green", "Search match count indicator"),
+                                new HelpOverlay.Entry("dim", "XML structure characters, metadata"))),
+                new HelpOverlay.Section(
+                        "Navigation",
+                        List.of(
+                                new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("\u2190 / \u2192", "Collapse / expand tree node"),
+                                new HelpOverlay.Entry("e", "Expand all nodes"),
+                                new HelpOverlay.Entry("w", "Collapse all (keeps root expanded)"),
+                                new HelpOverlay.Entry("Tab", "Switch Raw POM / Effective POM"))),
+                new HelpOverlay.Section(
+                        "Search",
+                        List.of(
+                                new HelpOverlay.Entry("/", "Enter search mode \u2014 type to search"),
+                                new HelpOverlay.Entry("n / N", "Next / previous search match"),
+                                new HelpOverlay.Entry("Esc", "Clear search or quit"))),
+                new HelpOverlay.Section(
+                        "General",
+                        List.of(
+                                new HelpOverlay.Entry("h", "Toggle this help screen"),
+                                new HelpOverlay.Entry("q / Esc", "Quit"))));
     }
 
     private boolean handleSearchKeys(KeyEvent key) {
@@ -387,7 +447,11 @@ class PomTui {
 
         int idx = 0;
         renderHeader(frame, zones.get(idx++));
-        renderXmlTree(frame, zones.get(idx++));
+        if (helpOverlay.isActive()) {
+            helpOverlay.render(frame, zones.get(idx++));
+        } else {
+            renderXmlTree(frame, zones.get(idx++));
+        }
         if (showDetail) {
             idx++; // skip spacer
             renderOriginDetail(frame, zones.get(idx++), snippet);
@@ -543,6 +607,8 @@ class PomTui {
             spans.add(Span.raw(":Search  "));
             spans.add(Span.raw("e/w").bold());
             spans.add(Span.raw(":Expand/Collapse all  "));
+            spans.add(Span.raw("h").bold());
+            spans.add(Span.raw(":Help  "));
             spans.add(Span.raw("q").bold());
             spans.add(Span.raw(":Quit"));
         }

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Collects and aggregates dependencies across all reactor modules.
+ *
+ * <p>Deduplicates by groupId:artifactId, tracks which modules use each dependency,
+ * detects property-based version expressions, and identifies which POM defines the property.</p>
+ */
+class ReactorCollector {
+
+    private static final Pattern PROPERTY_PATTERN = Pattern.compile("\\$\\{(.+?)\\}");
+
+    static class ModuleUsage {
+        final MavenProject project;
+        final String version;
+        final String scope;
+        final boolean managed;
+
+        ModuleUsage(MavenProject project, String version, String scope, boolean managed) {
+            this.project = project;
+            this.version = version;
+            this.scope = scope;
+            this.managed = managed;
+        }
+    }
+
+    static class AggregatedDependency {
+        final String groupId;
+        final String artifactId;
+        final List<ModuleUsage> usages = new ArrayList<>();
+        String primaryVersion;
+        String rawVersionExpr;
+        String propertyName;
+        MavenProject propertyOrigin;
+
+        String newestVersion;
+        VersionComparator.UpdateType updateType;
+        boolean selected;
+
+        AggregatedDependency(String groupId, String artifactId) {
+            this.groupId = groupId;
+            this.artifactId = artifactId;
+        }
+
+        String ga() {
+            return groupId + ":" + artifactId;
+        }
+
+        boolean hasUpdate() {
+            return newestVersion != null && !newestVersion.equals(primaryVersion) && !newestVersion.isEmpty();
+        }
+
+        boolean isPropertyManaged() {
+            return propertyName != null;
+        }
+
+        int moduleCount() {
+            return usages.size();
+        }
+    }
+
+    static class PropertyGroup {
+        final String propertyName;
+        final String rawExpression;
+        String resolvedVersion;
+        final MavenProject origin;
+        final List<AggregatedDependency> dependencies = new ArrayList<>();
+
+        String newestVersion;
+        VersionComparator.UpdateType updateType;
+        boolean selected;
+
+        PropertyGroup(String propertyName, String rawExpression, String resolvedVersion, MavenProject origin) {
+            this.propertyName = propertyName;
+            this.rawExpression = rawExpression;
+            this.resolvedVersion = resolvedVersion;
+            this.origin = origin;
+        }
+
+        boolean hasUpdate() {
+            return newestVersion != null && !newestVersion.equals(resolvedVersion) && !newestVersion.isEmpty();
+        }
+
+        int totalModuleCount() {
+            return dependencies.stream()
+                    .mapToInt(AggregatedDependency::moduleCount)
+                    .max()
+                    .orElse(0);
+        }
+    }
+
+    static class CollectionResult {
+        final List<AggregatedDependency> allDependencies;
+        final List<PropertyGroup> propertyGroups;
+        final List<AggregatedDependency> ungroupedDependencies;
+
+        CollectionResult(
+                List<AggregatedDependency> allDependencies,
+                List<PropertyGroup> propertyGroups,
+                List<AggregatedDependency> ungroupedDependencies) {
+            this.allDependencies = allDependencies;
+            this.propertyGroups = propertyGroups;
+            this.ungroupedDependencies = ungroupedDependencies;
+        }
+    }
+
+    static CollectionResult collect(List<MavenProject> projects) {
+        Map<String, AggregatedDependency> byGA = new LinkedHashMap<>();
+
+        for (MavenProject project : projects) {
+            collectFromProject(project, byGA);
+        }
+
+        List<AggregatedDependency> allDeps = new ArrayList<>(byGA.values());
+
+        Map<String, PropertyGroup> groupsByProperty = new LinkedHashMap<>();
+        List<AggregatedDependency> ungrouped = new ArrayList<>();
+
+        for (AggregatedDependency dep : allDeps) {
+            if (dep.isPropertyManaged()) {
+                PropertyGroup group = groupsByProperty.computeIfAbsent(
+                        dep.propertyName,
+                        k -> new PropertyGroup(
+                                dep.propertyName, dep.rawVersionExpr, dep.primaryVersion, dep.propertyOrigin));
+                group.dependencies.add(dep);
+            } else {
+                ungrouped.add(dep);
+            }
+        }
+
+        return new CollectionResult(allDeps, new ArrayList<>(groupsByProperty.values()), ungrouped);
+    }
+
+    private static void collectFromProject(MavenProject project, Map<String, AggregatedDependency> byGA) {
+        DependencyManagement mgmt = project.getDependencyManagement();
+        DependencyManagement originalMgmt = project.getOriginalModel().getDependencyManagement();
+        if (mgmt != null && mgmt.getDependencies() != null) {
+            List<Dependency> originalMgmtDeps = originalMgmt != null && originalMgmt.getDependencies() != null
+                    ? originalMgmt.getDependencies()
+                    : List.of();
+
+            for (Dependency dep : mgmt.getDependencies()) {
+                String ga = dep.getGroupId() + ":" + dep.getArtifactId();
+                AggregatedDependency agg =
+                        byGA.computeIfAbsent(ga, k -> new AggregatedDependency(dep.getGroupId(), dep.getArtifactId()));
+
+                agg.usages.add(new ModuleUsage(project, dep.getVersion(), dep.getScope(), true));
+
+                if (agg.primaryVersion == null) {
+                    agg.primaryVersion = dep.getVersion();
+                }
+
+                if (agg.rawVersionExpr == null) {
+                    detectPropertyVersion(agg, dep, originalMgmtDeps, project);
+                }
+            }
+        }
+
+        List<Dependency> originalDeps = project.getOriginalModel().getDependencies() != null
+                ? project.getOriginalModel().getDependencies()
+                : List.of();
+
+        for (Dependency dep : project.getDependencies()) {
+            String ga = dep.getGroupId() + ":" + dep.getArtifactId();
+            AggregatedDependency agg =
+                    byGA.computeIfAbsent(ga, k -> new AggregatedDependency(dep.getGroupId(), dep.getArtifactId()));
+
+            boolean alreadyTracked = agg.usages.stream().anyMatch(u -> u.project == project);
+            if (!alreadyTracked) {
+                agg.usages.add(new ModuleUsage(project, dep.getVersion(), dep.getScope(), false));
+            }
+
+            if (agg.primaryVersion == null) {
+                agg.primaryVersion = dep.getVersion();
+            }
+
+            if (agg.rawVersionExpr == null) {
+                detectPropertyVersion(agg, dep, originalDeps, project);
+            }
+        }
+    }
+
+    private static void detectPropertyVersion(
+            AggregatedDependency agg, Dependency resolvedDep, List<Dependency> originalDeps, MavenProject project) {
+        String rawVersion = null;
+        for (Dependency orig : originalDeps) {
+            if (orig.getGroupId().equals(resolvedDep.getGroupId())
+                    && orig.getArtifactId().equals(resolvedDep.getArtifactId())) {
+                rawVersion = orig.getVersion();
+                break;
+            }
+        }
+
+        if (rawVersion == null) {
+            return;
+        }
+
+        Matcher matcher = PROPERTY_PATTERN.matcher(rawVersion);
+        if (matcher.matches()) {
+            String propertyName = matcher.group(1);
+            agg.rawVersionExpr = rawVersion;
+            agg.propertyName = propertyName;
+            agg.propertyOrigin = findPropertyOrigin(project, propertyName);
+        }
+    }
+
+    private static MavenProject findPropertyOrigin(MavenProject project, String propertyName) {
+        MavenProject current = project;
+        while (current != null) {
+            Properties props = current.getOriginalModel().getProperties();
+            if (props != null && props.containsKey(propertyName)) {
+                return current;
+            }
+            current = current.getParent();
+        }
+        return project;
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
@@ -146,9 +146,11 @@ class ReactorCollector {
         List<AggregatedDependency> ungrouped = new ArrayList<>();
 
         for (AggregatedDependency dep : allDeps) {
-            if (dep.isPropertyManaged()) {
+            if (dep.isPropertyManaged() && dep.propertyOrigin != null) {
+                String groupKey =
+                        dep.propertyName + "@" + dep.propertyOrigin.getFile().getAbsolutePath();
                 PropertyGroup group = groupsByProperty.computeIfAbsent(
-                        dep.propertyName,
+                        groupKey,
                         k -> new PropertyGroup(
                                 dep.propertyName, dep.rawVersionExpr, dep.primaryVersion, dep.propertyOrigin));
                 group.dependencies.add(dep);
@@ -242,6 +244,6 @@ class ReactorCollector {
             }
             current = current.getParent();
         }
-        return project;
+        return null;
     }
 }

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorModel.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorModel.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Tree model representing the reactor module hierarchy.
+ *
+ * <p>Built from {@code MavenSession.getProjects()}, this model mirrors the
+ * {@code <modules>} structure of the reactor. Each node tracks its own
+ * update count and the total (own + descendants) for display as {@code "3/12"}.</p>
+ */
+class ReactorModel {
+
+    static class ModuleNode {
+        final MavenProject project;
+        final String name;
+        final String pomPath;
+        final int depth;
+        final List<ModuleNode> children = new ArrayList<>();
+        boolean expanded;
+        int ownUpdateCount;
+        int totalUpdateCount;
+
+        ModuleNode(MavenProject project, int depth) {
+            this.project = project;
+            this.name = project.getArtifactId();
+            this.pomPath = project.getFile().getAbsolutePath();
+            this.depth = depth;
+            this.expanded = depth < 2;
+        }
+
+        boolean hasChildren() {
+            return !children.isEmpty();
+        }
+
+        boolean isLeaf() {
+            return children.isEmpty();
+        }
+
+        String ga() {
+            return project.getGroupId() + ":" + project.getArtifactId();
+        }
+
+        String gav() {
+            return project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
+        }
+    }
+
+    final ModuleNode root;
+    final List<ModuleNode> allModules;
+
+    ReactorModel(ModuleNode root, List<ModuleNode> allModules) {
+        this.root = root;
+        this.allModules = allModules;
+    }
+
+    /**
+     * Build a reactor model from the session's project list.
+     *
+     * <p>The tree is constructed by matching each project's basedir to its parent
+     * project's basedir. The first project in the list is assumed to be the root
+     * (top-level project).</p>
+     */
+    static ReactorModel build(List<MavenProject> reactorProjects) {
+        if (reactorProjects.isEmpty()) {
+            throw new IllegalArgumentException("No projects in reactor");
+        }
+
+        List<ModuleNode> allModules = new ArrayList<>();
+        Map<File, ModuleNode> byBasedir = new LinkedHashMap<>();
+
+        MavenProject rootProject = reactorProjects.get(0);
+        ModuleNode rootNode = new ModuleNode(rootProject, 0);
+        byBasedir.put(canonicalBasedir(rootProject), rootNode);
+        allModules.add(rootNode);
+
+        for (int i = 1; i < reactorProjects.size(); i++) {
+            MavenProject project = reactorProjects.get(i);
+            File basedir = canonicalBasedir(project);
+
+            ModuleNode parent = findParentNode(project, byBasedir);
+            int depth = parent != null ? parent.depth + 1 : 1;
+
+            ModuleNode node = new ModuleNode(project, depth);
+            byBasedir.put(basedir, node);
+            allModules.add(node);
+
+            if (parent != null) {
+                parent.children.add(node);
+            } else {
+                rootNode.children.add(node);
+            }
+        }
+
+        return new ReactorModel(rootNode, allModules);
+    }
+
+    /**
+     * Returns the flattened list of visible nodes respecting expand/collapse state.
+     */
+    List<ModuleNode> visibleNodes() {
+        List<ModuleNode> visible = new ArrayList<>();
+        collectVisible(root, visible);
+        return visible;
+    }
+
+    private void collectVisible(ModuleNode node, List<ModuleNode> visible) {
+        visible.add(node);
+        if (node.expanded) {
+            for (ModuleNode child : node.children) {
+                collectVisible(child, visible);
+            }
+        }
+    }
+
+    /**
+     * Filter modules by name substring (case-insensitive).
+     */
+    List<ModuleNode> filter(String query) {
+        String lowerQuery = query.toLowerCase(Locale.ROOT);
+        List<ModuleNode> result = new ArrayList<>();
+        filterNode(root, lowerQuery, result);
+        return result;
+    }
+
+    private void filterNode(ModuleNode node, String query, List<ModuleNode> result) {
+        if (node.name.toLowerCase(Locale.ROOT).contains(query)
+                || node.ga().toLowerCase(Locale.ROOT).contains(query)) {
+            result.add(node);
+        }
+        for (ModuleNode child : node.children) {
+            filterNode(child, query, result);
+        }
+    }
+
+    /**
+     * Recompute totalUpdateCount for all nodes bottom-up.
+     */
+    void recomputeCounts() {
+        recomputeCounts(root);
+    }
+
+    private int recomputeCounts(ModuleNode node) {
+        int total = node.ownUpdateCount;
+        for (ModuleNode child : node.children) {
+            total += recomputeCounts(child);
+        }
+        node.totalUpdateCount = total;
+        return total;
+    }
+
+    private static ModuleNode findParentNode(MavenProject project, Map<File, ModuleNode> byBasedir) {
+        File basedir = canonicalBasedir(project);
+        File parentDir = basedir.getParentFile();
+
+        while (parentDir != null) {
+            ModuleNode parent = byBasedir.get(parentDir);
+            if (parent != null) {
+                return parent;
+            }
+            parentDir = parentDir.getParentFile();
+        }
+
+        return null;
+    }
+
+    private static File canonicalBasedir(MavenProject project) {
+        try {
+            return project.getBasedir().getCanonicalFile();
+        } catch (Exception e) {
+            return project.getBasedir().getAbsoluteFile();
+        }
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -47,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -101,11 +100,14 @@ class ReactorUpdatesTui {
     private final UpdatesTui.VersionResolver versionResolver;
     private final TableState tableState = new TableState();
     private final TableState moduleTableState = new TableState();
-    private final ExecutorService httpPool = Executors.newFixedThreadPool(8);
+    private final ExecutorService httpPool = MojoHelper.newHttpPool();
 
     private View view = View.DEPENDENCIES;
     private List<ReactorRow> displayRows = new ArrayList<>();
     private Filter filter = Filter.ALL;
+    private final DiffOverlay diffOverlay = new DiffOverlay();
+    private final HelpOverlay helpOverlay = new HelpOverlay();
+    private int lastContentHeight;
     String status = "Loading updates\u2026";
     boolean loading = true;
     int loadedCount = 0;
@@ -274,6 +276,30 @@ class ReactorUpdatesTui {
             return true;
         }
 
+        // Diff overlay mode
+        if (diffOverlay.isActive()) {
+            if (key.isKey(KeyCode.ESCAPE)) {
+                diffOverlay.close();
+                return true;
+            }
+            if (diffOverlay.handleScrollKey(key, lastContentHeight)) return true;
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                runner.quit();
+                return true;
+            }
+            return false;
+        }
+
+        // Help overlay mode
+        if (helpOverlay.isActive()) {
+            if (helpOverlay.handleKey(key)) return true;
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                runner.quit();
+                return true;
+            }
+            return false;
+        }
+
         if (key.isCtrlC() || key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
             runner.quit();
             return true;
@@ -312,6 +338,10 @@ class ReactorUpdatesTui {
             deselectAll();
             return true;
         }
+        if (key.isCharIgnoreCase('d')) {
+            toggleDiffView();
+            return true;
+        }
         if (key.isKey(KeyCode.ENTER)) {
             applyUpdates();
             return true;
@@ -334,6 +364,10 @@ class ReactorUpdatesTui {
         if (key.isCharIgnoreCase('4')) {
             filter = Filter.MAJOR;
             buildDisplayRows();
+            return true;
+        }
+        if (key.isCharIgnoreCase('h')) {
+            helpOverlay.open(buildHelp());
             return true;
         }
         return false;
@@ -368,6 +402,10 @@ class ReactorUpdatesTui {
                     node.expanded = false;
                 }
             }
+            return true;
+        }
+        if (key.isCharIgnoreCase('h')) {
+            helpOverlay.open(buildHelp());
             return true;
         }
         return false;
@@ -427,6 +465,79 @@ class ReactorUpdatesTui {
         for (var dep : reactorResult.ungroupedDependencies) {
             dep.selected = false;
         }
+    }
+
+    // -- Diff preview --
+
+    private void toggleDiffView() {
+        Map<String, Map.Entry<String, String>> fileDiffs = new LinkedHashMap<>();
+
+        // Build preview editors for all affected POMs
+        Map<Path, PomEditor> previewEditors = new LinkedHashMap<>();
+
+        for (var group : reactorResult.propertyGroups) {
+            if (group.selected && group.hasUpdate()) {
+                Path pomPath = group.origin.getFile().toPath();
+                PomEditor editor = previewEditors.computeIfAbsent(pomPath, p -> {
+                    try {
+                        return new PomEditor(Document.of(Files.readString(p)));
+                    } catch (Exception e) {
+                        throw new IllegalStateException("Cannot read POM: " + p, e);
+                    }
+                });
+                editor.properties().updateProperty(true, group.propertyName, group.newestVersion);
+            }
+        }
+
+        for (var dep : reactorResult.ungroupedDependencies) {
+            if (dep.selected && dep.hasUpdate() && !dep.usages.isEmpty()) {
+                var managedUsage = dep.usages.stream().filter(u -> u.managed).findFirst();
+                Path pomPath;
+                boolean managed;
+                if (managedUsage.isPresent()) {
+                    pomPath = managedUsage.orElseThrow().project.getFile().toPath();
+                    managed = true;
+                } else {
+                    pomPath = dep.usages.get(0).project.getFile().toPath();
+                    managed = false;
+                }
+                PomEditor editor = previewEditors.computeIfAbsent(pomPath, p -> {
+                    try {
+                        return new PomEditor(Document.of(Files.readString(p)));
+                    } catch (Exception e) {
+                        throw new IllegalStateException("Cannot read POM: " + p, e);
+                    }
+                });
+                var coords =
+                        eu.maveniverse.domtrip.maven.Coordinates.of(dep.groupId, dep.artifactId, dep.newestVersion);
+                if (managed) {
+                    editor.dependencies().updateManagedDependency(true, coords);
+                } else {
+                    editor.dependencies().updateDependency(true, coords);
+                }
+            }
+        }
+
+        if (previewEditors.isEmpty()) {
+            status = "No updates selected";
+            return;
+        }
+
+        for (var entry : previewEditors.entrySet()) {
+            try {
+                String original = Files.readString(entry.getKey());
+                String modified = entry.getValue().toXml();
+                fileDiffs.put(entry.getKey().getFileName().toString(), Map.entry(original, modified));
+            } catch (Exception e) {
+                status = "Failed to compute diff: " + e.getMessage();
+                return;
+            }
+        }
+
+        long changes = diffOverlay.openMulti(fileDiffs);
+        status = changes == 0
+                ? "No changes to show"
+                : changes + " line(s) changed across " + fileDiffs.size() + " file(s)";
     }
 
     // -- Apply --
@@ -558,7 +669,12 @@ class ReactorUpdatesTui {
                 .split(frame.area());
 
         renderHeader(frame, zones.get(0));
-        if (view == View.DEPENDENCIES) {
+        lastContentHeight = zones.get(1).height();
+        if (helpOverlay.isActive()) {
+            helpOverlay.render(frame, zones.get(1));
+        } else if (diffOverlay.isActive()) {
+            diffOverlay.render(frame, zones.get(1), " POM Changes ");
+        } else if (view == View.DEPENDENCIES) {
             renderDepsTable(frame, zones.get(1));
         } else {
             renderModulesTable(frame, zones.get(1));
@@ -780,30 +896,92 @@ class ReactorUpdatesTui {
         // Key bindings
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" "));
-        spans.add(Span.raw("Tab").bold());
-        spans.add(Span.raw(":View  "));
-        if (view == View.DEPENDENCIES) {
+        if (diffOverlay.isActive()) {
             spans.add(Span.raw("\u2191\u2193").bold());
-            spans.add(Span.raw(":Nav  "));
-            spans.add(Span.raw("Space").bold());
-            spans.add(Span.raw(":Toggle  "));
-            spans.add(Span.raw("a").bold());
-            spans.add(Span.raw(":All  "));
-            spans.add(Span.raw("n").bold());
-            spans.add(Span.raw(":None  "));
-            spans.add(Span.raw("Enter").bold());
-            spans.add(Span.raw(":Apply  "));
-            spans.add(Span.raw("1-4").bold());
-            spans.add(Span.raw(":Filter  "));
+            spans.add(Span.raw(":Scroll  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Close  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
         } else {
-            spans.add(Span.raw("\u2191\u2193").bold());
-            spans.add(Span.raw(":Nav  "));
-            spans.add(Span.raw("\u2190\u2192").bold());
-            spans.add(Span.raw(":Expand  "));
+            spans.add(Span.raw("Tab").bold());
+            spans.add(Span.raw(":View  "));
+            if (view == View.DEPENDENCIES) {
+                spans.add(Span.raw("\u2191\u2193").bold());
+                spans.add(Span.raw(":Nav  "));
+                spans.add(Span.raw("Space").bold());
+                spans.add(Span.raw(":Toggle  "));
+                spans.add(Span.raw("a").bold());
+                spans.add(Span.raw(":All  "));
+                spans.add(Span.raw("n").bold());
+                spans.add(Span.raw(":None  "));
+                spans.add(Span.raw("d").bold());
+                spans.add(Span.raw(":Diff  "));
+                spans.add(Span.raw("Enter").bold());
+                spans.add(Span.raw(":Apply  "));
+                spans.add(Span.raw("1-4").bold());
+                spans.add(Span.raw(":Filter  "));
+                spans.add(Span.raw("h").bold());
+                spans.add(Span.raw(":Help  "));
+            } else {
+                spans.add(Span.raw("\u2191\u2193").bold());
+                spans.add(Span.raw(":Nav  "));
+                spans.add(Span.raw("\u2190\u2192").bold());
+                spans.add(Span.raw(":Expand  "));
+                spans.add(Span.raw("h").bold());
+                spans.add(Span.raw(":Help  "));
+            }
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
         }
-        spans.add(Span.raw("q").bold());
-        spans.add(Span.raw(":Quit"));
 
         frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(3));
+    }
+
+    private List<HelpOverlay.Section> buildHelp() {
+        return List.of(
+                new HelpOverlay.Section(
+                        "Reactor Dependency Updates",
+                        List.of(
+                                new HelpOverlay.Entry("", "Aggregates dependency updates across all reactor"),
+                                new HelpOverlay.Entry("", "modules. Dependencies managed via properties (e.g."),
+                                new HelpOverlay.Entry("", "${jackson.version}) are grouped together \u2014 selecting"),
+                                new HelpOverlay.Entry("", "the group header toggles all dependencies in it."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "The 'N mod' column shows how many reactor modules"),
+                                new HelpOverlay.Entry("", "use each dependency. 'M' indicates a managed"),
+                                new HelpOverlay.Entry("", "dependency (from dependencyManagement)."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "When you apply updates, property-based deps edit"),
+                                new HelpOverlay.Entry("", "the <properties> in the POM that defines them;"),
+                                new HelpOverlay.Entry("", "direct deps edit the module's own POM."))),
+                new HelpOverlay.Section(
+                        "Colors",
+                        List.of(
+                                new HelpOverlay.Entry("green", "Patch update \u2014 bug fixes, safe to apply"),
+                                new HelpOverlay.Entry("yellow", "Minor update \u2014 new features, usually compatible"),
+                                new HelpOverlay.Entry("red", "Major update \u2014 breaking changes possible"),
+                                new HelpOverlay.Entry("cyan", "Property group header (${property.name})"))),
+                new HelpOverlay.Section(
+                        "Dependencies View",
+                        List.of(
+                                new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("Space", "Toggle selection (group or individual)"),
+                                new HelpOverlay.Entry("a / n", "Select all / deselect all"),
+                                new HelpOverlay.Entry("Enter", "Apply selected updates to POM files"),
+                                new HelpOverlay.Entry("1-4", "Filter: all / patch / minor / major"),
+                                new HelpOverlay.Entry("d", "Preview changes as a multi-file diff"))),
+                new HelpOverlay.Section(
+                        "Modules View",
+                        List.of(
+                                new HelpOverlay.Entry("", "Shows the reactor module tree with update counts."),
+                                new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("\u2190 / \u2192", "Collapse / expand module tree"))),
+                new HelpOverlay.Section(
+                        "General",
+                        List.of(
+                                new HelpOverlay.Entry("Tab", "Switch Dependencies / Modules view"),
+                                new HelpOverlay.Entry("h", "Toggle this help screen"),
+                                new HelpOverlay.Entry("q / Esc", "Quit"))));
     }
 }

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -1,0 +1,782 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.tui.TuiRunner;
+import dev.tamboui.tui.event.Event;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import dev.tamboui.widgets.table.Row;
+import dev.tamboui.widgets.table.Table;
+import dev.tamboui.widgets.table.TableState;
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.maven.PomEditor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Interactive TUI for viewing and applying dependency updates across a multi-module reactor.
+ *
+ * <p>Provides two views switchable via Tab:</p>
+ * <ul>
+ *   <li><b>Dependencies</b> — aggregated list grouped by shared version property</li>
+ *   <li><b>Modules</b> — reactor tree with per-module update counts</li>
+ * </ul>
+ */
+class ReactorUpdatesTui {
+
+    private enum View {
+        DEPENDENCIES,
+        MODULES
+    }
+
+    private enum Filter {
+        ALL,
+        PATCH,
+        MINOR,
+        MAJOR
+    }
+
+    private static class ReactorRow {
+        final ReactorCollector.PropertyGroup propertyGroup;
+        final ReactorCollector.AggregatedDependency dependency;
+
+        private ReactorRow(ReactorCollector.PropertyGroup pg, ReactorCollector.AggregatedDependency dep) {
+            this.propertyGroup = pg;
+            this.dependency = dep;
+        }
+
+        static ReactorRow group(ReactorCollector.PropertyGroup pg) {
+            return new ReactorRow(pg, null);
+        }
+
+        static ReactorRow dep(ReactorCollector.AggregatedDependency dep) {
+            return new ReactorRow(null, dep);
+        }
+
+        boolean isGroupHeader() {
+            return propertyGroup != null;
+        }
+    }
+
+    private final ReactorCollector.CollectionResult reactorResult;
+    private final ReactorModel reactorModel;
+    private final String projectGav;
+    private final UpdatesTui.VersionResolver versionResolver;
+    private final TableState tableState = new TableState();
+    private final TableState moduleTableState = new TableState();
+    private final ExecutorService httpPool = Executors.newFixedThreadPool(8);
+
+    private View view = View.DEPENDENCIES;
+    private List<ReactorRow> displayRows = new ArrayList<>();
+    private Filter filter = Filter.ALL;
+    String status = "Loading updates\u2026";
+    boolean loading = true;
+    int loadedCount = 0;
+    int failedCount = 0;
+
+    private TuiRunner runner;
+
+    ReactorUpdatesTui(
+            ReactorCollector.CollectionResult result,
+            ReactorModel reactorModel,
+            String projectGav,
+            UpdatesTui.VersionResolver versionResolver) {
+        this.reactorResult = result;
+        this.reactorModel = reactorModel;
+        this.projectGav = projectGav;
+        this.versionResolver = versionResolver;
+        if (!reactorModel.allModules.isEmpty()) {
+            moduleTableState.select(0);
+        }
+    }
+
+    void run() throws Exception {
+        var configured = TuiRunner.builder()
+                .eventHandler(this::handleEvent)
+                .renderer(this::render)
+                .tickRate(Duration.ofMillis(100))
+                .build();
+        try {
+            runner = configured.runner();
+            fetchAllUpdates();
+            configured.run();
+        } finally {
+            configured.close();
+            httpPool.shutdownNow();
+            httpPool.awaitTermination(5, TimeUnit.SECONDS);
+        }
+    }
+
+    // -- Version resolution --
+
+    private void fetchAllUpdates() {
+        for (var dep : reactorResult.allDependencies) {
+            CompletableFuture.supplyAsync(() -> versionResolver.resolveVersions(dep.groupId, dep.artifactId), httpPool)
+                    .thenAccept(versions -> runner.runOnRenderThread(() -> {
+                        applyVersionResult(dep, versions);
+                        loadedCount++;
+                        updateStatusIfDone();
+                    }))
+                    .exceptionally(ex -> {
+                        runner.runOnRenderThread(() -> {
+                            loadedCount++;
+                            failedCount++;
+                            updateStatusIfDone();
+                        });
+                        return null;
+                    });
+        }
+    }
+
+    private void applyVersionResult(ReactorCollector.AggregatedDependency dep, List<String> versions) {
+        String newest = null;
+        for (String v : versions) {
+            if (VersionComparator.isPreview(v)) continue;
+            if (dep.primaryVersion == null
+                    || dep.primaryVersion.isEmpty()
+                    || VersionComparator.isNewer(dep.primaryVersion, v)) {
+                newest = v;
+                break;
+            }
+        }
+        if (newest != null) {
+            dep.newestVersion = newest;
+            dep.updateType = VersionComparator.classify(dep.primaryVersion, newest);
+        }
+    }
+
+    private void updateStatusIfDone() {
+        if (loadedCount >= reactorResult.allDependencies.size()) {
+            loading = false;
+            for (var group : reactorResult.propertyGroups) {
+                for (var dep : group.dependencies) {
+                    if (dep.hasUpdate() && group.newestVersion == null) {
+                        group.newestVersion = dep.newestVersion;
+                        group.updateType = dep.updateType;
+                    }
+                }
+            }
+            updateReactorCounts();
+            buildDisplayRows();
+            long updates = reactorResult.allDependencies.stream()
+                    .filter(ReactorCollector.AggregatedDependency::hasUpdate)
+                    .count();
+            status = updates + " update(s) available across " + reactorModel.allModules.size() + " modules";
+            if (failedCount > 0) {
+                status += "; " + failedCount + " lookup(s) failed";
+            }
+        }
+    }
+
+    private void updateReactorCounts() {
+        Map<String, Integer> countsByModule = new LinkedHashMap<>();
+        for (var dep : reactorResult.allDependencies) {
+            if (dep.hasUpdate()) {
+                for (var usage : dep.usages) {
+                    String ga = usage.project.getGroupId() + ":" + usage.project.getArtifactId();
+                    countsByModule.merge(ga, 1, Integer::sum);
+                }
+            }
+        }
+        for (var node : reactorModel.allModules) {
+            Integer count = countsByModule.get(node.ga());
+            node.ownUpdateCount = count != null ? count : 0;
+        }
+        reactorModel.recomputeCounts();
+    }
+
+    private void buildDisplayRows() {
+        displayRows = new ArrayList<>();
+        for (var group : reactorResult.propertyGroups) {
+            boolean groupHasUpdate = group.hasUpdate()
+                    || group.dependencies.stream().anyMatch(ReactorCollector.AggregatedDependency::hasUpdate);
+            if (filter != Filter.ALL) {
+                groupHasUpdate = matchesFilter(group.updateType);
+            }
+            if (groupHasUpdate) {
+                displayRows.add(ReactorRow.group(group));
+                for (var dep : group.dependencies) {
+                    displayRows.add(ReactorRow.dep(dep));
+                }
+            }
+        }
+        for (var dep : reactorResult.ungroupedDependencies) {
+            boolean show =
+                    switch (filter) {
+                        case ALL -> dep.hasUpdate();
+                        case PATCH -> dep.updateType == VersionComparator.UpdateType.PATCH;
+                        case MINOR -> dep.updateType == VersionComparator.UpdateType.MINOR;
+                        case MAJOR -> dep.updateType == VersionComparator.UpdateType.MAJOR;
+                    };
+            if (show) {
+                displayRows.add(ReactorRow.dep(dep));
+            }
+        }
+        if (!displayRows.isEmpty()) {
+            tableState.select(0);
+        }
+    }
+
+    private boolean matchesFilter(VersionComparator.UpdateType type) {
+        return switch (filter) {
+            case ALL -> true;
+            case PATCH -> type == VersionComparator.UpdateType.PATCH;
+            case MINOR -> type == VersionComparator.UpdateType.MINOR;
+            case MAJOR -> type == VersionComparator.UpdateType.MAJOR;
+        };
+    }
+
+    // -- Event handling --
+
+    boolean handleEvent(Event event, TuiRunner runner) {
+        if (!(event instanceof KeyEvent key)) {
+            return true;
+        }
+
+        if (key.isCtrlC() || key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
+            runner.quit();
+            return true;
+        }
+
+        if (key.isKey(KeyCode.TAB)) {
+            view = view == View.DEPENDENCIES ? View.MODULES : View.DEPENDENCIES;
+            return true;
+        }
+
+        if (view == View.DEPENDENCIES) {
+            return handleDepsEvent(key);
+        } else {
+            return handleModulesEvent(key);
+        }
+    }
+
+    private boolean handleDepsEvent(KeyEvent key) {
+        if (key.isUp()) {
+            tableState.selectPrevious();
+            return true;
+        }
+        if (key.isDown()) {
+            tableState.selectNext(displayRows.size());
+            return true;
+        }
+        if (key.isCharIgnoreCase(' ')) {
+            toggleSelection();
+            return true;
+        }
+        if (key.isCharIgnoreCase('a')) {
+            selectAll();
+            return true;
+        }
+        if (key.isCharIgnoreCase('n')) {
+            deselectAll();
+            return true;
+        }
+        if (key.isKey(KeyCode.ENTER)) {
+            applyUpdates();
+            return true;
+        }
+        if (key.isCharIgnoreCase('1')) {
+            filter = Filter.ALL;
+            buildDisplayRows();
+            return true;
+        }
+        if (key.isCharIgnoreCase('2')) {
+            filter = Filter.PATCH;
+            buildDisplayRows();
+            return true;
+        }
+        if (key.isCharIgnoreCase('3')) {
+            filter = Filter.MINOR;
+            buildDisplayRows();
+            return true;
+        }
+        if (key.isCharIgnoreCase('4')) {
+            filter = Filter.MAJOR;
+            buildDisplayRows();
+            return true;
+        }
+        return false;
+    }
+
+    private boolean handleModulesEvent(KeyEvent key) {
+        List<ReactorModel.ModuleNode> visible = reactorModel.visibleNodes();
+
+        if (key.isUp()) {
+            moduleTableState.selectPrevious();
+            return true;
+        }
+        if (key.isDown()) {
+            moduleTableState.selectNext(visible.size());
+            return true;
+        }
+        if (key.isKey(KeyCode.ENTER) || key.isKey(KeyCode.RIGHT)) {
+            Integer sel = moduleTableState.selected();
+            if (sel != null && sel < visible.size()) {
+                var node = visible.get(sel);
+                if (node.hasChildren()) {
+                    node.expanded = !node.expanded;
+                }
+            }
+            return true;
+        }
+        if (key.isKey(KeyCode.LEFT)) {
+            Integer sel = moduleTableState.selected();
+            if (sel != null && sel < visible.size()) {
+                var node = visible.get(sel);
+                if (node.expanded && node.hasChildren()) {
+                    node.expanded = false;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private void toggleSelection() {
+        Integer sel = tableState.selected();
+        if (sel == null || sel >= displayRows.size()) return;
+
+        var row = displayRows.get(sel);
+        if (row.isGroupHeader()) {
+            var group = row.propertyGroup;
+            boolean newState = !group.selected;
+            group.selected = newState;
+            for (var dep : group.dependencies) {
+                dep.selected = newState;
+            }
+        } else if (row.dependency != null && row.dependency.hasUpdate()) {
+            var dep = row.dependency;
+            boolean newState = !dep.selected;
+            dep.selected = newState;
+            // If part of a property group, toggle the whole group
+            if (dep.isPropertyManaged()) {
+                for (var group : reactorResult.propertyGroups) {
+                    if (group.dependencies.contains(dep)) {
+                        group.selected = newState;
+                        for (var other : group.dependencies) {
+                            other.selected = newState;
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    private void selectAll() {
+        for (var group : reactorResult.propertyGroups) {
+            if (group.hasUpdate()) {
+                group.selected = true;
+                for (var dep : group.dependencies) {
+                    dep.selected = true;
+                }
+            }
+        }
+        for (var dep : reactorResult.ungroupedDependencies) {
+            if (dep.hasUpdate()) dep.selected = true;
+        }
+    }
+
+    private void deselectAll() {
+        for (var group : reactorResult.propertyGroups) {
+            group.selected = false;
+            for (var dep : group.dependencies) {
+                dep.selected = false;
+            }
+        }
+        for (var dep : reactorResult.ungroupedDependencies) {
+            dep.selected = false;
+        }
+    }
+
+    // -- Apply --
+
+    private void applyUpdates() {
+        Map<Path, List<Map.Entry<String, String>>> propertyUpdates = new LinkedHashMap<>();
+        for (var group : reactorResult.propertyGroups) {
+            if (group.selected && group.hasUpdate()) {
+                Path pomPath = group.origin.getFile().toPath();
+                propertyUpdates
+                        .computeIfAbsent(pomPath, k -> new ArrayList<>())
+                        .add(Map.entry(group.propertyName, group.newestVersion));
+            }
+        }
+
+        Map<Path, List<ReactorCollector.AggregatedDependency>> depUpdates = new LinkedHashMap<>();
+        for (var dep : reactorResult.ungroupedDependencies) {
+            if (dep.selected && dep.hasUpdate() && !dep.usages.isEmpty()) {
+                Path pomPath = dep.usages.get(0).project.getFile().toPath();
+                depUpdates.computeIfAbsent(pomPath, k -> new ArrayList<>()).add(dep);
+            }
+        }
+
+        if (propertyUpdates.isEmpty() && depUpdates.isEmpty()) {
+            status = "No updates selected";
+            return;
+        }
+
+        try {
+            int updatedFiles = 0;
+            int totalUpdates = 0;
+
+            for (var entry : propertyUpdates.entrySet()) {
+                Path pomPath = entry.getKey();
+                String pomContent = Files.readString(pomPath);
+                PomEditor pomEditor = new PomEditor(Document.of(pomContent));
+
+                for (var propEntry : entry.getValue()) {
+                    pomEditor.properties().updateProperty(true, propEntry.getKey(), propEntry.getValue());
+                    totalUpdates++;
+                }
+
+                Files.writeString(pomPath, pomEditor.toXml());
+                updatedFiles++;
+            }
+
+            for (var entry : depUpdates.entrySet()) {
+                Path pomPath = entry.getKey();
+                String pomContent = Files.readString(pomPath);
+                PomEditor pomEditor = new PomEditor(Document.of(pomContent));
+
+                for (var dep : entry.getValue()) {
+                    var coords =
+                            eu.maveniverse.domtrip.maven.Coordinates.of(dep.groupId, dep.artifactId, dep.newestVersion);
+                    boolean managed = dep.usages.stream().anyMatch(u -> u.managed);
+                    if (managed) {
+                        pomEditor.dependencies().updateManagedDependency(true, coords);
+                    } else {
+                        pomEditor.dependencies().updateDependency(true, coords);
+                    }
+                    totalUpdates++;
+                }
+
+                Files.writeString(pomPath, pomEditor.toXml());
+                updatedFiles++;
+            }
+
+            // Update model state
+            for (var group : reactorResult.propertyGroups) {
+                if (group.selected && group.hasUpdate()) {
+                    group.resolvedVersion = group.newestVersion;
+                    group.newestVersion = null;
+                    group.selected = false;
+                    group.updateType = null;
+                    for (var dep : group.dependencies) {
+                        dep.primaryVersion = group.resolvedVersion;
+                        dep.newestVersion = null;
+                        dep.selected = false;
+                        dep.updateType = null;
+                    }
+                }
+            }
+            for (var dep : reactorResult.ungroupedDependencies) {
+                if (dep.selected && dep.hasUpdate()) {
+                    dep.primaryVersion = dep.newestVersion;
+                    dep.newestVersion = null;
+                    dep.selected = false;
+                    dep.updateType = null;
+                }
+            }
+
+            updateReactorCounts();
+            buildDisplayRows();
+            status = "Applied " + totalUpdates + " update(s) to " + updatedFiles + " POM file(s)";
+        } catch (Exception e) {
+            status = "Failed to apply: " + e.getMessage();
+        }
+    }
+
+    // -- Rendering --
+
+    void render(Frame frame) {
+        var zones = Layout.vertical()
+                .constraints(Constraint.length(3), Constraint.fill(), Constraint.length(4))
+                .split(frame.area());
+
+        renderHeader(frame, zones.get(0));
+        if (view == View.DEPENDENCIES) {
+            renderDepsTable(frame, zones.get(1));
+        } else {
+            renderModulesTable(frame, zones.get(1));
+        }
+        renderInfoBar(frame, zones.get(2));
+    }
+
+    private void renderHeader(Frame frame, Rect area) {
+        String title = loading ? " Pilot \u2014 Checking Updates\u2026 " : " Pilot \u2014 Reactor Updates ";
+        Block block = Block.builder()
+                .title(title)
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().cyan())
+                .build();
+
+        List<Span> spans = new ArrayList<>();
+        spans.add(Span.raw(" " + projectGav).bold().cyan());
+        spans.add(Span.raw("  (" + reactorModel.allModules.size() + " modules)").dim());
+        if (loading) {
+            spans.add(Span.raw("  Checking " + loadedCount + "/" + reactorResult.allDependencies.size() + "\u2026")
+                    .dim());
+        }
+
+        Paragraph header = Paragraph.builder()
+                .text(dev.tamboui.text.Text.from(Line.from(spans)))
+                .block(block)
+                .build();
+        frame.renderWidget(header, area);
+    }
+
+    private void renderDepsTable(Frame frame, Rect area) {
+        long updateCount = reactorResult.allDependencies.stream()
+                .filter(ReactorCollector.AggregatedDependency::hasUpdate)
+                .count();
+        String title = " Dependencies (" + updateCount + " updates) [" + filter + "] ";
+
+        Block block = Block.builder()
+                .title(title)
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().fg(Color.DARK_GRAY))
+                .build();
+
+        if (displayRows.isEmpty()) {
+            String msg = loading ? "Checking versions\u2026" : "No updates available";
+            Paragraph empty =
+                    Paragraph.builder().text(msg).block(block).centered().build();
+            frame.renderWidget(empty, area);
+            return;
+        }
+
+        Row header = Row.from("", "dependency / property", "current", "", "available", "info")
+                .style(Style.create().bold().yellow());
+
+        List<Row> rows = new ArrayList<>();
+        for (var row : displayRows) {
+            rows.add(createReactorRow(row));
+        }
+
+        Table table = Table.builder()
+                .header(header)
+                .rows(rows)
+                .widths(
+                        Constraint.length(3),
+                        Constraint.percentage(40),
+                        Constraint.percentage(15),
+                        Constraint.length(3),
+                        Constraint.percentage(15),
+                        Constraint.percentage(10))
+                .highlightStyle(Style.create().reversed().bold())
+                .highlightSymbol("\u25B8 ")
+                .block(block)
+                .build();
+
+        frame.renderStatefulWidget(table, area, tableState);
+    }
+
+    private Row createReactorRow(ReactorRow row) {
+        if (row.isGroupHeader()) {
+            var group = row.propertyGroup;
+            String check = group.selected ? "[\u2713]" : "[ ]";
+            String name = "${" + group.propertyName + "}";
+            String current = group.resolvedVersion != null ? group.resolvedVersion : "";
+            String arrow = group.hasUpdate() ? "\u2192" : "";
+            String available = group.hasUpdate() ? group.newestVersion : "";
+            int modCount = group.totalModuleCount();
+            String info = modCount + " mod";
+
+            Style style = Style.create().fg(Color.CYAN).bold();
+            return Row.from(check, name, current, arrow, available, info).style(style);
+        } else {
+            var dep = row.dependency;
+            String check = dep.selected ? "[\u2713]" : "   ";
+            String ga = "  \u21B3 " + dep.artifactId;
+            boolean inGroup = dep.isPropertyManaged();
+            String current = inGroup ? "" : (dep.primaryVersion != null ? dep.primaryVersion : "");
+            String arrow = (!inGroup && dep.hasUpdate()) ? "\u2192" : "";
+            String available = (!inGroup && dep.hasUpdate()) ? dep.newestVersion : "";
+            int modCount = dep.moduleCount();
+            String info = modCount + " mod";
+            if (dep.usages.stream().anyMatch(u -> u.managed)) {
+                info += " M";
+            }
+
+            Style style = dep.updateType != null
+                    ? switch (dep.updateType) {
+                        case PATCH -> Style.create().fg(Color.GREEN);
+                        case MINOR -> Style.create().fg(Color.YELLOW);
+                        case MAJOR -> Style.create().fg(Color.RED);
+                    }
+                    : Style.create();
+
+            return Row.from(check, ga, current, arrow, available, info).style(style);
+        }
+    }
+
+    private void renderModulesTable(Frame frame, Rect area) {
+        String title = " Modules (" + reactorModel.allModules.size() + ") ";
+
+        Block block = Block.builder()
+                .title(title)
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().fg(Color.DARK_GRAY))
+                .build();
+
+        List<ReactorModel.ModuleNode> visible = reactorModel.visibleNodes();
+
+        if (visible.isEmpty()) {
+            Paragraph empty = Paragraph.builder()
+                    .text("No modules")
+                    .block(block)
+                    .centered()
+                    .build();
+            frame.renderWidget(empty, area);
+            return;
+        }
+
+        Row header = Row.from("module", "updates").style(Style.create().bold().yellow());
+
+        List<Row> rows = new ArrayList<>();
+        for (var node : visible) {
+            rows.add(createModuleRow(node));
+        }
+
+        Table table = Table.builder()
+                .header(header)
+                .rows(rows)
+                .widths(Constraint.percentage(75), Constraint.percentage(25))
+                .highlightStyle(Style.create().reversed().bold())
+                .highlightSymbol("\u25B8 ")
+                .block(block)
+                .build();
+
+        frame.renderStatefulWidget(table, area, moduleTableState);
+    }
+
+    private Row createModuleRow(ReactorModel.ModuleNode node) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < node.depth; i++) {
+            sb.append("  ");
+        }
+        if (node.hasChildren()) {
+            sb.append(node.expanded ? "\u25BE " : "\u25B8 ");
+        } else {
+            sb.append("  ");
+        }
+        sb.append(node.name);
+
+        String counts;
+        if (node.hasChildren()) {
+            counts = node.ownUpdateCount + "/" + node.totalUpdateCount;
+        } else {
+            counts = String.valueOf(node.ownUpdateCount);
+        }
+
+        Style style;
+        if (node.totalUpdateCount > 0 || node.ownUpdateCount > 0) {
+            style = Style.create().fg(Color.YELLOW);
+        } else {
+            style = Style.create();
+        }
+
+        return Row.from(sb.toString(), counts).style(style);
+    }
+
+    private void renderInfoBar(Frame frame, Rect area) {
+        var rows = Layout.vertical()
+                .constraints(Constraint.length(1), Constraint.length(1), Constraint.length(1), Constraint.length(1))
+                .split(area);
+
+        // View indicator
+        List<Span> viewSpans = new ArrayList<>();
+        viewSpans.add(Span.raw(" "));
+        viewSpans.add(
+                view == View.DEPENDENCIES
+                        ? Span.raw("[Dependencies]").bold().cyan()
+                        : Span.raw(" Dependencies ").dim());
+        viewSpans.add(Span.raw(" "));
+        viewSpans.add(
+                view == View.MODULES
+                        ? Span.raw("[Modules]").bold().cyan()
+                        : Span.raw(" Modules ").dim());
+        frame.renderWidget(Paragraph.from(Line.from(viewSpans)), rows.get(0));
+
+        // Status
+        frame.renderWidget(
+                Paragraph.from(Line.from(List.of(Span.raw(" " + status).fg(Color.GREEN)))), rows.get(1));
+
+        // Selected count
+        long selectedCount = reactorResult.allDependencies.stream()
+                .filter(d -> d.selected && d.hasUpdate())
+                .count();
+        if (selectedCount > 0) {
+            frame.renderWidget(
+                    Paragraph.from(Line.from(List.of(Span.raw(" " + selectedCount + " update(s) selected")
+                            .fg(Color.CYAN)))),
+                    rows.get(2));
+        }
+
+        // Key bindings
+        List<Span> spans = new ArrayList<>();
+        spans.add(Span.raw(" "));
+        spans.add(Span.raw("Tab").bold());
+        spans.add(Span.raw(":View  "));
+        if (view == View.DEPENDENCIES) {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Nav  "));
+            spans.add(Span.raw("Space").bold());
+            spans.add(Span.raw(":Toggle  "));
+            spans.add(Span.raw("a").bold());
+            spans.add(Span.raw(":All  "));
+            spans.add(Span.raw("n").bold());
+            spans.add(Span.raw(":None  "));
+            spans.add(Span.raw("Enter").bold());
+            spans.add(Span.raw(":Apply  "));
+            spans.add(Span.raw("1-4").bold());
+            spans.add(Span.raw(":Filter  "));
+        } else {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Nav  "));
+            spans.add(Span.raw("\u2190\u2192").bold());
+            spans.add(Span.raw(":Expand  "));
+        }
+        spans.add(Span.raw("q").bold());
+        spans.add(Span.raw(":Quit"));
+
+        frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(3));
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -187,9 +187,13 @@ class ReactorUpdatesTui {
             loading = false;
             for (var group : reactorResult.propertyGroups) {
                 for (var dep : group.dependencies) {
-                    if (dep.hasUpdate() && group.newestVersion == null) {
-                        group.newestVersion = dep.newestVersion;
-                        group.updateType = dep.updateType;
+                    if (dep.hasUpdate()) {
+                        if (group.newestVersion == null
+                                || VersionComparator.isNewer(dep.newestVersion, group.newestVersion)) {
+                            // Pick the most conservative (smallest) version available for all deps
+                            group.newestVersion = dep.newestVersion;
+                            group.updateType = dep.updateType;
+                        }
                     }
                 }
             }
@@ -401,16 +405,15 @@ class ReactorUpdatesTui {
     }
 
     private void selectAll() {
-        for (var group : reactorResult.propertyGroups) {
-            if (group.hasUpdate()) {
-                group.selected = true;
-                for (var dep : group.dependencies) {
+        for (var row : displayRows) {
+            if (row.isGroupHeader() && row.propertyGroup.hasUpdate()) {
+                row.propertyGroup.selected = true;
+                for (var dep : row.propertyGroup.dependencies) {
                     dep.selected = true;
                 }
+            } else if (row.dependency != null && !row.dependency.isPropertyManaged() && row.dependency.hasUpdate()) {
+                row.dependency.selected = true;
             }
-        }
-        for (var dep : reactorResult.ungroupedDependencies) {
-            if (dep.hasUpdate()) dep.selected = true;
         }
     }
 
@@ -439,11 +442,21 @@ class ReactorUpdatesTui {
             }
         }
 
-        Map<Path, List<ReactorCollector.AggregatedDependency>> depUpdates = new LinkedHashMap<>();
+        Map<Path, List<Map.Entry<ReactorCollector.AggregatedDependency, Boolean>>> depUpdates = new LinkedHashMap<>();
         for (var dep : reactorResult.ungroupedDependencies) {
             if (dep.selected && dep.hasUpdate() && !dep.usages.isEmpty()) {
-                Path pomPath = dep.usages.get(0).project.getFile().toPath();
-                depUpdates.computeIfAbsent(pomPath, k -> new ArrayList<>()).add(dep);
+                // Prefer managed usage (version is declared in <dependencyManagement>)
+                var managedUsage = dep.usages.stream().filter(u -> u.managed).findFirst();
+                Path pomPath;
+                boolean managed;
+                if (managedUsage.isPresent()) {
+                    pomPath = managedUsage.orElseThrow().project.getFile().toPath();
+                    managed = true;
+                } else {
+                    pomPath = dep.usages.get(0).project.getFile().toPath();
+                    managed = false;
+                }
+                depUpdates.computeIfAbsent(pomPath, k -> new ArrayList<>()).add(Map.entry(dep, managed));
             }
         }
 
@@ -456,29 +469,40 @@ class ReactorUpdatesTui {
             int updatedFiles = 0;
             int totalUpdates = 0;
 
+            // Collect all POM paths that need editing
+            Map<Path, PomEditor> editors = new LinkedHashMap<>();
+
             for (var entry : propertyUpdates.entrySet()) {
                 Path pomPath = entry.getKey();
-                String pomContent = Files.readString(pomPath);
-                PomEditor pomEditor = new PomEditor(Document.of(pomContent));
+                PomEditor pomEditor = editors.computeIfAbsent(pomPath, p -> {
+                    try {
+                        return new PomEditor(Document.of(Files.readString(p)));
+                    } catch (Exception e) {
+                        throw new IllegalStateException("Cannot read POM: " + p, e);
+                    }
+                });
 
                 for (var propEntry : entry.getValue()) {
                     pomEditor.properties().updateProperty(true, propEntry.getKey(), propEntry.getValue());
                     totalUpdates++;
                 }
-
-                Files.writeString(pomPath, pomEditor.toXml());
-                updatedFiles++;
             }
 
             for (var entry : depUpdates.entrySet()) {
                 Path pomPath = entry.getKey();
-                String pomContent = Files.readString(pomPath);
-                PomEditor pomEditor = new PomEditor(Document.of(pomContent));
+                PomEditor pomEditor = editors.computeIfAbsent(pomPath, p -> {
+                    try {
+                        return new PomEditor(Document.of(Files.readString(p)));
+                    } catch (Exception e) {
+                        throw new IllegalStateException("Cannot read POM: " + p, e);
+                    }
+                });
 
-                for (var dep : entry.getValue()) {
+                for (var depEntry : entry.getValue()) {
+                    var dep = depEntry.getKey();
+                    boolean managed = depEntry.getValue();
                     var coords =
                             eu.maveniverse.domtrip.maven.Coordinates.of(dep.groupId, dep.artifactId, dep.newestVersion);
-                    boolean managed = dep.usages.stream().anyMatch(u -> u.managed);
                     if (managed) {
                         pomEditor.dependencies().updateManagedDependency(true, coords);
                     } else {
@@ -486,8 +510,11 @@ class ReactorUpdatesTui {
                     }
                     totalUpdates++;
                 }
+            }
 
-                Files.writeString(pomPath, pomEditor.toXml());
+            // Write all modified POMs
+            for (var entry : editors.entrySet()) {
+                Files.writeString(entry.getKey(), entry.getValue().toXml());
                 updatedFiles++;
             }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
@@ -41,6 +41,7 @@ import jakarta.json.JsonObject;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -51,7 +52,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -77,14 +77,23 @@ class SearchTui {
         final String url;
         final String organization;
         final String license;
+        final String licenseUrl;
         final String date;
 
-        PomInfo(String name, String description, String url, String organization, String license, String date) {
+        PomInfo(
+                String name,
+                String description,
+                String url,
+                String organization,
+                String license,
+                String licenseUrl,
+                String date) {
             this.name = name;
             this.description = description;
             this.url = url;
             this.organization = organization;
             this.license = license;
+            this.licenseUrl = licenseUrl;
             this.date = date;
         }
     }
@@ -127,7 +136,7 @@ class SearchTui {
     private String selectedGav;
 
     // Background HTTP pool (limited to avoid saturating connections)
-    private final ExecutorService httpPool = Executors.newFixedThreadPool(3);
+    private final ExecutorService httpPool = MojoHelper.newHttpPool();
 
     // Dependencies
     private final SearchClient client;
@@ -821,6 +830,11 @@ class SearchTui {
      *         returns a PomInfo with all fields set to `null` if the POM cannot be retrieved or parsed
      */
     static PomInfo fetchPomFromCentral(String groupId, String artifactId, String version) {
+        // Try local Maven repository first (handles SNAPSHOTs and offline artifacts)
+        PomInfo local = fetchPomFromLocal(groupId, artifactId, version);
+        if (local != null) return local;
+
+        // Fall back to Maven Central
         try {
             String path = groupId.replace('.', '/') + "/" + artifactId + "/" + version + "/" + artifactId + "-"
                     + version + ".pom";
@@ -834,7 +848,7 @@ class SearchTui {
                 conn.setReadTimeout(5_000);
 
                 if (conn.getResponseCode() != 200) {
-                    return new PomInfo(null, null, null, null, null, null);
+                    return new PomInfo(null, null, null, null, null, null, null);
                 }
 
                 // Capture Last-Modified as publication date
@@ -848,34 +862,159 @@ class SearchTui {
                 }
 
                 try (InputStream is = conn.getInputStream()) {
-                    DocumentBuilder db = createSafeDocumentBuilder();
-                    Document doc = db.parse(is);
-                    Element root = doc.getDocumentElement();
-
-                    String name = getChildText(root, "name");
-                    String description = getChildText(root, "description");
-                    String url = getChildText(root, "url");
-
-                    String org = null;
-                    NodeList orgNodes = root.getElementsByTagName("organization");
-                    if (orgNodes.getLength() > 0) {
-                        org = getChildText((Element) orgNodes.item(0), "name");
-                    }
-
-                    String license = null;
-                    NodeList licNodes = root.getElementsByTagName("license");
-                    if (licNodes.getLength() > 0) {
-                        license = getChildText((Element) licNodes.item(0), "name");
-                    }
-
-                    return new PomInfo(name, description, url, org, license, date);
+                    return parsePomInfo(is, date);
                 }
             } finally {
                 conn.disconnect();
             }
         } catch (Exception e) {
-            return new PomInfo(null, null, null, null, null, null);
+            return new PomInfo(null, null, null, null, null, null, null);
         }
+    }
+
+    private static PomInfo fetchPomFromLocal(String groupId, String artifactId, String version) {
+        try {
+            String localRepo = System.getProperty("maven.repo.local");
+            if (localRepo == null) {
+                localRepo = System.getProperty("user.home") + "/.m2/repository";
+            }
+            Path pomFile = Path.of(
+                    localRepo, groupId.replace('.', '/'), artifactId, version, artifactId + "-" + version + ".pom");
+            if (!pomFile.toFile().isFile()) return null;
+
+            String date = Instant.ofEpochMilli(pomFile.toFile().lastModified())
+                    .atZone(ZoneId.systemDefault())
+                    .toLocalDate()
+                    .toString();
+
+            try (InputStream is = java.nio.file.Files.newInputStream(pomFile)) {
+                return parsePomInfo(is, date);
+            }
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private record LicenseInfo(String name, String url) {}
+
+    private static PomInfo parsePomInfo(InputStream is, String date) throws Exception {
+        DocumentBuilder db = createSafeDocumentBuilder();
+        Document doc = db.parse(is);
+        Element root = doc.getDocumentElement();
+
+        String name = getChildText(root, "name");
+        String description = getChildText(root, "description");
+        String url = getChildText(root, "url");
+
+        String org = null;
+        Element orgEl = getChildElement(root, "organization");
+        if (orgEl != null) {
+            org = getChildText(orgEl, "name");
+        }
+
+        LicenseInfo licInfo = extractLicenseInfo(root);
+
+        // If no license found, follow parent POM chain
+        if (licInfo == null) {
+            licInfo = fetchLicenseInfoFromParent(root);
+        }
+
+        String license = licInfo != null ? licInfo.name : null;
+        String licenseUrl = licInfo != null ? licInfo.url : null;
+
+        return new PomInfo(name, description, url, org, license, licenseUrl, date);
+    }
+
+    /**
+     * Follow the parent POM chain to find a license declaration.
+     * Checks local Maven repository first, then Maven Central.
+     */
+    private static LicenseInfo fetchLicenseInfoFromParent(Element pomRoot) {
+        Element parentEl = getChildElement(pomRoot, "parent");
+        if (parentEl == null) return null;
+        String pGroupId = getChildText(parentEl, "groupId");
+        String pArtifactId = getChildText(parentEl, "artifactId");
+        String pVersion = getChildText(parentEl, "version");
+        if (pGroupId == null || pArtifactId == null || pVersion == null) return null;
+
+        Element parentRoot = loadPomElement(pGroupId, pArtifactId, pVersion);
+        if (parentRoot == null) return null;
+
+        LicenseInfo licInfo = extractLicenseInfo(parentRoot);
+        if (licInfo != null) return licInfo;
+        return fetchLicenseInfoFromParent(parentRoot);
+    }
+
+    /**
+     * Load a POM's root element, trying local repo first then Central.
+     */
+    private static Element loadPomElement(String groupId, String artifactId, String version) {
+        String relPath = groupId.replace('.', '/') + "/" + artifactId + "/" + version + "/" + artifactId + "-" + version
+                + ".pom";
+
+        // Try local repo first
+        try {
+            String localRepo = System.getProperty("maven.repo.local");
+            if (localRepo == null) {
+                localRepo = System.getProperty("user.home") + "/.m2/repository";
+            }
+            Path pomFile = Path.of(
+                    localRepo, groupId.replace('.', '/'), artifactId, version, artifactId + "-" + version + ".pom");
+            if (pomFile.toFile().isFile()) {
+                try (InputStream is = java.nio.file.Files.newInputStream(pomFile)) {
+                    return createSafeDocumentBuilder().parse(is).getDocumentElement();
+                }
+            }
+        } catch (Exception e) {
+            // fall through to Central
+        }
+
+        // Try Maven Central
+        try {
+            String pomUrl = "https://repo1.maven.org/maven2/" + relPath;
+            HttpURLConnection conn =
+                    (HttpURLConnection) URI.create(pomUrl).toURL().openConnection();
+            try {
+                conn.setRequestMethod("GET");
+                conn.setConnectTimeout(5_000);
+                conn.setReadTimeout(5_000);
+                if (conn.getResponseCode() != 200) return null;
+                try (InputStream is = conn.getInputStream()) {
+                    return createSafeDocumentBuilder().parse(is).getDocumentElement();
+                }
+            } finally {
+                conn.disconnect();
+            }
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Extract license name and URL from a POM root element using direct child traversal.
+     */
+    private static LicenseInfo extractLicenseInfo(Element pomRoot) {
+        Element licensesEl = getChildElement(pomRoot, "licenses");
+        if (licensesEl == null) return null;
+        Element licenseEl = getChildElement(licensesEl, "license");
+        if (licenseEl == null) return null;
+        String name = getChildText(licenseEl, "name");
+        if (name == null) return null;
+        String url = getChildText(licenseEl, "url");
+        return new LicenseInfo(name, url);
+    }
+
+    /**
+     * Find a direct child element by tag name.
+     */
+    private static Element getChildElement(Element parent, String tagName) {
+        NodeList list = parent.getChildNodes();
+        for (int i = 0; i < list.getLength(); i++) {
+            if (list.item(i) instanceof Element el && el.getTagName().equals(tagName)) {
+                return el;
+            }
+        }
+        return null;
     }
 
     private static DocumentBuilder createSafeDocumentBuilder() throws Exception {

--- a/src/main/java/eu/maveniverse/maven/pilot/ToolPickerTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ToolPickerTui.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import dev.tamboui.layout.Constraint;
+import dev.tamboui.layout.Layout;
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.tui.TuiRunner;
+import dev.tamboui.tui.event.Event;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import dev.tamboui.widgets.table.Row;
+import dev.tamboui.widgets.table.Table;
+import dev.tamboui.widgets.table.TableState;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tool selection TUI for the pilot launcher.
+ *
+ * <p>Displays a list of available tools and lets the user select one.
+ * Returns the selected tool name or {@code null} if the user quits.</p>
+ */
+class ToolPickerTui {
+
+    record Tool(String name, String description, boolean reactorWide) {}
+
+    private static final List<Tool> TOOLS = List.of(
+            new Tool("tree", "Browse dependency tree", false),
+            new Tool("dependencies", "Analyze declared vs used dependencies", false),
+            new Tool("pom", "Browse effective POM", false),
+            new Tool("align", "Align dependencies with a BOM", false),
+            new Tool("updates", "Check for dependency updates", true),
+            new Tool("conflicts", "Detect version conflicts", true),
+            new Tool("audit", "Security audit of dependencies", true));
+
+    private final String contextLabel;
+    private final boolean isReactor;
+    private final TableState tableState = new TableState();
+    private final HelpOverlay helpOverlay = new HelpOverlay();
+    private String selectedTool;
+
+    ToolPickerTui(String contextLabel, boolean isReactor) {
+        this.contextLabel = contextLabel;
+        this.isReactor = isReactor;
+        tableState.select(0);
+    }
+
+    String pick() throws Exception {
+        var configured = TuiRunner.builder()
+                .eventHandler(this::handleEvent)
+                .renderer(this::render)
+                .tickRate(Duration.ofMillis(100))
+                .build();
+        try {
+            configured.run();
+        } finally {
+            configured.close();
+        }
+        return selectedTool;
+    }
+
+    boolean handleEvent(Event event, TuiRunner runner) {
+        if (!(event instanceof KeyEvent key)) {
+            return true;
+        }
+
+        if (helpOverlay.isActive()) {
+            if (helpOverlay.handleKey(key)) return true;
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                runner.quit();
+                return true;
+            }
+            return false;
+        }
+
+        if (key.isCtrlC() || key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
+            runner.quit();
+            return true;
+        }
+
+        if (key.isUp()) {
+            tableState.selectPrevious();
+            return true;
+        }
+        if (key.isDown()) {
+            tableState.selectNext(TOOLS.size());
+            return true;
+        }
+
+        if (key.isKey(KeyCode.ENTER)) {
+            Integer sel = tableState.selected();
+            if (sel != null && sel >= 0 && sel < TOOLS.size()) {
+                selectedTool = TOOLS.get(sel).name;
+                runner.quit();
+            }
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('h')) {
+            helpOverlay.open(buildHelp());
+            return true;
+        }
+
+        return false;
+    }
+
+    void render(Frame frame) {
+        var zones = Layout.vertical()
+                .constraints(Constraint.length(3), Constraint.fill(), Constraint.length(3))
+                .split(frame.area());
+
+        renderHeader(frame, zones.get(0));
+        if (helpOverlay.isActive()) {
+            helpOverlay.render(frame, zones.get(1));
+        } else {
+            renderTools(frame, zones.get(1));
+        }
+        renderInfoBar(frame, zones.get(2));
+    }
+
+    private void renderHeader(Frame frame, Rect area) {
+        Block block = Block.builder()
+                .title(" Pilot \u2014 select tool ")
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().cyan())
+                .build();
+
+        Paragraph header = Paragraph.builder()
+                .text(dev.tamboui.text.Text.from(
+                        Line.from(Span.raw(" " + contextLabel).bold().cyan())))
+                .block(block)
+                .build();
+        frame.renderWidget(header, area);
+    }
+
+    private void renderTools(Frame frame, Rect area) {
+        Block block = Block.builder()
+                .title(" Tools (" + TOOLS.size() + ") ")
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().fg(Color.DARK_GRAY))
+                .build();
+
+        Row header = Row.from("tool", "description", "scope")
+                .style(Style.create().bold().yellow());
+
+        List<Row> rows = new ArrayList<>();
+        for (Tool tool : TOOLS) {
+            String scope = isReactor ? (tool.reactorWide ? "reactor" : "module") : "";
+            rows.add(Row.from(tool.name, tool.description, scope));
+        }
+
+        Table table = Table.builder()
+                .header(header)
+                .rows(rows)
+                .widths(Constraint.percentage(20), Constraint.percentage(60), Constraint.percentage(20))
+                .highlightStyle(Style.create().reversed().bold())
+                .highlightSymbol("\u25B8 ")
+                .block(block)
+                .build();
+
+        frame.renderStatefulWidget(table, area, tableState);
+    }
+
+    private void renderInfoBar(Frame frame, Rect area) {
+        var rows = Layout.vertical()
+                .constraints(Constraint.length(1), Constraint.length(1), Constraint.length(1))
+                .split(area);
+
+        List<Span> statusSpans = new ArrayList<>();
+        statusSpans.add(Span.raw(" Select a tool to run").fg(Color.GREEN));
+        frame.renderWidget(Paragraph.from(Line.from(statusSpans)), rows.get(1));
+
+        List<Span> spans = new ArrayList<>();
+        spans.add(Span.raw(" "));
+        spans.add(Span.raw("\u2191\u2193").bold());
+        spans.add(Span.raw(":Navigate  "));
+        spans.add(Span.raw("Enter").bold());
+        spans.add(Span.raw(":Select  "));
+        spans.add(Span.raw("h").bold());
+        spans.add(Span.raw(":Help  "));
+        spans.add(Span.raw("q").bold());
+        spans.add(Span.raw(":Back"));
+
+        frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(2));
+    }
+
+    private List<HelpOverlay.Section> buildHelp() {
+        return List.of(
+                new HelpOverlay.Section(
+                        "Tool Picker",
+                        List.of(
+                                new HelpOverlay.Entry("", "Choose an analysis tool to run. In a reactor build,"),
+                                new HelpOverlay.Entry("", "the 'scope' column indicates whether the tool runs"),
+                                new HelpOverlay.Entry("", "on a single module or across the entire reactor."))),
+                new HelpOverlay.Section(
+                        "Available Tools",
+                        List.of(
+                                new HelpOverlay.Entry("tree", "Browse the resolved dependency tree \u2014 see all"),
+                                new HelpOverlay.Entry("", "  direct and transitive dependencies with versions"),
+                                new HelpOverlay.Entry(
+                                        "dependencies", "Bytecode analysis of declared vs used deps \u2014"),
+                                new HelpOverlay.Entry("", "  find unused or undeclared dependencies"),
+                                new HelpOverlay.Entry("pom", "Browse raw and effective POM as an XML tree \u2014"),
+                                new HelpOverlay.Entry("", "  see where inherited elements are defined"),
+                                new HelpOverlay.Entry("align", "Restructure dependency version declarations \u2014"),
+                                new HelpOverlay.Entry("", "  apply consistent property/management conventions"),
+                                new HelpOverlay.Entry("updates", "Check Maven Central for newer versions \u2014"),
+                                new HelpOverlay.Entry("", "  select and apply updates to POM files"),
+                                new HelpOverlay.Entry("conflicts", "Detect version conflicts in the dep tree \u2014"),
+                                new HelpOverlay.Entry("", "  pin resolved versions in dependencyManagement"),
+                                new HelpOverlay.Entry("audit", "License compliance and CVE vulnerability scan \u2014"),
+                                new HelpOverlay.Entry("", "  review licenses and known security issues"))),
+                new HelpOverlay.Section(
+                        "Keys",
+                        List.of(
+                                new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("Enter", "Run the selected tool"),
+                                new HelpOverlay.Entry("h", "Toggle this help screen"),
+                                new HelpOverlay.Entry("q / Esc", "Go back / quit"))));
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/TreeMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/TreeMojo.java
@@ -18,7 +18,9 @@
  */
 package eu.maveniverse.maven.pilot;
 
+import java.util.List;
 import javax.inject.Inject;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -40,11 +42,14 @@ import org.eclipse.aether.collection.CollectResult;
  *
  * @since 0.1.0
  */
-@Mojo(name = "tree", requiresProject = true, threadSafe = true)
+@Mojo(name = "tree", requiresProject = true, aggregator = true, threadSafe = true)
 public class TreeMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
 
     @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
     private RepositorySystemSession repoSession;
@@ -58,22 +63,36 @@ public class TreeMojo extends AbstractMojo {
     @Parameter(property = "scope", defaultValue = "compile")
     private String scope;
 
-    /**
-     * Builds the project's dependency tree model and launches the interactive tree TUI for the current Maven project.
-     *
-     * @throws MojoExecutionException if dependency collection or TUI execution fails
-     */
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
-            CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(project));
-            DependencyTreeModel model = DependencyTreeModel.fromDependencyNode(result.getRoot(), scope);
-
-            TreeTui tui = new TreeTui(
-                    model, project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion());
-            tui.run();
+            List<MavenProject> projects = session.getProjects();
+            if (projects.size() > 1) {
+                executeReactor(projects);
+            } else {
+                executeForProject(project);
+            }
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to display dependency tree: " + e.getMessage(), e);
         }
+    }
+
+    private void executeReactor(List<MavenProject> projects) throws Exception {
+        ReactorModel reactorModel = ReactorModel.build(projects);
+        MavenProject root = projects.get(0);
+        String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
+
+        while (true) {
+            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "tree").pick();
+            if (selected == null) break;
+            executeForProject(selected);
+        }
+    }
+
+    private void executeForProject(MavenProject proj) throws Exception {
+        CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
+        DependencyTreeModel model = DependencyTreeModel.fromDependencyNode(result.getRoot(), scope);
+        TreeTui tui = new TreeTui(model, proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion());
+        tui.run();
     }
 }

--- a/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -44,7 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 /**
  * Interactive TUI for browsing the dependency tree.
@@ -60,8 +59,9 @@ class TreeTui {
     private final DependencyTreeModel model;
     private final String projectGav;
     private final TableState tableState = new TableState();
-    private final ExecutorService httpPool = Executors.newFixedThreadPool(3);
+    private final ExecutorService httpPool = MojoHelper.newHttpPool();
     private final Map<String, SearchTui.PomInfo> pomInfoCache = new HashMap<>();
+    private final HelpOverlay helpOverlay = new HelpOverlay();
 
     private Mode mode = Mode.TREE;
     private List<DependencyTreeModel.TreeNode> displayNodes;
@@ -103,6 +103,15 @@ class TreeTui {
     boolean handleEvent(Event event, TuiRunner runner) {
         if (!(event instanceof KeyEvent key)) {
             return true;
+        }
+
+        if (helpOverlay.isActive()) {
+            if (helpOverlay.handleKey(key)) return true;
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                runner.quit();
+                return true;
+            }
+            return false;
         }
 
         if (key.isCtrlC()) {
@@ -208,6 +217,11 @@ class TreeTui {
             return true;
         }
 
+        if (key.isCharIgnoreCase('h')) {
+            helpOverlay.open(buildHelp());
+            return true;
+        }
+
         return false;
     }
 
@@ -306,9 +320,29 @@ class TreeTui {
     }
 
     private void collapseAll() {
+        // Remember the selected node before collapsing
+        int sel = selectedIndex();
+        DependencyTreeModel.TreeNode selectedNode =
+                (sel >= 0 && sel < displayNodes.size()) ? displayNodes.get(sel) : null;
+
         collapseNode(model.root);
         model.root.expanded = true; // keep root expanded
-        refreshDisplay();
+        displayNodes = model.visibleNodes();
+
+        // Find the selected node or its nearest visible ancestor
+        if (selectedNode != null) {
+            int newIndex = displayNodes.indexOf(selectedNode);
+            if (newIndex < 0) {
+                // Node is hidden — find nearest visible ancestor via path from root
+                List<DependencyTreeModel.TreeNode> path = model.pathToRoot(selectedNode);
+                for (int i = path.size() - 2; i >= 0; i--) {
+                    newIndex = displayNodes.indexOf(path.get(i));
+                    if (newIndex >= 0) break;
+                }
+                if (newIndex < 0) newIndex = 0;
+            }
+            tableState.select(newIndex);
+        }
     }
 
     private void expandNode(DependencyTreeModel.TreeNode node) {
@@ -328,6 +362,50 @@ class TreeTui {
         for (var child : node.children) {
             collapseNode(child);
         }
+    }
+
+    private List<HelpOverlay.Section> buildHelp() {
+        return List.of(
+                new HelpOverlay.Section(
+                        "Dependency Tree",
+                        List.of(
+                                new HelpOverlay.Entry("", "Shows the fully resolved dependency tree of the project."),
+                                new HelpOverlay.Entry("", "Each row is a dependency (groupId:artifactId:version)."),
+                                new HelpOverlay.Entry("", "Indentation shows the transitive dependency chain:"),
+                                new HelpOverlay.Entry("", "a child was pulled in by its parent in the tree."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "Scope (compile, test, runtime, provided) is shown"),
+                                new HelpOverlay.Entry("", "in brackets when not 'compile'. Each scope has a"),
+                                new HelpOverlay.Entry("", "distinct color. The status bar shows artifact"),
+                                new HelpOverlay.Entry("", "metadata (name, license) fetched from Central."))),
+                new HelpOverlay.Section(
+                        "Colors (by scope)",
+                        List.of(
+                                new HelpOverlay.Entry("default", "compile scope"),
+                                new HelpOverlay.Entry("blue", "runtime scope"),
+                                new HelpOverlay.Entry("magenta", "provided scope"),
+                                new HelpOverlay.Entry("dark gray", "test scope"),
+                                new HelpOverlay.Entry("red", "system scope"),
+                                new HelpOverlay.Entry("yellow", "Version conflict \u2014 multiple versions requested"),
+                                new HelpOverlay.Entry("dim", "Scope label, optional marker"))),
+                new HelpOverlay.Section(
+                        "Navigation",
+                        List.of(
+                                new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("\u2190 / \u2192", "Collapse / expand tree node"),
+                                new HelpOverlay.Entry("e", "Expand all nodes"),
+                                new HelpOverlay.Entry("w", "Collapse all (keeps root expanded)"))),
+                new HelpOverlay.Section(
+                        "Actions",
+                        List.of(
+                                new HelpOverlay.Entry("/", "Filter \u2014 type to search by groupId or artifactId"),
+                                new HelpOverlay.Entry("c", "Jump to next conflict (only when conflicts exist)"),
+                                new HelpOverlay.Entry("r", "Reverse path \u2014 show how root depends on selection"))),
+                new HelpOverlay.Section(
+                        "General",
+                        List.of(
+                                new HelpOverlay.Entry("h", "Toggle this help screen"),
+                                new HelpOverlay.Entry("q / Esc", "Quit"))));
     }
 
     /**
@@ -363,7 +441,9 @@ class TreeTui {
 
         renderHeader(frame, zones.get(0));
 
-        if (mode == Mode.REVERSE_PATH) {
+        if (helpOverlay.isActive()) {
+            helpOverlay.render(frame, zones.get(1));
+        } else if (mode == Mode.REVERSE_PATH) {
             renderReversePath(frame, zones.get(1));
         } else {
             renderTree(frame, zones.get(1));
@@ -614,12 +694,16 @@ class TreeTui {
             spans.add(Span.raw(":Expand/Collapse  "));
             spans.add(Span.raw("/").bold());
             spans.add(Span.raw(":Filter  "));
-            spans.add(Span.raw("c").bold());
-            spans.add(Span.raw(":Conflicts  "));
+            if (!model.conflicts.isEmpty()) {
+                spans.add(Span.raw("c").bold());
+                spans.add(Span.raw(":Conflicts  "));
+            }
             spans.add(Span.raw("r").bold());
             spans.add(Span.raw(":Reverse  "));
             spans.add(Span.raw("e/w").bold());
             spans.add(Span.raw(":Expand/Collapse all  "));
+            spans.add(Span.raw("h").bold());
+            spans.add(Span.raw(":Help  "));
             spans.add(Span.raw("q").bold());
             spans.add(Span.raw(":Quit"));
         }
@@ -641,7 +725,7 @@ class TreeTui {
         var node = displayNodes.get(sel);
         String pomKey = node.gav();
         if (pomInfoCache.containsKey(pomKey)) return;
-        pomInfoCache.put(pomKey, new SearchTui.PomInfo(null, null, null, null, null, null)); // placeholder
+        pomInfoCache.put(pomKey, new SearchTui.PomInfo(null, null, null, null, null, null, null)); // placeholder
 
         CompletableFuture.supplyAsync(
                         () -> SearchTui.fetchPomFromCentral(node.groupId, node.artifactId, node.version), httpPool)

--- a/src/main/java/eu/maveniverse/maven/pilot/UnifiedDiff.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UnifiedDiff.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.terminal.Frame;
+import dev.tamboui.text.Line;
+import dev.tamboui.text.Span;
+import dev.tamboui.widgets.block.Block;
+import dev.tamboui.widgets.block.BorderType;
+import dev.tamboui.widgets.paragraph.Paragraph;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Line-based unified diff computation and TUI rendering.
+ */
+class UnifiedDiff {
+
+    enum Type {
+        CONTEXT,
+        ADDED,
+        REMOVED
+    }
+
+    record DiffLine(Type type, String text) {}
+
+    /**
+     * Compute a line-based diff between two strings.
+     *
+     * @param original the original text
+     * @param modified the modified text
+     * @return list of diff lines with type annotations
+     */
+    static List<DiffLine> compute(String original, String modified) {
+        String[] oldLines = original.isEmpty() ? new String[0] : original.split("\n", -1);
+        String[] newLines = modified.isEmpty() ? new String[0] : modified.split("\n", -1);
+
+        // LCS table
+        int m = oldLines.length;
+        int n = newLines.length;
+        int[][] lcs = new int[m + 1][n + 1];
+        for (int i = m - 1; i >= 0; i--) {
+            for (int j = n - 1; j >= 0; j--) {
+                if (oldLines[i].equals(newLines[j])) {
+                    lcs[i][j] = lcs[i + 1][j + 1] + 1;
+                } else {
+                    lcs[i][j] = Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+                }
+            }
+        }
+
+        // Backtrack to produce diff
+        List<DiffLine> result = new ArrayList<>();
+        int i = 0, j = 0;
+        while (i < m || j < n) {
+            if (i < m && j < n && oldLines[i].equals(newLines[j])) {
+                result.add(new DiffLine(Type.CONTEXT, oldLines[i]));
+                i++;
+                j++;
+            } else if (i < m && (j >= n || lcs[i + 1][j] >= lcs[i][j + 1])) {
+                result.add(new DiffLine(Type.REMOVED, oldLines[i]));
+                i++;
+            } else if (j < n) {
+                result.add(new DiffLine(Type.ADDED, newLines[j]));
+                j++;
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Render a diff into a bordered area with scrolling support.
+     *
+     * @param frame the TUI frame to render into
+     * @param area the rectangular area to use
+     * @param lines the diff lines to display
+     * @param scroll the scroll offset (number of lines to skip)
+     * @param title the title for the diff block
+     */
+    static void render(Frame frame, Rect area, List<DiffLine> lines, int scroll, String title) {
+        Block block = Block.builder()
+                .title(title)
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().yellow())
+                .build();
+
+        if (lines.isEmpty()) {
+            Paragraph empty = Paragraph.builder()
+                    .text("No changes")
+                    .block(block)
+                    .centered()
+                    .build();
+            frame.renderWidget(empty, area);
+            return;
+        }
+
+        // Build visible lines within the bordered area
+        int innerHeight = area.height() - 2; // borders top/bottom
+        if (innerHeight <= 0) {
+            frame.renderWidget(Paragraph.builder().text("").block(block).build(), area);
+            return;
+        }
+
+        List<Line> visibleLines = new ArrayList<>();
+        int end = Math.min(scroll + innerHeight, lines.size());
+        for (int idx = scroll; idx < end; idx++) {
+            DiffLine dl = lines.get(idx);
+            String prefix;
+            Style style;
+            switch (dl.type()) {
+                case ADDED -> {
+                    prefix = "+ ";
+                    style = Style.create().fg(Color.GREEN);
+                }
+                case REMOVED -> {
+                    prefix = "- ";
+                    style = Style.create().fg(Color.RED);
+                }
+                default -> {
+                    prefix = "  ";
+                    style = Style.create().dim();
+                }
+            }
+            visibleLines.add(Line.from(Span.raw(prefix + dl.text()).style(style)));
+        }
+
+        // Build a single Text block from all visible lines
+        dev.tamboui.text.Text text = dev.tamboui.text.Text.from(visibleLines);
+        Paragraph paragraph = Paragraph.builder().text(text).block(block).build();
+        frame.renderWidget(paragraph, area);
+    }
+
+    /**
+     * Compute the maximum scroll offset for the given diff lines and visible area height.
+     */
+    static int maxScroll(List<DiffLine> lines, int areaHeight) {
+        int innerHeight = areaHeight - 2;
+        return Math.max(0, lines.size() - innerHeight);
+    }
+
+    /**
+     * Filter diff lines to only show changes (added/removed) with surrounding context.
+     *
+     * @param lines the full diff lines
+     * @param contextLines number of context lines to show around changes
+     * @return filtered list with only relevant lines
+     */
+    static List<DiffLine> filterContext(List<DiffLine> lines, int contextLines) {
+        if (lines.isEmpty()) return lines;
+
+        boolean[] show = new boolean[lines.size()];
+        // Mark all non-context lines and their surrounding context
+        for (int i = 0; i < lines.size(); i++) {
+            if (lines.get(i).type() != Type.CONTEXT) {
+                for (int j = Math.max(0, i - contextLines); j <= Math.min(lines.size() - 1, i + contextLines); j++) {
+                    show[j] = true;
+                }
+            }
+        }
+
+        List<DiffLine> result = new ArrayList<>();
+        for (int i = 0; i < lines.size(); i++) {
+            if (show[i]) {
+                result.add(lines.get(i));
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Count the number of changes (added + removed lines) in the diff.
+     */
+    static long changeCount(List<DiffLine> lines) {
+        return lines.stream().filter(l -> l.type() != Type.CONTEXT).count();
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/UnifiedDiff.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UnifiedDiff.java
@@ -153,7 +153,7 @@ class UnifiedDiff {
      * Compute the maximum scroll offset for the given diff lines and visible area height.
      */
     static int maxScroll(List<DiffLine> lines, int areaHeight) {
-        int innerHeight = areaHeight - 2;
+        int innerHeight = Math.max(0, areaHeight - 2);
         return Math.max(0, lines.size() - innerHeight);
     }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesMojo.java
@@ -21,6 +21,7 @@ package eu.maveniverse.maven.pilot;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -38,6 +39,9 @@ import org.eclipse.aether.resolution.VersionRangeResult;
 /**
  * Interactive TUI showing which dependencies have newer versions available.
  *
+ * <p>In a multi-module reactor, aggregates dependencies across all modules,
+ * groups by shared version properties, and applies updates to the correct POM.</p>
+ *
  * <p>Usage:</p>
  * <pre>
  * mvn pilot:updates
@@ -45,11 +49,14 @@ import org.eclipse.aether.resolution.VersionRangeResult;
  *
  * @since 0.1.0
  */
-@Mojo(name = "updates", requiresProject = true, threadSafe = true)
+@Mojo(name = "updates", requiresProject = true, aggregator = true, threadSafe = true)
 public class UpdatesMojo extends AbstractMojo {
 
     @Parameter(defaultValue = "${project}", readonly = true, required = true)
     private MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
 
     @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
     private RepositorySystemSession repoSession;
@@ -64,49 +71,70 @@ public class UpdatesMojo extends AbstractMojo {
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         try {
-            List<UpdatesTui.DependencyInfo> dependencies = new ArrayList<>();
+            UpdatesTui.VersionResolver versionResolver = createVersionResolver();
+            List<MavenProject> projects = session.getProjects();
 
-            for (Dependency dep : project.getDependencies()) {
-                dependencies.add(new UpdatesTui.DependencyInfo(
-                        dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType()));
+            if (projects.size() > 1) {
+                executeReactor(projects, versionResolver);
+            } else {
+                executeSingleProject(versionResolver);
             }
-
-            // Also include managed dependencies
-            if (project.getDependencyManagement() != null) {
-                for (Dependency dep : project.getDependencyManagement().getDependencies()) {
-                    boolean alreadyListed = dependencies.stream()
-                            .anyMatch(d ->
-                                    d.groupId.equals(dep.getGroupId()) && d.artifactId.equals(dep.getArtifactId()));
-                    if (!alreadyListed) {
-                        var info = new UpdatesTui.DependencyInfo(
-                                dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType());
-                        info.managed = true;
-                        dependencies.add(info);
-                    }
-                }
-            }
-
-            String pomPath = project.getFile().getAbsolutePath();
-            String gav = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
-
-            // Use the Resolver to fetch available versions, respecting all configured
-            // repositories, mirrors, authentication, and proxies.
-            UpdatesTui.VersionResolver versionResolver = (groupId, artifactId) -> {
-                try {
-                    VersionRangeRequest request = new VersionRangeRequest();
-                    request.setArtifact(new DefaultArtifact(groupId, artifactId, "jar", "[0,)"));
-                    request.setRepositories(project.getRemoteProjectRepositories());
-                    VersionRangeResult result = repoSystem.resolveVersionRange(repoSession, request);
-                    return UpdatesTui.versionsNewestFirst(result.getVersions());
-                } catch (VersionRangeResolutionException e) {
-                    throw new IllegalStateException("Failed to resolve versions for " + groupId + ":" + artifactId, e);
-                }
-            };
-
-            UpdatesTui tui = new UpdatesTui(dependencies, pomPath, gav, versionResolver);
-            tui.run();
         } catch (Exception e) {
             throw new MojoExecutionException("Failed to check updates: " + e.getMessage(), e);
         }
+    }
+
+    private void executeSingleProject(UpdatesTui.VersionResolver versionResolver) throws Exception {
+        List<UpdatesTui.DependencyInfo> dependencies = new ArrayList<>();
+
+        for (Dependency dep : project.getDependencies()) {
+            dependencies.add(new UpdatesTui.DependencyInfo(
+                    dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType()));
+        }
+
+        if (project.getDependencyManagement() != null) {
+            for (Dependency dep : project.getDependencyManagement().getDependencies()) {
+                boolean alreadyListed = dependencies.stream()
+                        .anyMatch(d -> d.groupId.equals(dep.getGroupId()) && d.artifactId.equals(dep.getArtifactId()));
+                if (!alreadyListed) {
+                    var info = new UpdatesTui.DependencyInfo(
+                            dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType());
+                    info.managed = true;
+                    dependencies.add(info);
+                }
+            }
+        }
+
+        String pomPath = project.getFile().getAbsolutePath();
+        String gav = project.getGroupId() + ":" + project.getArtifactId() + ":" + project.getVersion();
+
+        UpdatesTui tui = new UpdatesTui(dependencies, pomPath, gav, versionResolver);
+        tui.run();
+    }
+
+    private void executeReactor(List<MavenProject> projects, UpdatesTui.VersionResolver versionResolver)
+            throws Exception {
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(projects);
+        ReactorModel reactorModel = ReactorModel.build(projects);
+
+        MavenProject root = projects.get(0);
+        String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
+
+        ReactorUpdatesTui tui = new ReactorUpdatesTui(result, reactorModel, reactorGav, versionResolver);
+        tui.run();
+    }
+
+    private UpdatesTui.VersionResolver createVersionResolver() {
+        return (groupId, artifactId) -> {
+            try {
+                VersionRangeRequest request = new VersionRangeRequest();
+                request.setArtifact(new DefaultArtifact(groupId, artifactId, "jar", "[0,)"));
+                request.setRepositories(project.getRemoteProjectRepositories());
+                VersionRangeResult result = repoSystem.resolveVersionRange(repoSession, request);
+                return UpdatesTui.versionsNewestFirst(result.getVersions());
+            } catch (VersionRangeResolutionException e) {
+                throw new IllegalStateException("Failed to resolve versions for " + groupId + ":" + artifactId, e);
+            }
+        };
     }
 }

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -125,8 +125,7 @@ class UpdatesTui {
     private final PomEditor editor;
     private boolean dirty;
     private boolean pendingQuit;
-    private List<UnifiedDiff.DiffLine> diffLines;
-    private int diffScroll;
+    private final DiffOverlay diffOverlay = new DiffOverlay();
     private int lastContentHeight;
 
     private TuiRunner runner;
@@ -316,28 +315,12 @@ class UpdatesTui {
         }
 
         // Diff overlay mode — Esc closes overlay first
-        if (diffLines != null) {
+        if (diffOverlay.isActive()) {
             if (key.isKey(KeyCode.ESCAPE)) {
-                diffLines = null;
-                diffScroll = 0;
+                diffOverlay.close();
                 return true;
             }
-            if (key.isUp()) {
-                if (diffScroll > 0) diffScroll--;
-                return true;
-            }
-            if (key.isDown()) {
-                diffScroll = Math.min(diffScroll + 1, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
-                return true;
-            }
-            if (key.isKey(KeyCode.PAGE_UP)) {
-                diffScroll = Math.max(0, diffScroll - 10);
-                return true;
-            }
-            if (key.isKey(KeyCode.PAGE_DOWN)) {
-                diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
-                return true;
-            }
+            if (diffOverlay.handleScrollKey(key, lastContentHeight)) return true;
             if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
                 requestQuit();
                 return true;
@@ -474,15 +457,8 @@ class UpdatesTui {
             modifiedPom = preview.toXml();
         }
 
-        var fullDiff = UnifiedDiff.compute(originalPomContent, modifiedPom);
-        long changes = UnifiedDiff.changeCount(fullDiff);
-        if (changes == 0) {
-            status = "No changes to show";
-            return;
-        }
-        diffLines = UnifiedDiff.filterContext(fullDiff, 3);
-        diffScroll = 0;
-        status = changes + " line(s) changed";
+        long changes = diffOverlay.open(originalPomContent, modifiedPom);
+        status = changes == 0 ? "No changes to show" : changes + " line(s) changed";
     }
 
     private void selectAll() {
@@ -554,8 +530,8 @@ class UpdatesTui {
 
         renderHeader(frame, zones.get(0));
         lastContentHeight = zones.get(1).height();
-        if (diffLines != null) {
-            UnifiedDiff.render(frame, zones.get(1), diffLines, diffScroll, " POM Changes ");
+        if (diffOverlay.isActive()) {
+            diffOverlay.render(frame, zones.get(1), " POM Changes ");
         } else {
             renderUpdatesTable(frame, zones.get(1));
         }
@@ -671,7 +647,7 @@ class UpdatesTui {
             spans.add(Span.raw(":Discard and quit  "));
             spans.add(Span.raw("Esc").bold());
             spans.add(Span.raw(":Cancel"));
-        } else if (diffLines != null) {
+        } else if (diffOverlay.isActive()) {
             spans.add(Span.raw("\u2191\u2193").bold());
             spans.add(Span.raw(":Scroll  "));
             spans.add(Span.raw("Esc").bold());

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -49,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
 /**
@@ -113,7 +112,7 @@ class UpdatesTui {
     private final String projectGav;
     private final VersionResolver versionResolver;
     private final TableState tableState = new TableState();
-    private final ExecutorService httpPool = Executors.newFixedThreadPool(5);
+    private final ExecutorService httpPool = MojoHelper.newHttpPool();
     private final Map<String, SearchTui.PomInfo> pomInfoCache = new HashMap<>();
 
     private Filter filter = Filter.ALL;
@@ -126,6 +125,7 @@ class UpdatesTui {
     private boolean dirty;
     private boolean pendingQuit;
     private final DiffOverlay diffOverlay = new DiffOverlay();
+    private final HelpOverlay helpOverlay = new HelpOverlay();
     private int lastContentHeight;
 
     private TuiRunner runner;
@@ -326,6 +326,16 @@ class UpdatesTui {
             return false;
         }
 
+        // Help overlay mode
+        if (helpOverlay.isActive()) {
+            if (helpOverlay.handleKey(key)) return true;
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                requestQuit();
+                return true;
+            }
+            return false;
+        }
+
         if (key.isCtrlC() || key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
             requestQuit();
             return true;
@@ -385,6 +395,11 @@ class UpdatesTui {
 
         if (key.isCharIgnoreCase('d')) {
             toggleDiffView();
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('h')) {
+            helpOverlay.open(buildHelp());
             return true;
         }
 
@@ -548,7 +563,9 @@ class UpdatesTui {
 
         renderHeader(frame, zones.get(0));
         lastContentHeight = zones.get(1).height();
-        if (diffOverlay.isActive()) {
+        if (helpOverlay.isActive()) {
+            helpOverlay.render(frame, zones.get(1));
+        } else if (diffOverlay.isActive()) {
             diffOverlay.render(frame, zones.get(1), " POM Changes ");
         } else {
             renderUpdatesTable(frame, zones.get(1));
@@ -687,6 +704,8 @@ class UpdatesTui {
             spans.add(Span.raw(":Filter  "));
             spans.add(Span.raw("d").bold());
             spans.add(Span.raw(":Diff  "));
+            spans.add(Span.raw("h").bold());
+            spans.add(Span.raw(":Help  "));
             spans.add(Span.raw("q").bold());
             spans.add(Span.raw(":Quit"));
         }
@@ -733,6 +752,53 @@ class UpdatesTui {
         frame.renderWidget(Paragraph.from(Line.from(spans)), area);
     }
 
+    private List<HelpOverlay.Section> buildHelp() {
+        return List.of(
+                new HelpOverlay.Section(
+                        "Dependency Updates",
+                        List.of(
+                                new HelpOverlay.Entry("", "Checks Maven Central for newer versions of each"),
+                                new HelpOverlay.Entry("", "declared dependency. The table shows the current"),
+                                new HelpOverlay.Entry("", "version, the latest available version, and the"),
+                                new HelpOverlay.Entry("", "update type (patch, minor, or major)."),
+                                new HelpOverlay.Entry("", ""),
+                                new HelpOverlay.Entry("", "Select the updates you want with Space, then press"),
+                                new HelpOverlay.Entry("", "Enter to write changes to the POM. Use 'd' to"),
+                                new HelpOverlay.Entry("", "preview the exact POM diff before applying."))),
+                new HelpOverlay.Section(
+                        "Table Columns",
+                        List.of(
+                                new HelpOverlay.Entry("[ ] / [x]", "Selection checkbox"),
+                                new HelpOverlay.Entry("dependency", "groupId:artifactId"),
+                                new HelpOverlay.Entry("current", "Version currently in the POM"),
+                                new HelpOverlay.Entry("latest", "Newest version on Maven Central"),
+                                new HelpOverlay.Entry("type", "patch / minor / major"))),
+                new HelpOverlay.Section(
+                        "Colors",
+                        List.of(
+                                new HelpOverlay.Entry("green", "Patch update \u2014 bug fixes, safe to apply"),
+                                new HelpOverlay.Entry("yellow", "Minor update \u2014 new features, usually compatible"),
+                                new HelpOverlay.Entry("red", "Major update \u2014 breaking changes possible"),
+                                new HelpOverlay.Entry("cyan", "Artifact name/info in footer"))),
+                new HelpOverlay.Section(
+                        "Selection & Filtering",
+                        List.of(
+                                new HelpOverlay.Entry("Space", "Toggle selection of current dependency"),
+                                new HelpOverlay.Entry("a / n", "Select all / deselect all"),
+                                new HelpOverlay.Entry("Enter", "Apply selected updates to POM"),
+                                new HelpOverlay.Entry("1", "Show all updates"),
+                                new HelpOverlay.Entry("2", "Patch only (e.g. 1.0.0 \u2192 1.0.1)"),
+                                new HelpOverlay.Entry("3", "Minor only (e.g. 1.0.0 \u2192 1.1.0)"),
+                                new HelpOverlay.Entry("4", "Major only (e.g. 1.0.0 \u2192 2.0.0)"))),
+                new HelpOverlay.Section(
+                        "General",
+                        List.of(
+                                new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("d", "Preview POM changes as a unified diff"),
+                                new HelpOverlay.Entry("h", "Toggle this help screen"),
+                                new HelpOverlay.Entry("q / Esc", "Quit (prompts to save if modified)"))));
+    }
+
     /**
      * Fetches and caches POM metadata for the currently selected dependency if it is not already cached.
      *
@@ -747,7 +813,7 @@ class UpdatesTui {
         var dep = displayDeps.get(sel);
         String pomKey = dep.groupId + ":" + dep.artifactId + ":" + dep.version;
         if (pomInfoCache.containsKey(pomKey)) return;
-        pomInfoCache.put(pomKey, new SearchTui.PomInfo(null, null, null, null, null, null));
+        pomInfoCache.put(pomKey, new SearchTui.PomInfo(null, null, null, null, null, null, null));
 
         CompletableFuture.supplyAsync(
                         () -> SearchTui.fetchPomFromCentral(dep.groupId, dep.artifactId, dep.version), httpPool)

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -81,6 +81,7 @@ class UpdatesTui {
         VersionComparator.UpdateType updateType;
         boolean selected;
         boolean managed;
+        String versionProperty; // shared property name, e.g. "mavenVersion" from "${mavenVersion}"
 
         DependencyInfo(String groupId, String artifactId, String version, String scope, String type) {
             this.groupId = groupId;
@@ -120,6 +121,13 @@ class UpdatesTui {
     boolean loading = true;
     int loadedCount = 0;
     int failedCount = 0;
+    private final String originalPomContent;
+    private final PomEditor editor;
+    private boolean dirty;
+    private boolean pendingQuit;
+    private List<UnifiedDiff.DiffLine> diffLines;
+    private int diffScroll;
+    private int lastContentHeight;
 
     private TuiRunner runner;
 
@@ -149,9 +157,47 @@ class UpdatesTui {
         this.pomPath = pomPath;
         this.projectGav = projectGav;
         this.versionResolver = versionResolver;
+        String pom;
+        try {
+            pom = Files.readString(Path.of(pomPath));
+        } catch (Exception e) {
+            pom = "<project/>";
+        }
+        this.originalPomContent = pom;
+        this.editor = new PomEditor(Document.of(pom));
+        detectPropertyGroups();
         if (!displayDeps.isEmpty()) {
             tableState.select(0);
         }
+    }
+
+    private void detectPropertyGroups() {
+        try {
+            eu.maveniverse.domtrip.Element root = editor.document().root();
+            scanDependencyVersions(root.childElement("dependencies").orElse(null));
+            root.childElement("dependencyManagement")
+                    .flatMap(dm -> dm.childElement("dependencies"))
+                    .ifPresent(this::scanDependencyVersions);
+        } catch (Exception ignored) {
+            // best-effort
+        }
+    }
+
+    private void scanDependencyVersions(eu.maveniverse.domtrip.Element deps) {
+        if (deps == null) return;
+        deps.childElements("dependency").forEach(dep -> {
+            String gid = dep.childTextOr("groupId", "");
+            String aid = dep.childTextOr("artifactId", "");
+            String rawVersion = dep.childTextOr("version", null);
+            if (rawVersion != null && rawVersion.startsWith("${") && rawVersion.endsWith("}")) {
+                String prop = rawVersion.substring(2, rawVersion.length() - 1);
+                for (DependencyInfo di : allDeps) {
+                    if (di.groupId.equals(gid) && di.artifactId.equals(aid)) {
+                        di.versionProperty = prop;
+                    }
+                }
+            }
+        });
     }
 
     void run() throws Exception {
@@ -249,8 +295,52 @@ class UpdatesTui {
             return true;
         }
 
-        if (key.isCtrlC() || key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q')) {
-            runner.quit();
+        // Save prompt mode
+        if (pendingQuit) {
+            if (key.isCharIgnoreCase('y')) {
+                saveAndQuit();
+                return true;
+            }
+            if (key.isCharIgnoreCase('n')) {
+                runner.quit();
+                return true;
+            }
+            if (key.isKey(KeyCode.ESCAPE)) {
+                pendingQuit = false;
+                status = "Quit cancelled";
+                return true;
+            }
+            return false;
+        }
+
+        // Diff overlay mode — Esc closes overlay first
+        if (diffLines != null) {
+            if (key.isKey(KeyCode.ESCAPE)) {
+                diffLines = null;
+                diffScroll = 0;
+                return true;
+            }
+            if (key.isUp()) {
+                if (diffScroll > 0) diffScroll--;
+                return true;
+            }
+            if (key.isDown()) {
+                diffScroll = Math.min(diffScroll + 1, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            if (key.isKey(KeyCode.PAGE_UP)) {
+                diffScroll = Math.max(0, diffScroll - 10);
+                return true;
+            }
+            if (key.isKey(KeyCode.PAGE_DOWN)) {
+                diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            return false;
+        }
+
+        if (key.isCtrlC() || key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
+            requestQuit();
             return true;
         }
 
@@ -306,6 +396,11 @@ class UpdatesTui {
             return true;
         }
 
+        if (key.isCharIgnoreCase('d')) {
+            toggleDiffView();
+            return true;
+        }
+
         return false;
     }
 
@@ -320,9 +415,68 @@ class UpdatesTui {
         if (sel >= 0 && sel < displayDeps.size()) {
             var dep = displayDeps.get(sel);
             if (dep.hasUpdate()) {
-                dep.selected = !dep.selected;
+                boolean newState = !dep.selected;
+                dep.selected = newState;
+                if (dep.versionProperty != null) {
+                    for (var other : allDeps) {
+                        if (other != dep && dep.versionProperty.equals(other.versionProperty)) {
+                            other.selected = newState;
+                        }
+                    }
+                }
             }
         }
+    }
+
+    private void requestQuit() {
+        if (dirty) {
+            pendingQuit = true;
+            status = "Save changes to POM?";
+        } else {
+            runner.quit();
+        }
+    }
+
+    private void saveAndQuit() {
+        try {
+            Files.writeString(Path.of(pomPath), editor.toXml());
+            runner.quit();
+        } catch (Exception e) {
+            pendingQuit = false;
+            status = "Failed to save: " + e.getMessage();
+        }
+    }
+
+    private void toggleDiffView() {
+        // Include both staged changes and currently selected (not yet applied) updates
+        List<DependencyInfo> pendingSelected =
+                displayDeps.stream().filter(d -> d.selected && d.hasUpdate()).toList();
+
+        String modifiedPom;
+        if (pendingSelected.isEmpty()) {
+            modifiedPom = editor.toXml();
+        } else {
+            PomEditor preview = new PomEditor(Document.of(editor.toXml()));
+            for (var dep : pendingSelected) {
+                var coords = Coordinates.of(dep.groupId, dep.artifactId, dep.newestVersion);
+                if (dep.managed) {
+                    preview.dependencies().updateManagedDependency(true, coords);
+                } else {
+                    preview.dependencies().updateDependency(true, coords);
+                }
+            }
+            modifiedPom = preview.toXml();
+        }
+
+        var fullDiff = UnifiedDiff.compute(originalPomContent, modifiedPom);
+        long changes = UnifiedDiff.changeCount(fullDiff);
+        if (changes == 0) {
+            status = "No changes to show";
+            return;
+        }
+        diffLines = UnifiedDiff.filterContext(fullDiff, 3);
+        diffScroll = 0;
+        status = changes + " line(s) changed";
     }
 
     private void selectAll() {
@@ -361,9 +515,6 @@ class UpdatesTui {
         }
 
         try {
-            String pomContent = Files.readString(Path.of(pomPath));
-            PomEditor editor = new PomEditor(Document.of(pomContent));
-
             for (var dep : toUpdate) {
                 var coords = Coordinates.of(dep.groupId, dep.artifactId, dep.newestVersion);
                 if (dep.managed) {
@@ -373,10 +524,9 @@ class UpdatesTui {
                 }
             }
 
-            Files.writeString(Path.of(pomPath), editor.toXml());
-            status = "Updated " + toUpdate.size() + " dependencies in POM";
+            dirty = true;
+            status = "Staged " + toUpdate.size() + " update(s) \u2014 save on exit";
 
-            // Update model
             for (var dep : toUpdate) {
                 dep.version = dep.newestVersion;
                 dep.newestVersion = null;
@@ -385,7 +535,7 @@ class UpdatesTui {
             }
             applyFilter();
         } catch (Exception e) {
-            status = "Failed to update POM: " + e.getMessage();
+            status = "Failed to update: " + e.getMessage();
         }
     }
 
@@ -397,7 +547,12 @@ class UpdatesTui {
                 .split(frame.area());
 
         renderHeader(frame, zones.get(0));
-        renderUpdatesTable(frame, zones.get(1));
+        lastContentHeight = zones.get(1).height();
+        if (diffLines != null) {
+            UnifiedDiff.render(frame, zones.get(1), diffLines, diffScroll, " POM Changes ");
+        } else {
+            renderUpdatesTable(frame, zones.get(1));
+        }
         renderInfoBar(frame, zones.get(2));
     }
 
@@ -414,6 +569,9 @@ class UpdatesTui {
         if (loading) {
             spans.add(Span.raw("  Checking " + loadedCount + "/" + allDeps.size() + "\u2026")
                     .dim());
+        }
+        if (dirty) {
+            spans.add(Span.raw("  [modified]").fg(Color.YELLOW));
         }
 
         Paragraph header = Paragraph.builder()
@@ -494,26 +652,44 @@ class UpdatesTui {
 
         // Status
         List<Span> statusSpans = new ArrayList<>();
-        statusSpans.add(Span.raw(" " + status).fg(Color.GREEN));
+        statusSpans.add(Span.raw(" " + status).fg(pendingQuit ? Color.YELLOW : Color.GREEN));
         frame.renderWidget(Paragraph.from(Line.from(statusSpans)), rows.get(1));
 
         // Key bindings
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" "));
-        spans.add(Span.raw("\u2191\u2193").bold());
-        spans.add(Span.raw(":Nav  "));
-        spans.add(Span.raw("Space").bold());
-        spans.add(Span.raw(":Toggle  "));
-        spans.add(Span.raw("a").bold());
-        spans.add(Span.raw(":All  "));
-        spans.add(Span.raw("n").bold());
-        spans.add(Span.raw(":None  "));
-        spans.add(Span.raw("Enter").bold());
-        spans.add(Span.raw(":Apply  "));
-        spans.add(Span.raw("1-4").bold());
-        spans.add(Span.raw(":Filter  "));
-        spans.add(Span.raw("q").bold());
-        spans.add(Span.raw(":Quit"));
+        if (pendingQuit) {
+            spans.add(Span.raw("y").bold());
+            spans.add(Span.raw(":Save and quit  "));
+            spans.add(Span.raw("n").bold());
+            spans.add(Span.raw(":Discard and quit  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Cancel"));
+        } else if (diffLines != null) {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Scroll  "));
+            spans.add(Span.raw("Esc").bold());
+            spans.add(Span.raw(":Close  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        } else {
+            spans.add(Span.raw("\u2191\u2193").bold());
+            spans.add(Span.raw(":Nav  "));
+            spans.add(Span.raw("Space").bold());
+            spans.add(Span.raw(":Toggle  "));
+            spans.add(Span.raw("a").bold());
+            spans.add(Span.raw(":All  "));
+            spans.add(Span.raw("n").bold());
+            spans.add(Span.raw(":None  "));
+            spans.add(Span.raw("Enter").bold());
+            spans.add(Span.raw(":Apply  "));
+            spans.add(Span.raw("1-4").bold());
+            spans.add(Span.raw(":Filter  "));
+            spans.add(Span.raw("d").bold());
+            spans.add(Span.raw(":Diff  "));
+            spans.add(Span.raw("q").bold());
+            spans.add(Span.raw(":Quit"));
+        }
 
         frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(2));
     }

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -160,8 +160,10 @@ class UpdatesTui {
         String pom;
         try {
             pom = Files.readString(Path.of(pomPath));
-        } catch (Exception e) {
+        } catch (java.nio.file.NoSuchFileException e) {
             pom = "<project/>";
+        } catch (Exception e) {
+            throw new IllegalStateException("Cannot read POM: " + pomPath, e);
         }
         this.originalPomContent = pom;
         this.editor = new PomEditor(Document.of(pom));
@@ -334,6 +336,10 @@ class UpdatesTui {
             }
             if (key.isKey(KeyCode.PAGE_DOWN)) {
                 diffScroll = Math.min(diffScroll + 10, UnifiedDiff.maxScroll(diffLines, lastContentHeight));
+                return true;
+            }
+            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+                requestQuit();
                 return true;
             }
             return false;

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -159,8 +159,6 @@ class UpdatesTui {
         String pom;
         try {
             pom = Files.readString(Path.of(pomPath));
-        } catch (java.nio.file.NoSuchFileException e) {
-            pom = "<project/>";
         } catch (Exception e) {
             throw new IllegalStateException("Cannot read POM: " + pomPath, e);
         }
@@ -428,6 +426,12 @@ class UpdatesTui {
 
     private void saveAndQuit() {
         try {
+            String currentOnDisk = Files.readString(Path.of(pomPath));
+            if (!currentOnDisk.equals(originalPomContent)) {
+                pendingQuit = false;
+                status = "POM modified externally \u2014 save aborted";
+                return;
+            }
             Files.writeString(Path.of(pomPath), editor.toXml());
             runner.quit();
         } catch (Exception e) {
@@ -438,8 +442,9 @@ class UpdatesTui {
 
     private void toggleDiffView() {
         // Include both staged changes and currently selected (not yet applied) updates
+        // Use allDeps to honor property-linked peers outside the filtered view
         List<DependencyInfo> pendingSelected =
-                displayDeps.stream().filter(d -> d.selected && d.hasUpdate()).toList();
+                allDeps.stream().filter(d -> d.selected && d.hasUpdate()).toList();
 
         String modifiedPom;
         if (pendingSelected.isEmpty()) {
@@ -488,8 +493,9 @@ class UpdatesTui {
     }
 
     private void applyUpdates() {
+        // Use allDeps to honor property-linked peers outside the filtered view
         List<DependencyInfo> toUpdate =
-                displayDeps.stream().filter(d -> d.selected && d.hasUpdate()).toList();
+                allDeps.stream().filter(d -> d.selected && d.hasUpdate()).toList();
 
         if (toUpdate.isEmpty()) {
             status = "No updates selected";
@@ -497,6 +503,18 @@ class UpdatesTui {
         }
 
         try {
+            // Validate on a preview editor first to avoid partial mutations
+            PomEditor preview = new PomEditor(Document.of(editor.toXml()));
+            for (var dep : toUpdate) {
+                var coords = Coordinates.of(dep.groupId, dep.artifactId, dep.newestVersion);
+                if (dep.managed) {
+                    preview.dependencies().updateManagedDependency(true, coords);
+                } else {
+                    preview.dependencies().updateDependency(true, coords);
+                }
+            }
+
+            // All updates succeeded on preview — apply to real editor
             for (var dep : toUpdate) {
                 var coords = Coordinates.of(dep.groupId, dep.artifactId, dep.newestVersion);
                 if (dep.managed) {

--- a/src/test/java/eu/maveniverse/maven/pilot/AlignTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AlignTuiTest.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import eu.maveniverse.domtrip.maven.AlignOptions;
+import org.junit.jupiter.api.Test;
+
+class AlignTuiTest {
+
+    @Test
+    void nextEnumWrapsAround() {
+        var values = AlignOptions.VersionStyle.values();
+        assertThat(AlignTui.nextEnum(values, AlignOptions.VersionStyle.INLINE))
+                .isEqualTo(AlignOptions.VersionStyle.MANAGED);
+        assertThat(AlignTui.nextEnum(values, AlignOptions.VersionStyle.MANAGED))
+                .isEqualTo(AlignOptions.VersionStyle.INLINE);
+    }
+
+    @Test
+    void prevEnumWrapsAround() {
+        var values = AlignOptions.VersionStyle.values();
+        assertThat(AlignTui.prevEnum(values, AlignOptions.VersionStyle.INLINE))
+                .isEqualTo(AlignOptions.VersionStyle.MANAGED);
+        assertThat(AlignTui.prevEnum(values, AlignOptions.VersionStyle.MANAGED))
+                .isEqualTo(AlignOptions.VersionStyle.INLINE);
+    }
+
+    @Test
+    void nextEnumCyclesAllPropertyNamingValues() {
+        var values = AlignOptions.PropertyNamingConvention.values();
+        var current = AlignOptions.PropertyNamingConvention.DOT_SUFFIX;
+        current = AlignTui.nextEnum(values, current);
+        assertThat(current).isEqualTo(AlignOptions.PropertyNamingConvention.DASH_SUFFIX);
+        current = AlignTui.nextEnum(values, current);
+        assertThat(current).isEqualTo(AlignOptions.PropertyNamingConvention.CAMEL_CASE);
+        current = AlignTui.nextEnum(values, current);
+        assertThat(current).isEqualTo(AlignOptions.PropertyNamingConvention.DOT_PREFIX);
+        current = AlignTui.nextEnum(values, current);
+        assertThat(current).isEqualTo(AlignOptions.PropertyNamingConvention.DOT_SUFFIX);
+    }
+
+    @Test
+    void buildSelectedOptionsReflectsDefaults() {
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.PROPERTY)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+
+        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", "<project/>", detected);
+        var options = tui.buildSelectedOptions();
+
+        assertThat(options.versionStyle()).isEqualTo(AlignOptions.VersionStyle.MANAGED);
+        assertThat(options.versionSource()).isEqualTo(AlignOptions.VersionSource.PROPERTY);
+        assertThat(options.namingConvention()).isEqualTo(AlignOptions.PropertyNamingConvention.DOT_SUFFIX);
+    }
+
+    @Test
+    void cycleForwardChangesSelectedStyle() {
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.INLINE)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+
+        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", "<project/>", detected);
+        tui.cycleForward(); // row 0 = VersionStyle
+
+        var options = tui.buildSelectedOptions();
+        assertThat(options.versionStyle()).isEqualTo(AlignOptions.VersionStyle.MANAGED);
+    }
+
+    @Test
+    void cycleBackwardChangesSelectedStyle() {
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+
+        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", "<project/>", detected);
+        tui.cycleBackward(); // row 0 = VersionStyle
+
+        var options = tui.buildSelectedOptions();
+        assertThat(options.versionStyle()).isEqualTo(AlignOptions.VersionStyle.INLINE);
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/AlignTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AlignTuiTest.java
@@ -65,7 +65,7 @@ class AlignTuiTest {
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
 
-        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", "<project/>", detected);
+        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", detected);
         var options = tui.buildSelectedOptions();
 
         assertThat(options.versionStyle()).isEqualTo(AlignOptions.VersionStyle.MANAGED);
@@ -81,7 +81,7 @@ class AlignTuiTest {
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
 
-        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", "<project/>", detected);
+        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", detected);
         tui.cycleForward(); // row 0 = VersionStyle
 
         var options = tui.buildSelectedOptions();
@@ -96,7 +96,7 @@ class AlignTuiTest {
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
 
-        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", "<project/>", detected);
+        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", detected);
         tui.cycleBackward(); // row 0 = VersionStyle
 
         var options = tui.buildSelectedOptions();

--- a/src/test/java/eu/maveniverse/maven/pilot/ConflictsDemoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ConflictsDemoTest.java
@@ -22,9 +22,12 @@ import dev.tamboui.layout.Size;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.pilot.Pilot;
 import dev.tamboui.tui.pilot.TuiTestRunner;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Demo test for Conflict Resolution TUI.
@@ -32,7 +35,9 @@ import org.junit.jupiter.api.Test;
 class ConflictsDemoTest {
 
     @Test
-    void browseConflictsAndToggleDetails() throws Exception {
+    void browseConflictsAndToggleDetails(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
         List<ConflictsTui.ConflictGroup> conflicts = new ArrayList<>();
 
         // A real conflict: commons-lang3
@@ -48,7 +53,7 @@ class ConflictsDemoTest {
         var e4 = new ConflictsTui.ConflictEntry("org.slf4j", "slf4j-api", "2.0.9", "2.0.9", "direct", "compile");
         conflicts.add(new ConflictsTui.ConflictGroup("org.slf4j:slf4j-api", List.of(e3, e4)));
 
-        ConflictsTui tui = new ConflictsTui(conflicts, "/tmp/test-pom.xml", "com.example:demo:1.0.0");
+        ConflictsTui tui = new ConflictsTui(conflicts, pomPath, "com.example:demo:1.0.0");
 
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
 

--- a/src/test/java/eu/maveniverse/maven/pilot/DependenciesDemoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/DependenciesDemoTest.java
@@ -37,7 +37,9 @@ import org.junit.jupiter.api.io.TempDir;
 class DependenciesDemoTest {
 
     @Test
-    void browseDeclaredAndTransitive() throws Exception {
+    void browseDeclaredAndTransitive(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
         List<DependenciesTui.DepEntry> declared = new ArrayList<>();
         var d1 = new DependenciesTui.DepEntry("com.google.guava", "guava", "", "33.0.0-jre", "compile", true);
         d1.usageStatus = DependencyUsageAnalyzer.UsageStatus.USED;
@@ -60,8 +62,7 @@ class DependenciesDemoTest {
         transitive.add(t2);
 
         // Use a non-existent POM path since we won't actually write
-        DependenciesTui tui =
-                new DependenciesTui(declared, transitive, "/tmp/test-pom.xml", "com.example:demo:1.0.0", true);
+        DependenciesTui tui = new DependenciesTui(declared, transitive, pomPath, "com.example:demo:1.0.0", true);
 
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
 
@@ -94,7 +95,9 @@ class DependenciesDemoTest {
     }
 
     @Test
-    void browseWithoutBytecodeAnalysis() throws Exception {
+    void browseWithoutBytecodeAnalysis(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
         List<DependenciesTui.DepEntry> declared = new ArrayList<>();
         declared.add(new DependenciesTui.DepEntry("com.google.guava", "guava", "", "33.0.0-jre", "compile", true));
         declared.add(new DependenciesTui.DepEntry("org.slf4j", "slf4j-api", "", "2.0.9", "compile", true));
@@ -105,7 +108,7 @@ class DependenciesDemoTest {
         transitive.add(t1);
 
         // bytecodeAnalyzed = false
-        DependenciesTui tui = new DependenciesTui(declared, transitive, "/tmp/test-pom.xml", "com.example:demo:1.0.0");
+        DependenciesTui tui = new DependenciesTui(declared, transitive, pomPath, "com.example:demo:1.0.0");
 
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
             Pilot pilot = testRunner.pilot();
@@ -123,9 +126,11 @@ class DependenciesDemoTest {
     }
 
     @Test
-    void emptyDependencyList() throws Exception {
-        DependenciesTui tui = new DependenciesTui(
-                new ArrayList<>(), new ArrayList<>(), "/tmp/test-pom.xml", "com.example:demo:1.0.0");
+    void emptyDependencyList(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
+        DependenciesTui tui =
+                new DependenciesTui(new ArrayList<>(), new ArrayList<>(), pomPath, "com.example:demo:1.0.0");
 
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
             Pilot pilot = testRunner.pilot();
@@ -140,14 +145,15 @@ class DependenciesDemoTest {
     }
 
     @Test
-    void undeterminedStatusRendering() throws Exception {
+    void undeterminedStatusRendering(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
         List<DependenciesTui.DepEntry> declared = new ArrayList<>();
         var d1 = new DependenciesTui.DepEntry("com.example", "unknown-lib", "", "1.0", "compile", true);
         d1.usageStatus = DependencyUsageAnalyzer.UsageStatus.UNDETERMINED;
         declared.add(d1);
 
-        DependenciesTui tui =
-                new DependenciesTui(declared, new ArrayList<>(), "/tmp/test-pom.xml", "com.example:demo:1.0.0", true);
+        DependenciesTui tui = new DependenciesTui(declared, new ArrayList<>(), pomPath, "com.example:demo:1.0.0", true);
 
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
             Pilot pilot = testRunner.pilot();

--- a/src/test/java/eu/maveniverse/maven/pilot/DependenciesDemoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/DependenciesDemoTest.java
@@ -190,28 +190,28 @@ class DependenciesDemoTest {
             pilot.press('s');
             pilot.pause();
 
-            String pomContent = Files.readString(pomFile);
+            String pomContent = tui.currentPomContent();
             assertThat(pomContent).contains("<scope>provided</scope>");
 
             // Press 's' again to cycle scope from provided -> runtime
             pilot.press('s');
             pilot.pause();
 
-            pomContent = Files.readString(pomFile);
+            pomContent = tui.currentPomContent();
             assertThat(pomContent).contains("<scope>runtime</scope>");
 
             // Press 's' again: runtime -> test
             pilot.press('s');
             pilot.pause();
 
-            pomContent = Files.readString(pomFile);
+            pomContent = tui.currentPomContent();
             assertThat(pomContent).contains("<scope>test</scope>");
 
             // Press 's' again: test -> compile (removes <scope> element)
             pilot.press('s');
             pilot.pause();
 
-            pomContent = Files.readString(pomFile);
+            pomContent = tui.currentPomContent();
             assertThat(pomContent).doesNotContain("<scope>");
 
             pilot.press('q');
@@ -248,11 +248,11 @@ class DependenciesDemoTest {
             Pilot pilot = testRunner.pilot();
             pilot.pause();
 
-            // Press 'd' to remove the selected dependency
-            pilot.press('d');
+            // Press 'x' to remove the selected dependency
+            pilot.press('x');
             pilot.pause();
 
-            String pomContent = Files.readString(pomFile);
+            String pomContent = tui.currentPomContent();
             assertThat(pomContent).doesNotContain("guava");
 
             pilot.press('q');
@@ -295,7 +295,7 @@ class DependenciesDemoTest {
             pilot.press('a');
             pilot.pause();
 
-            String pomContent = Files.readString(pomFile);
+            String pomContent = tui.currentPomContent();
             assertThat(pomContent).contains("guava");
 
             pilot.press('q');

--- a/src/test/java/eu/maveniverse/maven/pilot/DiffOverlayTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/DiffOverlayTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class DiffOverlayTest {
+
+    @Test
+    void initiallyInactive() {
+        DiffOverlay overlay = new DiffOverlay();
+        assertThat(overlay.isActive()).isFalse();
+        assertThat(overlay.lines()).isNull();
+        assertThat(overlay.scroll()).isEqualTo(0);
+    }
+
+    @Test
+    void openWithChanges() {
+        DiffOverlay overlay = new DiffOverlay();
+        long changes = overlay.open("line1\nline2\n", "line1\nmodified\n");
+
+        assertThat(changes).isGreaterThan(0);
+        assertThat(overlay.isActive()).isTrue();
+        assertThat(overlay.lines()).isNotEmpty();
+        assertThat(overlay.scroll()).isEqualTo(0);
+    }
+
+    @Test
+    void openWithNoChanges() {
+        DiffOverlay overlay = new DiffOverlay();
+        long changes = overlay.open("same content", "same content");
+
+        assertThat(changes).isEqualTo(0);
+        assertThat(overlay.isActive()).isFalse();
+    }
+
+    @Test
+    void close() {
+        DiffOverlay overlay = new DiffOverlay();
+        overlay.open("a\n", "b\n");
+        assertThat(overlay.isActive()).isTrue();
+
+        overlay.close();
+        assertThat(overlay.isActive()).isFalse();
+        assertThat(overlay.scroll()).isEqualTo(0);
+    }
+
+    @Test
+    void openAfterClose() {
+        DiffOverlay overlay = new DiffOverlay();
+        overlay.open("a\n", "b\n");
+        overlay.close();
+
+        long changes = overlay.open("x\n", "y\n");
+        assertThat(changes).isGreaterThan(0);
+        assertThat(overlay.isActive()).isTrue();
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/ReactorCollectorTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ReactorCollectorTest.java
@@ -1,0 +1,330 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ReactorCollectorTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path subdir(String name) throws IOException {
+        return Files.createDirectories(tempDir.resolve(name));
+    }
+
+    private MavenProject createProject(String groupId, String artifactId, String version, Path basedir) {
+        Model model = new Model();
+        model.setGroupId(groupId);
+        model.setArtifactId(artifactId);
+        model.setVersion(version);
+
+        Model originalModel = new Model();
+        originalModel.setGroupId(groupId);
+        originalModel.setArtifactId(artifactId);
+        originalModel.setVersion(version);
+
+        MavenProject project = new MavenProject(model);
+        project.setOriginalModel(originalModel);
+        project.setFile(basedir.resolve("pom.xml").toFile());
+        return project;
+    }
+
+    private Dependency dep(String groupId, String artifactId, String version) {
+        return dep(groupId, artifactId, version, null);
+    }
+
+    private Dependency dep(String groupId, String artifactId, String version, String scope) {
+        Dependency d = new Dependency();
+        d.setGroupId(groupId);
+        d.setArtifactId(artifactId);
+        d.setVersion(version);
+        d.setScope(scope);
+        return d;
+    }
+
+    @Test
+    void collectSingleProjectDependencies() {
+        MavenProject project = createProject("com.example", "app", "1.0", tempDir);
+        project.getModel().addDependency(dep("org.junit", "junit", "5.10.0", "test"));
+        project.getOriginalModel().addDependency(dep("org.junit", "junit", "5.10.0", "test"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        assertThat(result.allDependencies).hasSize(1);
+        assertThat(result.allDependencies.get(0).groupId).isEqualTo("org.junit");
+        assertThat(result.allDependencies.get(0).artifactId).isEqualTo("junit");
+        assertThat(result.allDependencies.get(0).primaryVersion).isEqualTo("5.10.0");
+        assertThat(result.allDependencies.get(0).usages).hasSize(1);
+    }
+
+    @Test
+    void collectDeduplicatesByGA() throws IOException {
+        Path dir1 = subdir("mod1");
+        Path dir2 = subdir("mod2");
+
+        MavenProject p1 = createProject("com.example", "mod1", "1.0", dir1);
+        p1.getModel().addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+        p1.getOriginalModel().addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+
+        MavenProject p2 = createProject("com.example", "mod2", "1.0", dir2);
+        p2.getModel().addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+        p2.getOriginalModel().addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(p1, p2));
+
+        assertThat(result.allDependencies).hasSize(1);
+        assertThat(result.allDependencies.get(0).usages).hasSize(2);
+        assertThat(result.allDependencies.get(0).moduleCount()).isEqualTo(2);
+    }
+
+    @Test
+    void collectDetectsPropertyVersion() {
+        MavenProject project = createProject("com.example", "app", "1.0", tempDir);
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+
+        Dependency origDep = dep("com.fasterxml", "jackson-core", "${jackson.version}");
+        project.getOriginalModel().addDependency(origDep);
+
+        Properties props = new Properties();
+        props.setProperty("jackson.version", "2.17.0");
+        project.getOriginalModel().setProperties(props);
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        assertThat(result.allDependencies).hasSize(1);
+        var dep = result.allDependencies.get(0);
+        assertThat(dep.propertyName).isEqualTo("jackson.version");
+        assertThat(dep.rawVersionExpr).isEqualTo("${jackson.version}");
+        assertThat(dep.propertyOrigin).isEqualTo(project);
+    }
+
+    @Test
+    void collectGroupsByProperty() {
+        MavenProject project = createProject("com.example", "app", "1.0", tempDir);
+
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-databind", "2.17.0"));
+
+        project.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-core", "${jackson.version}"));
+        project.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-databind", "${jackson.version}"));
+
+        Properties props = new Properties();
+        props.setProperty("jackson.version", "2.17.0");
+        project.getOriginalModel().setProperties(props);
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        assertThat(result.allDependencies).hasSize(2);
+        assertThat(result.propertyGroups).hasSize(1);
+        assertThat(result.propertyGroups.get(0).propertyName).isEqualTo("jackson.version");
+        assertThat(result.propertyGroups.get(0).dependencies).hasSize(2);
+        assertThat(result.ungroupedDependencies).isEmpty();
+    }
+
+    @Test
+    void collectSeparatesUngroupedDependencies() {
+        MavenProject project = createProject("com.example", "app", "1.0", tempDir);
+
+        // Property-based dependency
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        project.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-core", "${jackson.version}"));
+        Properties props = new Properties();
+        props.setProperty("jackson.version", "2.17.0");
+        project.getOriginalModel().setProperties(props);
+
+        // Direct version dependency
+        project.getModel().addDependency(dep("commons-io", "commons-io", "2.15.1"));
+        project.getOriginalModel().addDependency(dep("commons-io", "commons-io", "2.15.1"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        assertThat(result.allDependencies).hasSize(2);
+        assertThat(result.propertyGroups).hasSize(1);
+        assertThat(result.ungroupedDependencies).hasSize(1);
+        assertThat(result.ungroupedDependencies.get(0).groupId).isEqualTo("commons-io");
+    }
+
+    @Test
+    void collectManagedDependencies() {
+        MavenProject project = createProject("com.example", "app", "1.0", tempDir);
+
+        DependencyManagement mgmt = new DependencyManagement();
+        mgmt.addDependency(dep("org.junit", "junit", "5.10.0", "test"));
+        project.getModel().setDependencyManagement(mgmt);
+
+        DependencyManagement origMgmt = new DependencyManagement();
+        origMgmt.addDependency(dep("org.junit", "junit", "5.10.0", "test"));
+        project.getOriginalModel().setDependencyManagement(origMgmt);
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        assertThat(result.allDependencies).hasSize(1);
+        assertThat(result.allDependencies.get(0).usages.get(0).managed).isTrue();
+    }
+
+    @Test
+    void collectEmptyProjectList() {
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of());
+        assertThat(result.allDependencies).isEmpty();
+        assertThat(result.propertyGroups).isEmpty();
+        assertThat(result.ungroupedDependencies).isEmpty();
+    }
+
+    @Test
+    void propertyOriginReturnsNullWhenNotFound() {
+        MavenProject project = createProject("com.example", "app", "1.0", tempDir);
+
+        // Raw expression but no property defined in original model
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        project.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-core", "${jackson.version}"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        assertThat(result.allDependencies).hasSize(1);
+        var dep = result.allDependencies.get(0);
+        assertThat(dep.propertyName).isEqualTo("jackson.version");
+        assertThat(dep.propertyOrigin).isNull();
+        // Should be ungrouped since propertyOrigin is null
+        assertThat(result.ungroupedDependencies).hasSize(1);
+        assertThat(result.propertyGroups).isEmpty();
+    }
+
+    @Test
+    void compoundGroupingKeySeparatesSamePropertyFromDifferentOrigins() throws IOException {
+        Path dir1 = subdir("parent");
+        Path dir2 = subdir("child");
+
+        MavenProject parent = createProject("com.example", "parent", "1.0", dir1);
+        Properties parentProps = new Properties();
+        parentProps.setProperty("lib.version", "1.0");
+        parent.getOriginalModel().setProperties(parentProps);
+        parent.getModel().addDependency(dep("com.example", "lib-a", "1.0"));
+        parent.getOriginalModel().addDependency(dep("com.example", "lib-a", "${lib.version}"));
+
+        MavenProject child = createProject("com.example", "child", "1.0", dir2);
+        Properties childProps = new Properties();
+        childProps.setProperty("lib.version", "2.0");
+        child.getOriginalModel().setProperties(childProps);
+        child.getModel().addDependency(dep("com.example", "lib-b", "2.0"));
+        child.getOriginalModel().addDependency(dep("com.example", "lib-b", "${lib.version}"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(parent, child));
+
+        // Same property name but from different origins → two groups
+        assertThat(result.propertyGroups).hasSize(2);
+    }
+
+    @Test
+    void aggregatedDependencyGa() {
+        var dep = new ReactorCollector.AggregatedDependency("org.slf4j", "slf4j-api");
+        assertThat(dep.ga()).isEqualTo("org.slf4j:slf4j-api");
+    }
+
+    @Test
+    void aggregatedDependencyHasUpdate() {
+        var dep = new ReactorCollector.AggregatedDependency("g", "a");
+        dep.primaryVersion = "1.0";
+        assertThat(dep.hasUpdate()).isFalse();
+
+        dep.newestVersion = "2.0";
+        assertThat(dep.hasUpdate()).isTrue();
+
+        dep.newestVersion = "1.0";
+        assertThat(dep.hasUpdate()).isFalse();
+
+        dep.newestVersion = "";
+        assertThat(dep.hasUpdate()).isFalse();
+    }
+
+    @Test
+    void aggregatedDependencyIsPropertyManaged() {
+        var dep = new ReactorCollector.AggregatedDependency("g", "a");
+        assertThat(dep.isPropertyManaged()).isFalse();
+
+        dep.propertyName = "lib.version";
+        assertThat(dep.isPropertyManaged()).isTrue();
+    }
+
+    @Test
+    void propertyGroupHasUpdate() {
+        var group = new ReactorCollector.PropertyGroup("lib.version", "${lib.version}", "1.0", null);
+        assertThat(group.hasUpdate()).isFalse();
+
+        group.newestVersion = "2.0";
+        assertThat(group.hasUpdate()).isTrue();
+
+        group.newestVersion = "1.0";
+        assertThat(group.hasUpdate()).isFalse();
+
+        group.newestVersion = "";
+        assertThat(group.hasUpdate()).isFalse();
+    }
+
+    @Test
+    void propertyGroupTotalModuleCount() {
+        MavenProject p1 = createProject("com.example", "mod1", "1.0", tempDir);
+        var group = new ReactorCollector.PropertyGroup("lib.version", "${lib.version}", "1.0", null);
+
+        assertThat(group.totalModuleCount()).isEqualTo(0);
+
+        var dep1 = new ReactorCollector.AggregatedDependency("g", "a");
+        dep1.usages.add(new ReactorCollector.ModuleUsage(p1, "1.0", "compile", false));
+        group.dependencies.add(dep1);
+
+        assertThat(group.totalModuleCount()).isEqualTo(1);
+    }
+
+    @Test
+    void collectWithPropertyInParent() throws IOException {
+        Path parentDir = subdir("parent2");
+        Path childDir = subdir("child2");
+
+        MavenProject parent = createProject("com.example", "parent", "1.0", parentDir);
+        Properties parentProps = new Properties();
+        parentProps.setProperty("junit.version", "5.10.0");
+        parent.getOriginalModel().setProperties(parentProps);
+
+        MavenProject child = createProject("com.example", "child", "1.0", childDir);
+        child.setParent(parent);
+        child.getModel().addDependency(dep("org.junit", "junit", "5.10.0", "test"));
+        child.getOriginalModel().addDependency(dep("org.junit", "junit", "${junit.version}", "test"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(parent, child));
+
+        var dep = result.allDependencies.stream()
+                .filter(d -> d.artifactId.equals("junit"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(dep.propertyName).isEqualTo("junit.version");
+        assertThat(dep.propertyOrigin).isEqualTo(parent);
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/ReactorCollectorTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ReactorCollectorTest.java
@@ -294,7 +294,7 @@ class ReactorCollectorTest {
         MavenProject p1 = createProject("com.example", "mod1", "1.0", tempDir);
         var group = new ReactorCollector.PropertyGroup("lib.version", "${lib.version}", "1.0", null);
 
-        assertThat(group.totalModuleCount()).isEqualTo(0);
+        assertThat(group.totalModuleCount()).isZero();
 
         var dep1 = new ReactorCollector.AggregatedDependency("g", "a");
         dep1.usages.add(new ReactorCollector.ModuleUsage(p1, "1.0", "compile", false));

--- a/src/test/java/eu/maveniverse/maven/pilot/ReactorModelTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ReactorModelTest.java
@@ -1,0 +1,262 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ReactorModelTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path subdir(String name) throws IOException {
+        return Files.createDirectories(tempDir.resolve(name));
+    }
+
+    private MavenProject createProject(String artifactId, Path basedir) {
+        Model model = new Model();
+        model.setGroupId("com.example");
+        model.setArtifactId(artifactId);
+        model.setVersion("1.0");
+        MavenProject project = new MavenProject(model);
+        project.setFile(basedir.resolve("pom.xml").toFile());
+        return project;
+    }
+
+    @Test
+    void buildSingleProject() {
+        MavenProject root = createProject("root", tempDir);
+        ReactorModel model = ReactorModel.build(List.of(root));
+
+        assertThat(model.root).isNotNull();
+        assertThat(model.root.name).isEqualTo("root");
+        assertThat(model.root.depth).isEqualTo(0);
+        assertThat(model.root.hasChildren()).isFalse();
+        assertThat(model.root.isLeaf()).isTrue();
+        assertThat(model.allModules).hasSize(1);
+    }
+
+    @Test
+    void buildParentChild() throws IOException {
+        Path childDir = subdir("child");
+
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject child = createProject("child", childDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child));
+
+        assertThat(model.root.name).isEqualTo("parent");
+        assertThat(model.root.hasChildren()).isTrue();
+        assertThat(model.root.children).hasSize(1);
+        assertThat(model.root.children.get(0).name).isEqualTo("child");
+        assertThat(model.root.children.get(0).depth).isEqualTo(1);
+        assertThat(model.allModules).hasSize(2);
+    }
+
+    @Test
+    void buildNestedHierarchy() throws IOException {
+        Path coreDir = subdir("core");
+        Path modelDir = Files.createDirectories(coreDir.resolve("core-model"));
+
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject core = createProject("core", coreDir);
+        MavenProject coreModel = createProject("core-model", modelDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, core, coreModel));
+
+        assertThat(model.root.children).hasSize(1);
+        assertThat(model.root.children.get(0).name).isEqualTo("core");
+        assertThat(model.root.children.get(0).children).hasSize(1);
+        assertThat(model.root.children.get(0).children.get(0).name).isEqualTo("core-model");
+        assertThat(model.root.children.get(0).children.get(0).depth).isEqualTo(2);
+    }
+
+    @Test
+    void visibleNodesCollapsed() throws IOException {
+        Path childDir = subdir("child");
+        Path grandchildDir = Files.createDirectories(childDir.resolve("grandchild"));
+
+        MavenProject root = createProject("root", tempDir);
+        MavenProject child = createProject("child", childDir);
+        MavenProject grandchild = createProject("grandchild", grandchildDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child, grandchild));
+
+        // Root is expanded by default (depth 0 < 2), child is expanded (depth 1 < 2)
+        List<ReactorModel.ModuleNode> visible = model.visibleNodes();
+        assertThat(visible).hasSize(3);
+
+        // Collapse child
+        model.root.children.get(0).expanded = false;
+        visible = model.visibleNodes();
+        assertThat(visible).hasSize(2);
+        assertThat(visible.get(0).name).isEqualTo("root");
+        assertThat(visible.get(1).name).isEqualTo("child");
+    }
+
+    @Test
+    void visibleNodesExpanded() throws IOException {
+        Path childDir = subdir("child2");
+
+        MavenProject root = createProject("root", tempDir);
+        MavenProject child = createProject("child", childDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child));
+
+        // All expanded by default (both depth < 2)
+        List<ReactorModel.ModuleNode> visible = model.visibleNodes();
+        assertThat(visible).hasSize(2);
+    }
+
+    @Test
+    void filterByName() throws IOException {
+        Path coreDir = subdir("core");
+        Path apiDir = subdir("api");
+
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject core = createProject("core-module", coreDir);
+        MavenProject api = createProject("api-module", apiDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, core, api));
+
+        List<ReactorModel.ModuleNode> filtered = model.filter("core");
+        assertThat(filtered).hasSize(1);
+        assertThat(filtered.get(0).name).isEqualTo("core-module");
+    }
+
+    @Test
+    void filterCaseInsensitive() throws IOException {
+        Path childDir = subdir("child3");
+
+        MavenProject root = createProject("ROOT-project", tempDir);
+        MavenProject child = createProject("Child-Module", childDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child));
+
+        assertThat(model.filter("root")).hasSize(1);
+        assertThat(model.filter("ROOT")).hasSize(1);
+        assertThat(model.filter("child")).hasSize(1);
+    }
+
+    @Test
+    void filterByGa() throws IOException {
+        Path childDir = subdir("child4");
+
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject child = createProject("child", childDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child));
+
+        List<ReactorModel.ModuleNode> filtered = model.filter("com.example:child");
+        assertThat(filtered).hasSize(1);
+        assertThat(filtered.get(0).name).isEqualTo("child");
+    }
+
+    @Test
+    void filterNoMatch() {
+        MavenProject root = createProject("app", tempDir);
+        ReactorModel model = ReactorModel.build(List.of(root));
+
+        assertThat(model.filter("nonexistent")).isEmpty();
+    }
+
+    @Test
+    void recomputeCounts() throws IOException {
+        Path coreDir = subdir("core2");
+        Path apiDir = subdir("api2");
+
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject core = createProject("core", coreDir);
+        MavenProject api = createProject("api", apiDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, core, api));
+
+        model.root.ownUpdateCount = 2;
+        model.root.children.get(0).ownUpdateCount = 3;
+        model.root.children.get(1).ownUpdateCount = 1;
+
+        model.recomputeCounts();
+
+        assertThat(model.root.totalUpdateCount).isEqualTo(6); // 2 + 3 + 1
+        assertThat(model.root.children.get(0).totalUpdateCount).isEqualTo(3);
+        assertThat(model.root.children.get(1).totalUpdateCount).isEqualTo(1);
+    }
+
+    @Test
+    void recomputeCountsNested() throws IOException {
+        Path coreDir = subdir("core3");
+        Path modelDir = Files.createDirectories(coreDir.resolve("model"));
+
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject core = createProject("core", coreDir);
+        MavenProject coreModel = createProject("model", modelDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, core, coreModel));
+
+        model.root.ownUpdateCount = 1;
+        model.root.children.get(0).ownUpdateCount = 2;
+        model.root.children.get(0).children.get(0).ownUpdateCount = 5;
+
+        model.recomputeCounts();
+
+        assertThat(model.root.totalUpdateCount).isEqualTo(8); // 1 + 2 + 5
+        assertThat(model.root.children.get(0).totalUpdateCount).isEqualTo(7); // 2 + 5
+        assertThat(model.root.children.get(0).children.get(0).totalUpdateCount).isEqualTo(5);
+    }
+
+    @Test
+    void buildEmptyProjectListThrows() {
+        assertThatThrownBy(() -> ReactorModel.build(List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("No projects in reactor");
+    }
+
+    @Test
+    void moduleNodeGaAndGav() {
+        MavenProject project = createProject("myapp", tempDir);
+        ReactorModel.ModuleNode node = new ReactorModel.ModuleNode(project, 0);
+
+        assertThat(node.ga()).isEqualTo("com.example:myapp");
+        assertThat(node.gav()).isEqualTo("com.example:myapp:1.0");
+    }
+
+    @Test
+    void moduleNodeDefaultExpansion() {
+        MavenProject project = createProject("myapp", tempDir);
+
+        ReactorModel.ModuleNode depth0 = new ReactorModel.ModuleNode(project, 0);
+        assertThat(depth0.expanded).isTrue();
+
+        ReactorModel.ModuleNode depth1 = new ReactorModel.ModuleNode(project, 1);
+        assertThat(depth1.expanded).isTrue();
+
+        ReactorModel.ModuleNode depth2 = new ReactorModel.ModuleNode(project, 2);
+        assertThat(depth2.expanded).isFalse();
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/ScreenshotTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ScreenshotTest.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Generates SVG screenshots of each TUI screen for documentation.
@@ -170,7 +171,9 @@ class ScreenshotTest {
     }
 
     @Test
-    void dependencyUpdates() throws Exception {
+    void dependencyUpdates(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
         List<UpdatesTui.DependencyInfo> deps = new ArrayList<>();
 
         var d1 = new UpdatesTui.DependencyInfo("com.google.guava", "guava", "33.0.0-jre", "compile", "jar");
@@ -198,7 +201,7 @@ class ScreenshotTest {
         d5.updateType = VersionComparator.UpdateType.MINOR;
         deps.add(d5);
 
-        UpdatesTui tui = new UpdatesTui(deps, "/tmp/test-pom.xml", "com.example:demo:1.0.0", (g, a) -> List.of());
+        UpdatesTui tui = new UpdatesTui(deps, pomPath, "com.example:demo:1.0.0", (g, a) -> List.of());
 
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(WIDTH, HEIGHT))) {
             Pilot pilot = testRunner.pilot();
@@ -213,7 +216,9 @@ class ScreenshotTest {
     }
 
     @Test
-    void dependencyAnalysis() throws Exception {
+    void dependencyAnalysis(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
         List<DependenciesTui.DepEntry> declared = new ArrayList<>();
         var d1 = new DependenciesTui.DepEntry("com.google.guava", "guava", "", "33.0.0-jre", "compile", true);
         d1.usageStatus = DependencyUsageAnalyzer.UsageStatus.USED;
@@ -238,8 +243,7 @@ class ScreenshotTest {
         t2.usageStatus = DependencyUsageAnalyzer.UsageStatus.UNUSED;
         transitive.add(t2);
 
-        DependenciesTui tui =
-                new DependenciesTui(declared, transitive, "/tmp/test-pom.xml", "com.example:demo:1.0.0", true);
+        DependenciesTui tui = new DependenciesTui(declared, transitive, pomPath, "com.example:demo:1.0.0", true);
 
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(WIDTH, HEIGHT))) {
             Pilot pilot = testRunner.pilot();
@@ -251,7 +255,9 @@ class ScreenshotTest {
     }
 
     @Test
-    void conflictResolution() throws Exception {
+    void conflictResolution(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
         List<ConflictsTui.ConflictGroup> conflicts = new ArrayList<>();
 
         var e1 = new ConflictsTui.ConflictEntry(
@@ -265,7 +271,7 @@ class ScreenshotTest {
         var e4 = new ConflictsTui.ConflictEntry("org.slf4j", "slf4j-api", "2.0.9", "2.0.9", "direct", "compile");
         conflicts.add(new ConflictsTui.ConflictGroup("org.slf4j:slf4j-api", List.of(e3, e4)));
 
-        ConflictsTui tui = new ConflictsTui(conflicts, "/tmp/test-pom.xml", "com.example:demo:1.0.0");
+        ConflictsTui tui = new ConflictsTui(conflicts, pomPath, "com.example:demo:1.0.0");
 
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(WIDTH, HEIGHT))) {
             Pilot pilot = testRunner.pilot();

--- a/src/test/java/eu/maveniverse/maven/pilot/UnifiedDiffTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UnifiedDiffTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class UnifiedDiffTest {
+
+    @Test
+    void identicalInputsProduceAllContext() {
+        String text = "line1\nline2\nline3";
+        var result = UnifiedDiff.compute(text, text);
+
+        assertThat(result).hasSize(3);
+        assertThat(result).allMatch(dl -> dl.type() == UnifiedDiff.Type.CONTEXT);
+        assertThat(result.get(0).text()).isEqualTo("line1");
+        assertThat(result.get(1).text()).isEqualTo("line2");
+        assertThat(result.get(2).text()).isEqualTo("line3");
+    }
+
+    @Test
+    void emptyOriginalProducesAllAdded() {
+        var result = UnifiedDiff.compute("", "line1\nline2");
+
+        assertThat(result).hasSize(2);
+        assertThat(result).allMatch(dl -> dl.type() == UnifiedDiff.Type.ADDED);
+        assertThat(result.get(0).text()).isEqualTo("line1");
+        assertThat(result.get(1).text()).isEqualTo("line2");
+    }
+
+    @Test
+    void emptyModifiedProducesAllRemoved() {
+        var result = UnifiedDiff.compute("line1\nline2", "");
+
+        assertThat(result).hasSize(2);
+        assertThat(result).allMatch(dl -> dl.type() == UnifiedDiff.Type.REMOVED);
+    }
+
+    @Test
+    void singleLineChange() {
+        var result = UnifiedDiff.compute("hello", "world");
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "hello"));
+        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "world"));
+    }
+
+    @Test
+    void multiLineChangesWithContext() {
+        String original = "a\nb\nc\nd";
+        String modified = "a\nB\nc\nd";
+
+        var result = UnifiedDiff.compute(original, modified);
+
+        assertThat(result).hasSize(5);
+        assertThat(result.get(0)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "a"));
+        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "b"));
+        assertThat(result.get(2)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "B"));
+        assertThat(result.get(3)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "c"));
+        assertThat(result.get(4)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "d"));
+    }
+
+    @Test
+    void addedLinesInMiddle() {
+        String original = "a\nc";
+        String modified = "a\nb\nc";
+
+        var result = UnifiedDiff.compute(original, modified);
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).type()).isEqualTo(UnifiedDiff.Type.CONTEXT);
+        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "b"));
+        assertThat(result.get(2).type()).isEqualTo(UnifiedDiff.Type.CONTEXT);
+    }
+
+    @Test
+    void removedLinesInMiddle() {
+        String original = "a\nb\nc";
+        String modified = "a\nc";
+
+        var result = UnifiedDiff.compute(original, modified);
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).type()).isEqualTo(UnifiedDiff.Type.CONTEXT);
+        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "b"));
+        assertThat(result.get(2).type()).isEqualTo(UnifiedDiff.Type.CONTEXT);
+    }
+
+    @Test
+    void changeCountReturnsNonContextLines() {
+        var lines = List.of(
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "a"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "b"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "B"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "c"));
+
+        assertThat(UnifiedDiff.changeCount(lines)).isEqualTo(2);
+    }
+
+    @Test
+    void changeCountZeroForIdentical() {
+        var lines = List.of(
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "a"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "b"));
+
+        assertThat(UnifiedDiff.changeCount(lines)).isZero();
+    }
+
+    @Test
+    void filterContextKeepsSurroundingLines() {
+        var lines = List.of(
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "1"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "2"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "3"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "4"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "4x"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "5"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "6"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "7"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "8"));
+
+        var filtered = UnifiedDiff.filterContext(lines, 1);
+
+        // Should keep lines 2-5 (1 context before/after the change at indices 3-4)
+        assertThat(filtered).hasSize(4);
+        assertThat(filtered.get(0).text()).isEqualTo("3");
+        assertThat(filtered.get(1).text()).isEqualTo("4");
+        assertThat(filtered.get(2).text()).isEqualTo("4x");
+        assertThat(filtered.get(3).text()).isEqualTo("5");
+    }
+
+    @Test
+    void maxScrollCalculation() {
+        var lines = List.of(
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "a"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "b"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "c"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "d"),
+                new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "e"));
+
+        // area height 5 = 3 inner lines (minus 2 for borders)
+        assertThat(UnifiedDiff.maxScroll(lines, 5)).isEqualTo(2);
+        // area height 10 = 8 inner lines > 5 lines → 0
+        assertThat(UnifiedDiff.maxScroll(lines, 10)).isZero();
+    }
+
+    @Test
+    void bothEmptyProducesEmptyResult() {
+        var result = UnifiedDiff.compute("", "");
+        assertThat(result).isEmpty();
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/UpdatesDemoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UpdatesDemoTest.java
@@ -22,9 +22,12 @@ import dev.tamboui.layout.Size;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.pilot.Pilot;
 import dev.tamboui.tui.pilot.TuiTestRunner;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Demo test for Dependency Updates TUI.
@@ -32,7 +35,9 @@ import org.junit.jupiter.api.Test;
 class UpdatesDemoTest {
 
     @Test
-    void browseAndFilterUpdates() throws Exception {
+    void browseAndFilterUpdates(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
         List<UpdatesTui.DependencyInfo> deps = new ArrayList<>();
 
         var d1 = new UpdatesTui.DependencyInfo("com.google.guava", "guava", "33.0.0-jre", "compile", "jar");
@@ -55,7 +60,7 @@ class UpdatesDemoTest {
         d4.updateType = VersionComparator.UpdateType.MINOR;
         deps.add(d4);
 
-        UpdatesTui tui = new UpdatesTui(deps, "/tmp/test-pom.xml", "com.example:demo:1.0.0", (g, a) -> List.of());
+        UpdatesTui tui = new UpdatesTui(deps, pomPath, "com.example:demo:1.0.0", (g, a) -> List.of());
 
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
 

--- a/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
@@ -21,12 +21,26 @@ package eu.maveniverse.maven.pilot;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class UpdatesTuiTest {
+
+    @TempDir
+    Path tempDir;
+
+    String pomPath;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        pomPath = Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
+    }
 
     @Test
     void versionResolverInterface() {
@@ -53,7 +67,7 @@ class UpdatesTuiTest {
         deps.get(0).newestVersion = "1.1";
         deps.get(0).updateType = VersionComparator.UpdateType.PATCH;
 
-        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "com.example:app:1.0", (g, a) -> List.of());
+        var tui = new UpdatesTui(deps, pomPath, "com.example:app:1.0", (g, a) -> List.of());
         tui.loadedCount = 2;
         tui.updateStatusIfDone();
 
@@ -68,7 +82,7 @@ class UpdatesTuiTest {
         deps.add(new UpdatesTui.DependencyInfo("com.example", "b", "2.0", "compile", "jar"));
         deps.add(new UpdatesTui.DependencyInfo("com.example", "c", "3.0", "compile", "jar"));
 
-        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "com.example:app:1.0", (g, a) -> List.of());
+        var tui = new UpdatesTui(deps, pomPath, "com.example:app:1.0", (g, a) -> List.of());
         tui.loadedCount = 3;
         tui.failedCount = 2;
         tui.updateStatusIfDone();
@@ -83,7 +97,7 @@ class UpdatesTuiTest {
         deps.add(new UpdatesTui.DependencyInfo("com.example", "a", "1.0", "compile", "jar"));
         deps.add(new UpdatesTui.DependencyInfo("com.example", "b", "2.0", "compile", "jar"));
 
-        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "com.example:app:1.0", (g, a) -> List.of());
+        var tui = new UpdatesTui(deps, pomPath, "com.example:app:1.0", (g, a) -> List.of());
         tui.loadedCount = 1; // not all loaded yet
         tui.updateStatusIfDone();
 
@@ -126,7 +140,7 @@ class UpdatesTuiTest {
         var dep = new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar");
         deps.add(dep);
 
-        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> List.of());
+        var tui = new UpdatesTui(deps, pomPath, "g:a:1.0", (g, a) -> List.of());
         tui.applyVersionResult(dep, List.of("2.0.0", "1.5.0", "1.0.0"));
 
         assertThat(dep.newestVersion).isEqualTo("2.0.0");
@@ -140,7 +154,7 @@ class UpdatesTuiTest {
         var dep = new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar");
         deps.add(dep);
 
-        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> List.of());
+        var tui = new UpdatesTui(deps, pomPath, "g:a:1.0", (g, a) -> List.of());
         tui.applyVersionResult(dep, List.of("2.0.0-beta1", "2.0.0-alpha1", "1.1.0"));
 
         assertThat(dep.newestVersion).isEqualTo("1.1.0");
@@ -153,7 +167,7 @@ class UpdatesTuiTest {
         var dep = new UpdatesTui.DependencyInfo("com.example", "lib", "2.0", "compile", "jar");
         deps.add(dep);
 
-        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> List.of());
+        var tui = new UpdatesTui(deps, pomPath, "g:a:1.0", (g, a) -> List.of());
         tui.applyVersionResult(dep, List.of("1.5.0", "1.0.0"));
 
         assertThat(dep.newestVersion).isNull();
@@ -166,7 +180,7 @@ class UpdatesTuiTest {
         var dep = new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar");
         deps.add(dep);
 
-        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> List.of());
+        var tui = new UpdatesTui(deps, pomPath, "g:a:1.0", (g, a) -> List.of());
         tui.applyVersionResult(dep, List.of());
 
         assertThat(dep.newestVersion).isNull();
@@ -179,7 +193,7 @@ class UpdatesTuiTest {
         var dep = new UpdatesTui.DependencyInfo("com.example", "lib", null, "compile", "jar");
         deps.add(dep);
 
-        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> List.of());
+        var tui = new UpdatesTui(deps, pomPath, "g:a:1.0", (g, a) -> List.of());
         tui.applyVersionResult(dep, List.of("2.0.0", "1.0.0"));
 
         // Empty version should accept any non-preview version
@@ -192,7 +206,7 @@ class UpdatesTuiTest {
         deps.add(new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar"));
         deps.add(new UpdatesTui.DependencyInfo("com.example", "other", "2.0", "compile", "jar"));
 
-        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> {
+        var tui = new UpdatesTui(deps, pomPath, "g:a:1.0", (g, a) -> {
             if ("lib".equals(a)) return List.of("2.0.0", "1.5.0", "1.0.0");
             return List.of("2.0.0");
         });
@@ -216,7 +230,7 @@ class UpdatesTuiTest {
         var deps = new ArrayList<UpdatesTui.DependencyInfo>();
         deps.add(new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar"));
 
-        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> {
+        var tui = new UpdatesTui(deps, pomPath, "g:a:1.0", (g, a) -> {
             throw new IllegalStateException("network error");
         });
 
@@ -239,7 +253,7 @@ class UpdatesTuiTest {
         deps.add(new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar"));
         deps.add(new UpdatesTui.DependencyInfo("com.example", "broken", "1.0", "compile", "jar"));
 
-        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> {
+        var tui = new UpdatesTui(deps, pomPath, "g:a:1.0", (g, a) -> {
             if ("broken".equals(a)) throw new IllegalStateException("timeout");
             return List.of("2.0.0", "1.0.0");
         });
@@ -283,7 +297,7 @@ class UpdatesTuiTest {
         var dep = new UpdatesTui.DependencyInfo("com.example", "lib", "1.0", "compile", "jar");
         deps.add(dep);
 
-        var tui = new UpdatesTui(deps, "/tmp/pom.xml", "g:a:1.0", (g, a) -> List.of());
+        var tui = new UpdatesTui(deps, pomPath, "g:a:1.0", (g, a) -> List.of());
         tui.applyVersionResult(dep, List.of("2.0.0-SNAPSHOT", "1.5.0-beta1", "1.2.0-alpha1"));
 
         assertThat(dep.newestVersion).isNull();


### PR DESCRIPTION
## Summary

- **Reactor aggregation**: In multi-module reactors, `pilot:updates` now aggregates dependencies across all modules, deduplicating by `groupId:artifactId` and detecting shared version properties (`${property}` expressions)
- **Two-view TUI**: Tab switches between a **Dependencies** view (aggregate list grouped by shared version property) and a **Modules** view (reactor tree with expand/collapse and per-module `own/total` update counts)
- **Smart apply**: Property-based updates edit `<properties>` in the POM that defines the property; direct version updates edit the module's own POM. Multiple POM files are updated in a single apply operation
- **Backward compatible**: Single-module projects behave identically to before

### New files
| File | Description |
|------|-------------|
| `ReactorModel.java` | Module tree model built from `MavenSession.getProjects()` |
| `ReactorCollector.java` | Aggregates dependencies across modules, detects property groups |
| `ReactorUpdatesTui.java` | Reactor-aware TUI with Dependencies/Modules views |

### Modified files
| File | Changes |
|------|---------|
| `UpdatesMojo.java` | Added `aggregator = true`, `MavenSession` injection, single/reactor branching |

## Test plan

- [x] All 173 existing tests pass (0 failures)
- [ ] Run `mvn pilot:updates` on a single-module project — identical behavior
- [ ] Run `mvn pilot:updates` on a multi-module reactor from root — Dependencies view shows property groups
- [ ] Press `Tab` to switch to Modules view — verify tree hierarchy and update counts
- [ ] Select updates via `Space` on property group header — all deps in group toggle together
- [ ] Press `Enter` to apply — verify correct POMs are modified
- [ ] Test on a large reactor (e.g., Apache Camel) — verify performance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive "align" goal with terminal UI for aligning POM conventions
  * Reactor-aware updates workflow and a multi-module updates UI (dependencies/modules views)
  * Scrollable unified diff overlay and diff rendering utility used across TUIs

* **Bug Fixes & Improvements**
  * Stage edits in-memory with explicit save/discard on exit; deferred persistence
  * Improved selection propagation, navigation, and modal quit/confirm flows
  * Keybinding updates (deletion key changed to 'x'; diff toggle and preview/apply flows)

* **Tests**
  * Added extensive tests for TUIs, reactor collection/model, diff utility, and integration flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->