### PR TITLE
feat: make align goal reactor-aware with cross-POM dependency management

### DIFF
--- a/src/main/java/eu/maveniverse/maven/pilot/AlignHelper.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignHelper.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.maven.AlignOptions;
+import eu.maveniverse.domtrip.maven.PomEditor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Shared utility for locating reactor-local parent POMs with dependency management.
+ */
+final class AlignHelper {
+
+    private static final Logger LOGGER = Logger.getLogger(AlignHelper.class.getName());
+
+    private AlignHelper() {}
+
+    /**
+     * Walk the parent chain to find the nearest reactor-local ancestor with {@code <dependencyManagement>}.
+     * Falls back to the direct reactor parent if none has dependency management.
+     *
+     * @param proj the project to find a parent for
+     * @param reactorProjects all projects in the reactor
+     * @return parent POM info, or {@code null} if the project has no reactor-local parent
+     */
+    static AlignTui.ParentPomInfo findParentPomInfo(MavenProject proj, List<MavenProject> reactorProjects) {
+        Set<String> reactorPaths = new HashSet<>();
+        for (MavenProject p : reactorProjects) {
+            reactorPaths.add(p.getFile().getAbsolutePath());
+        }
+
+        MavenProject current = proj.getParent();
+        MavenProject directParent = null;
+
+        while (current != null && current.getFile() != null) {
+            if (!reactorPaths.contains(current.getFile().getAbsolutePath())) {
+                break;
+            }
+            if (directParent == null) {
+                directParent = current;
+            }
+            var mgmt = current.getOriginalModel().getDependencyManagement();
+            if (mgmt != null
+                    && mgmt.getDependencies() != null
+                    && !mgmt.getDependencies().isEmpty()) {
+                return buildParentPomInfo(current);
+            }
+            current = current.getParent();
+        }
+
+        // No parent with depMgmt found; use direct reactor parent to create depMgmt
+        if (directParent != null) {
+            return buildParentPomInfo(directParent);
+        }
+        return null;
+    }
+
+    private static AlignTui.ParentPomInfo buildParentPomInfo(MavenProject parent) {
+        String parentPomPath = parent.getFile().getAbsolutePath();
+        String parentGav = parent.getGroupId() + ":" + parent.getArtifactId() + ":" + parent.getVersion();
+        try {
+            PomEditor parentEditor = new PomEditor(Document.of(Files.readString(Path.of(parentPomPath))));
+            AlignOptions parentOptions = parentEditor.dependencies().detectConventions();
+            return new AlignTui.ParentPomInfo(parentPomPath, parentGav, parentOptions);
+        } catch (Exception e) {
+            LOGGER.log(Level.FINE, "Failed to read parent POM at {0} ({1}); using defaults", new Object[] {
+                parentPomPath, parentGav
+            });
+            return new AlignTui.ParentPomInfo(parentPomPath, parentGav, AlignOptions.defaults());
+        }
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/AlignMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignMojo.java
@@ -73,9 +73,8 @@ public class AlignMojo extends AbstractMojo {
         MavenProject root = projects.get(0);
         String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
 
-        ModulePickerTui picker = new ModulePickerTui(reactorModel, reactorGav, "align");
         while (true) {
-            MavenProject selected = picker.pick();
+            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "align").pick();
             if (selected == null) break;
             executeForProject(selected);
         }
@@ -89,7 +88,8 @@ public class AlignMojo extends AbstractMojo {
 
         String gav = proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion();
 
-        AlignTui tui = new AlignTui(pomPath, gav, detectedOptions);
+        AlignTui.ParentPomInfo parentInfo = AlignHelper.findParentPomInfo(proj, session.getProjects());
+        AlignTui tui = new AlignTui(pomPath, gav, detectedOptions, parentInfo);
         tui.run();
     }
 }

--- a/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
@@ -38,15 +38,24 @@ import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.maven.AlignOptions;
+import eu.maveniverse.domtrip.maven.Coordinates;
 import eu.maveniverse.domtrip.maven.PomEditor;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Interactive TUI for dependency convention alignment.
+ *
+ * <p>Supports reactor-aware cross-POM alignment: when a child module's dependencies
+ * are managed by a parent POM in the reactor, the MANAGED version style moves
+ * managed dep entries to the parent POM and strips versions from the child POM.</p>
  */
 class AlignTui {
 
@@ -55,14 +64,23 @@ class AlignTui {
         PREVIEW
     }
 
+    /**
+     * Information about a reactor-local parent POM that holds (or should hold) dependency management.
+     */
+    record ParentPomInfo(String pomPath, String gav, AlignOptions detectedOptions) {}
+
+    private static final Logger LOGGER = Logger.getLogger(AlignTui.class.getName());
+
     private static final int ROW_VERSION_STYLE = 0;
     private static final int ROW_VERSION_SOURCE = 1;
     private static final int ROW_PROPERTY_NAMING = 2;
     private static final int ROW_COUNT = 3;
+    private static final String PROPERTIES_ELEMENT = "properties";
 
     private final String pomPath;
     private final String projectGav;
     private final AlignOptions detectedOptions;
+    private final ParentPomInfo parentInfo;
 
     // User-selected convention values (start matching detected)
     private AlignOptions.VersionStyle selectedStyle;
@@ -77,18 +95,40 @@ class AlignTui {
     private final DiffOverlay diffOverlay = new DiffOverlay();
     private final HelpOverlay helpOverlay = new HelpOverlay();
     private String alignedPomContent;
+    private Map<Path, String> alignedPomContents; // cross-POM mode
 
     private TuiRunner runner;
 
-    AlignTui(String pomPath, String projectGav, AlignOptions detectedOptions) {
+    AlignTui(String pomPath, String projectGav, AlignOptions detectedOptions, ParentPomInfo parentInfo) {
         this.pomPath = pomPath;
         this.projectGav = projectGav;
-        this.detectedOptions = detectedOptions;
-        this.selectedStyle = detectedOptions.versionStyle();
-        this.selectedSource = detectedOptions.versionSource();
-        this.selectedNaming = detectedOptions.namingConvention();
-        this.status = "Detected conventions from POM";
+        this.parentInfo = parentInfo;
+
+        // When deps are managed by parent, use parent's source/naming conventions
+        if (parentInfo != null && detectedOptions.versionStyle() == AlignOptions.VersionStyle.MANAGED) {
+            this.detectedOptions = AlignOptions.builder()
+                    .versionStyle(detectedOptions.versionStyle())
+                    .versionSource(parentInfo.detectedOptions().versionSource())
+                    .namingConvention(parentInfo.detectedOptions().namingConvention())
+                    .build();
+        } else {
+            this.detectedOptions = detectedOptions;
+        }
+
+        this.selectedStyle = this.detectedOptions.versionStyle();
+        this.selectedSource = this.detectedOptions.versionSource();
+        this.selectedNaming = this.detectedOptions.namingConvention();
+        this.status = parentInfo != null
+                ? "Reactor-aware mode: parent dependency management detected"
+                : "Detected conventions from POM";
         tableState.select(0);
+    }
+
+    /**
+     * Whether cross-POM editing is active: MANAGED style selected with a reactor parent available.
+     */
+    boolean isCrossPomMode() {
+        return parentInfo != null && selectedStyle == AlignOptions.VersionStyle.MANAGED;
     }
 
     void run() throws Exception {
@@ -237,6 +277,10 @@ class AlignTui {
     // -- Actions --
 
     private void showPreview() {
+        if (isCrossPomMode()) {
+            showCrossPomPreview();
+            return;
+        }
         try {
             String currentPom = Files.readString(Path.of(pomPath));
             PomEditor editor = new PomEditor(Document.of(currentPom));
@@ -258,6 +302,10 @@ class AlignTui {
     }
 
     private void applyAlignment() {
+        if (isCrossPomMode()) {
+            applyCrossPomAlignment();
+            return;
+        }
         try {
             String currentPom = Files.readString(Path.of(pomPath));
             PomEditor editor = new PomEditor(Document.of(currentPom));
@@ -269,37 +317,11 @@ class AlignTui {
         }
     }
 
-    private List<HelpOverlay.Section> buildHelp() {
-        return List.of(
-                new HelpOverlay.Section(
-                        "BOM Alignment",
-                        List.of(
-                                new HelpOverlay.Entry("", "Restructures dependency declarations to follow a"),
-                                new HelpOverlay.Entry("", "consistent convention. Configure three options:"),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "Version Style: how versions are expressed \u2014 inline"),
-                                new HelpOverlay.Entry("", "in <version> tags, via <properties>, or managed"),
-                                new HelpOverlay.Entry("", "through <dependencyManagement>."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "Version Source: where version values come from \u2014"),
-                                new HelpOverlay.Entry("", "keep current versions, import from a BOM, etc."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "Property Naming: convention for property names"),
-                                new HelpOverlay.Entry("", "(e.g. groupId.artifactId.version or artifact.version)."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "Preview the diff before applying to verify changes."))),
-                new HelpOverlay.Section(
-                        "Keys",
-                        List.of(
-                                new HelpOverlay.Entry("\u2191 / \u2193", "Move between options"),
-                                new HelpOverlay.Entry("\u2190 / \u2192 / Enter", "Cycle through option values"),
-                                new HelpOverlay.Entry("p", "Preview the POM changes as a diff"),
-                                new HelpOverlay.Entry("w", "Apply alignment and write to POM"),
-                                new HelpOverlay.Entry("h", "Toggle this help screen"),
-                                new HelpOverlay.Entry("q / Esc", "Quit"))));
-    }
-
     private void writeAlignedPom() {
+        if (isCrossPomMode() && alignedPomContents != null) {
+            writeCrossPomChanges();
+            return;
+        }
         try {
             String currentPom = Files.readString(Path.of(pomPath));
             PomEditor editor = new PomEditor(Document.of(currentPom));
@@ -312,6 +334,231 @@ class AlignTui {
         } catch (Exception e) {
             status = "Failed to write POM: " + e.getMessage();
         }
+    }
+
+    // -- Cross-POM alignment --
+
+    void showCrossPomPreview() {
+        try {
+            String childContent = Files.readString(Path.of(pomPath));
+            String parentContent = Files.readString(Path.of(parentInfo.pomPath()));
+
+            PomEditor childEditor = new PomEditor(Document.of(childContent));
+            PomEditor parentEditor = new PomEditor(Document.of(parentContent));
+
+            int count = alignCrossPom(childEditor, parentEditor);
+
+            String childModified = childEditor.toXml();
+            String parentModified = parentEditor.toXml();
+
+            // Build multi-file diff with distinguishing labels (both are pom.xml)
+            Path pp = Path.of(parentInfo.pomPath());
+            Path ppParent = pp.getParent();
+            String parentLabel = (ppParent != null ? ppParent.getFileName() + "/" : "") + pp.getFileName();
+            Path cp = Path.of(pomPath);
+            Path cpParent = cp.getParent();
+            String childLabel = (cpParent != null ? cpParent.getFileName() + "/" : "") + cp.getFileName();
+            Map<String, Map.Entry<String, String>> fileDiffs = new LinkedHashMap<>();
+            if (!parentContent.equals(parentModified)) {
+                fileDiffs.put(parentLabel, Map.entry(parentContent, parentModified));
+            }
+            if (!childContent.equals(childModified)) {
+                fileDiffs.put(childLabel, Map.entry(childContent, childModified));
+            }
+
+            if (fileDiffs.isEmpty()) {
+                status = "No changes needed \u2014 POM already aligned";
+                alignedPomContents = null;
+                return;
+            }
+
+            // Store for writing
+            alignedPomContents = new LinkedHashMap<>();
+            if (!parentContent.equals(parentModified)) {
+                alignedPomContents.put(Path.of(parentInfo.pomPath()), parentModified);
+            }
+            if (!childContent.equals(childModified)) {
+                alignedPomContents.put(Path.of(pomPath), childModified);
+            }
+
+            long changes = diffOverlay.openMulti(fileDiffs);
+            phase = Phase.PREVIEW;
+            status = count + " dependency(ies) aligned, " + changes + " line(s) changed across " + fileDiffs.size()
+                    + " file(s)";
+        } catch (Exception e) {
+            status = "Failed to compute preview: " + e.getMessage();
+        }
+    }
+
+    void applyCrossPomAlignment() {
+        try {
+            String childContent = Files.readString(Path.of(pomPath));
+            String parentContent = Files.readString(Path.of(parentInfo.pomPath()));
+
+            PomEditor childEditor = new PomEditor(Document.of(childContent));
+            PomEditor parentEditor = new PomEditor(Document.of(parentContent));
+
+            int count = alignCrossPom(childEditor, parentEditor);
+
+            // Writes are not atomic across the two files; users can roll back via git if interrupted
+            Files.writeString(Path.of(parentInfo.pomPath()), parentEditor.toXml());
+            Files.writeString(Path.of(pomPath), childEditor.toXml());
+            status = "Aligned " + count + " dependency(ies) across 2 POMs";
+        } catch (Exception e) {
+            status = "Failed to apply alignment: " + e.getMessage();
+        }
+    }
+
+    void writeCrossPomChanges() {
+        try {
+            for (var entry : alignedPomContents.entrySet()) {
+                Files.writeString(entry.getKey(), entry.getValue());
+            }
+            status = "Changes written to " + alignedPomContents.size() + " POM(s)";
+            phase = Phase.SELECT;
+            diffOverlay.close();
+            alignedPomContents = null;
+            alignedPomContent = null;
+        } catch (Exception e) {
+            status = "Failed to write POMs: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Align dependencies across child and parent POMs.
+     * Moves inline versions from child deps to parent's dependency management.
+     *
+     * @return the number of dependencies aligned
+     */
+    int alignCrossPom(PomEditor childEditor, PomEditor parentEditor) {
+        var depsOpt = childEditor.root().childElement("dependencies");
+        if (depsOpt.isEmpty()) return 0;
+
+        List<Coordinates> toManage = new ArrayList<>();
+
+        // Collect child deps that have inline versions
+        depsOpt.orElseThrow().childElements("dependency").forEach(dep -> {
+            String gid = dep.childTextOr("groupId", "");
+            String aid = dep.childTextOr("artifactId", "");
+            String ver = dep.childTextOr("version", null);
+            if (ver != null && !ver.isEmpty()) {
+                toManage.add(Coordinates.of(gid, aid, ver));
+            }
+        });
+
+        int count = 0;
+        for (var coords : toManage) {
+            addToParentDepMgmt(childEditor, parentEditor, coords);
+            childEditor.dependencies().deleteDependencyVersion(coords);
+            count++;
+        }
+
+        return count;
+    }
+
+    /**
+     * Add a dependency to the parent POM's dependency management section,
+     * following the selected version source and naming conventions.
+     */
+    void addToParentDepMgmt(PomEditor childEditor, PomEditor parentEditor, Coordinates coords) {
+        String version = coords.version();
+
+        if (selectedSource == AlignOptions.VersionSource.PROPERTY) {
+            String propName;
+            String propValue;
+
+            if (version.startsWith("${") && version.endsWith("}")) {
+                // Already a property reference - reuse name and resolve value from child
+                propName = version.substring(2, version.length() - 1);
+                propValue = childEditor
+                        .root()
+                        .childElement(PROPERTIES_ELEMENT)
+                        .map(p -> p.childTextOr(propName, null))
+                        .orElse(null);
+            } else {
+                // Literal version - create new property with selected naming convention
+                propName = AlignOptions.generatePropertyName(coords, selectedNaming);
+                propValue = version;
+            }
+
+            // Add property to parent and determine managed dep version
+            String managedVersion;
+            if (propValue != null) {
+                boolean parentHasProp = parentEditor
+                        .root()
+                        .childElement(PROPERTIES_ELEMENT)
+                        .flatMap(p -> p.childElement(propName))
+                        .isPresent();
+                if (!parentHasProp) {
+                    parentEditor.properties().updateProperty(true, propName, propValue);
+                }
+                managedVersion = "${" + propName + "}";
+            } else {
+                // Property not found in child POM — use raw version reference
+                LOGGER.log(Level.FINE, "Property {0} not found in child POM; using raw version: {1}", new Object[] {
+                    propName, version
+                });
+                managedVersion = version;
+            }
+
+            var managedCoords = Coordinates.of(coords.groupId(), coords.artifactId(), managedVersion);
+            parentEditor.dependencies().updateManagedDependency(true, managedCoords);
+        } else {
+            // LITERAL source - resolve property refs if possible, then add literal version
+            String literalVersion = version;
+            if (version.startsWith("${") && version.endsWith("}")) {
+                String propName = version.substring(2, version.length() - 1);
+                literalVersion = childEditor
+                        .root()
+                        .childElement(PROPERTIES_ELEMENT)
+                        .map(p -> p.childTextOr(propName, version))
+                        .orElse(version);
+            }
+            parentEditor
+                    .dependencies()
+                    .updateManagedDependency(
+                            true, Coordinates.of(coords.groupId(), coords.artifactId(), literalVersion));
+        }
+    }
+
+    // -- Help --
+
+    private List<HelpOverlay.Section> buildHelp() {
+        List<HelpOverlay.Entry> descEntries = new ArrayList<>();
+        descEntries.add(new HelpOverlay.Entry("", "Restructures dependency declarations to follow a"));
+        descEntries.add(new HelpOverlay.Entry("", "consistent convention. Configure three options:"));
+        descEntries.add(new HelpOverlay.Entry("", ""));
+        descEntries.add(new HelpOverlay.Entry("", "Version Style: how versions are expressed \u2014 inline"));
+        descEntries.add(new HelpOverlay.Entry("", "in <version> tags, via <properties>, or managed"));
+        descEntries.add(new HelpOverlay.Entry("", "through <dependencyManagement>."));
+        descEntries.add(new HelpOverlay.Entry("", ""));
+        descEntries.add(new HelpOverlay.Entry("", "Version Source: where version values come from \u2014"));
+        descEntries.add(new HelpOverlay.Entry("", "keep current versions, import from a BOM, etc."));
+        descEntries.add(new HelpOverlay.Entry("", ""));
+        descEntries.add(new HelpOverlay.Entry("", "Property Naming: convention for property names"));
+        descEntries.add(new HelpOverlay.Entry("", "(e.g. groupId.artifactId.version or artifact.version)."));
+        descEntries.add(new HelpOverlay.Entry("", ""));
+        descEntries.add(new HelpOverlay.Entry("", "Preview the diff before applying to verify changes."));
+
+        if (parentInfo != null) {
+            descEntries.add(new HelpOverlay.Entry("", ""));
+            descEntries.add(new HelpOverlay.Entry("", "Cross-POM mode: when MANAGED style is selected,"));
+            descEntries.add(new HelpOverlay.Entry("", "managed deps are written to the parent POM and"));
+            descEntries.add(new HelpOverlay.Entry("", "child deps become version-less."));
+            descEntries.add(new HelpOverlay.Entry("", "Parent: " + parentInfo.gav()));
+        }
+
+        return List.of(
+                new HelpOverlay.Section("BOM Alignment", descEntries),
+                new HelpOverlay.Section(
+                        "Keys",
+                        List.of(
+                                new HelpOverlay.Entry("\u2191 / \u2193", "Move between options"),
+                                new HelpOverlay.Entry("\u2190 / \u2192 / Enter", "Cycle through option values"),
+                                new HelpOverlay.Entry("p", "Preview the POM changes as a diff"),
+                                new HelpOverlay.Entry("w", "Apply alignment and write to POM"),
+                                new HelpOverlay.Entry("h", "Toggle this help screen"),
+                                new HelpOverlay.Entry("q / Esc", "Quit"))));
     }
 
     // -- Rendering --
@@ -348,6 +595,10 @@ class AlignTui {
 
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" " + projectGav).bold().cyan());
+        if (isCrossPomMode()) {
+            spans.add(Span.raw("  managed \u2192 ").fg(Color.DARK_GRAY));
+            spans.add(Span.raw(parentInfo.gav()).yellow());
+        }
 
         Paragraph header = Paragraph.builder()
                 .text(dev.tamboui.text.Text.from(Line.from(spans)))

--- a/src/main/java/eu/maveniverse/maven/pilot/DependenciesMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependenciesMojo.java
@@ -98,9 +98,8 @@ public class DependenciesMojo extends AbstractMojo {
         MavenProject root = projects.get(0);
         String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
 
-        ModulePickerTui picker = new ModulePickerTui(reactorModel, reactorGav, "dependencies");
         while (true) {
-            MavenProject selected = picker.pick();
+            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "dependencies").pick();
             if (selected == null) break;
             executeForProject(selected);
         }

--- a/src/main/java/eu/maveniverse/maven/pilot/ModulePickerTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ModulePickerTui.java
@@ -69,7 +69,6 @@ class ModulePickerTui {
      * @return the selected MavenProject, or null if the user quit without selecting
      */
     MavenProject pick() throws Exception {
-        selectedProject = null;
         var configured = TuiRunner.builder()
                 .eventHandler(this::handleEvent)
                 .renderer(this::render)

--- a/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
@@ -121,9 +121,8 @@ public class PilotMojo extends AbstractMojo {
         MavenProject root = projects.get(0);
         String reactorGav = gavOf(root);
 
-        ModulePickerTui picker = new ModulePickerTui(reactorModel, reactorGav, "pilot");
         while (true) {
-            MavenProject selected = picker.pick();
+            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "pilot").pick();
             if (selected == null) break;
             String tool = new ToolPickerTui(gavOf(selected), true).pick();
             if (tool == null) continue;
@@ -353,7 +352,9 @@ public class PilotMojo extends AbstractMojo {
         String pomContent = Files.readString(Path.of(pomPath));
         PomEditor editor = new PomEditor(Document.of(pomContent));
         var detectedOptions = editor.dependencies().detectConventions();
-        new AlignTui(pomPath, gavOf(proj), detectedOptions).run();
+
+        AlignTui.ParentPomInfo parentInfo = AlignHelper.findParentPomInfo(proj, session.getProjects());
+        new AlignTui(pomPath, gavOf(proj), detectedOptions, parentInfo).run();
     }
 
     // ── updates ─────────────────────────────────────────────────────────────

--- a/src/main/java/eu/maveniverse/maven/pilot/PomMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PomMojo.java
@@ -90,9 +90,8 @@ public class PomMojo extends AbstractMojo {
         MavenProject root = projects.get(0);
         String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
 
-        ModulePickerTui picker = new ModulePickerTui(reactorModel, reactorGav, "pom");
         while (true) {
-            MavenProject selected = picker.pick();
+            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "pom").pick();
             if (selected == null) break;
             executeForProject(selected);
         }

--- a/src/main/java/eu/maveniverse/maven/pilot/TreeMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/TreeMojo.java
@@ -82,9 +82,8 @@ public class TreeMojo extends AbstractMojo {
         MavenProject root = projects.get(0);
         String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
 
-        ModulePickerTui picker = new ModulePickerTui(reactorModel, reactorGav, "tree");
         while (true) {
-            MavenProject selected = picker.pick();
+            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "tree").pick();
             if (selected == null) break;
             executeForProject(selected);
         }

--- a/src/test/java/eu/maveniverse/maven/pilot/AlignHelperTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AlignHelperTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AlignHelperTest {
+
+    private static final String PARENT_POM = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>test</groupId>
+                <artifactId>parent</artifactId>
+                <version>1.0</version>
+                <packaging>pom</packaging>
+                <dependencyManagement>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.example</groupId>
+                            <artifactId>foo</artifactId>
+                            <version>2.0</version>
+                        </dependency>
+                    </dependencies>
+                </dependencyManagement>
+            </project>
+            """;
+
+    private static final String EMPTY_PARENT_POM = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>test</groupId>
+                <artifactId>parent</artifactId>
+                <version>1.0</version>
+                <packaging>pom</packaging>
+            </project>
+            """;
+
+    @Test
+    void findParentPomInfoFindsParentWithDepMgmt(@TempDir Path tempDir) throws Exception {
+        Path parentPomFile = tempDir.resolve("parent/pom.xml");
+        Files.createDirectories(parentPomFile.getParent());
+        Files.writeString(parentPomFile, PARENT_POM);
+
+        MavenProject parentProject = createProject("test", "parent", "1.0", parentPomFile);
+        addDepMgmt(parentProject, "org.example", "foo", "2.0");
+
+        Path childPomFile = tempDir.resolve("child/pom.xml");
+        Files.createDirectories(childPomFile.getParent());
+        Files.writeString(childPomFile, EMPTY_PARENT_POM);
+
+        MavenProject childProject = createProject("test", "child", "1.0", childPomFile);
+        childProject.setParent(parentProject);
+
+        var result = AlignHelper.findParentPomInfo(childProject, List.of(parentProject, childProject));
+
+        assertThat(result).isNotNull();
+        assertThat(result.pomPath()).isEqualTo(parentPomFile.toString());
+        assertThat(result.gav()).isEqualTo("test:parent:1.0");
+    }
+
+    @Test
+    void findParentPomInfoFallsBackToDirectParent(@TempDir Path tempDir) throws Exception {
+        Path parentPomFile = tempDir.resolve("parent/pom.xml");
+        Files.createDirectories(parentPomFile.getParent());
+        Files.writeString(parentPomFile, EMPTY_PARENT_POM);
+
+        MavenProject parentProject = createProject("test", "parent", "1.0", parentPomFile);
+        // No depMgmt set on originalModel
+
+        Path childPomFile = tempDir.resolve("child/pom.xml");
+        Files.createDirectories(childPomFile.getParent());
+        Files.writeString(childPomFile, EMPTY_PARENT_POM);
+
+        MavenProject childProject = createProject("test", "child", "1.0", childPomFile);
+        childProject.setParent(parentProject);
+
+        var result = AlignHelper.findParentPomInfo(childProject, List.of(parentProject, childProject));
+
+        assertThat(result).isNotNull();
+        assertThat(result.pomPath()).isEqualTo(parentPomFile.toString());
+        assertThat(result.gav()).isEqualTo("test:parent:1.0");
+    }
+
+    @Test
+    void findParentPomInfoReturnsNullWhenNoReactorParent(@TempDir Path tempDir) throws Exception {
+        Path childPomFile = tempDir.resolve("child/pom.xml");
+        Files.createDirectories(childPomFile.getParent());
+        Files.writeString(childPomFile, EMPTY_PARENT_POM);
+
+        MavenProject childProject = createProject("test", "child", "1.0", childPomFile);
+        // No parent set
+
+        var result = AlignHelper.findParentPomInfo(childProject, List.of(childProject));
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void findParentPomInfoSkipsNonReactorParent(@TempDir Path tempDir) throws Exception {
+        Path parentPomFile = tempDir.resolve("parent/pom.xml");
+        Files.createDirectories(parentPomFile.getParent());
+        Files.writeString(parentPomFile, PARENT_POM);
+
+        MavenProject parentProject = createProject("test", "parent", "1.0", parentPomFile);
+        addDepMgmt(parentProject, "org.example", "foo", "2.0");
+
+        Path childPomFile = tempDir.resolve("child/pom.xml");
+        Files.createDirectories(childPomFile.getParent());
+        Files.writeString(childPomFile, EMPTY_PARENT_POM);
+
+        MavenProject childProject = createProject("test", "child", "1.0", childPomFile);
+        childProject.setParent(parentProject);
+
+        // Parent is NOT in reactor list
+        var result = AlignHelper.findParentPomInfo(childProject, List.of(childProject));
+
+        assertThat(result).isNull();
+    }
+
+    private static MavenProject createProject(String groupId, String artifactId, String version, Path pomFile) {
+        Model model = new Model();
+        model.setGroupId(groupId);
+        model.setArtifactId(artifactId);
+        model.setVersion(version);
+        MavenProject project = new MavenProject(model);
+        project.setFile(pomFile.toFile());
+        project.setOriginalModel(model);
+        return project;
+    }
+
+    private static void addDepMgmt(MavenProject project, String groupId, String artifactId, String version) {
+        Model model = project.getOriginalModel();
+        DependencyManagement depMgmt = new DependencyManagement();
+        Dependency dep = new Dependency();
+        dep.setGroupId(groupId);
+        dep.setArtifactId(artifactId);
+        dep.setVersion(version);
+        depMgmt.addDependency(dep);
+        model.setDependencyManagement(depMgmt);
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/AlignTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AlignTuiTest.java
@@ -20,8 +20,14 @@ package eu.maveniverse.maven.pilot;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.maven.AlignOptions;
+import eu.maveniverse.domtrip.maven.Coordinates;
+import eu.maveniverse.domtrip.maven.PomEditor;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class AlignTuiTest {
 
@@ -65,7 +71,7 @@ class AlignTuiTest {
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
 
-        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", detected);
+        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", detected, null);
         var options = tui.buildSelectedOptions();
 
         assertThat(options.versionStyle()).isEqualTo(AlignOptions.VersionStyle.MANAGED);
@@ -81,7 +87,7 @@ class AlignTuiTest {
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
 
-        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", detected);
+        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", detected, null);
         tui.cycleForward(); // row 0 = VersionStyle
 
         var options = tui.buildSelectedOptions();
@@ -96,10 +102,847 @@ class AlignTuiTest {
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
 
-        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", detected);
+        var tui = new AlignTui("/tmp/pom.xml", "g:a:1.0", detected, null);
         tui.cycleBackward(); // row 0 = VersionStyle
 
         var options = tui.buildSelectedOptions();
         assertThat(options.versionStyle()).isEqualTo(AlignOptions.VersionStyle.INLINE);
+    }
+
+    // -- Cross-POM alignment tests --
+
+    @Test
+    void constructorWithParentMergesConventionsWhenManaged() {
+        var childDetected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentDetected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.INLINE)
+                .versionSource(AlignOptions.VersionSource.PROPERTY)
+                .namingConvention(AlignOptions.PropertyNamingConvention.CAMEL_CASE)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", parentDetected);
+
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", childDetected, parentInfo);
+        var options = tui.buildSelectedOptions();
+
+        assertThat(options.versionStyle()).isEqualTo(AlignOptions.VersionStyle.MANAGED);
+        assertThat(options.versionSource()).isEqualTo(AlignOptions.VersionSource.PROPERTY);
+        assertThat(options.namingConvention()).isEqualTo(AlignOptions.PropertyNamingConvention.CAMEL_CASE);
+    }
+
+    @Test
+    void constructorWithParentKeepsChildConventionsWhenNotManaged() {
+        var childDetected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.INLINE)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentDetected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.PROPERTY)
+                .namingConvention(AlignOptions.PropertyNamingConvention.CAMEL_CASE)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", parentDetected);
+
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", childDetected, parentInfo);
+        var options = tui.buildSelectedOptions();
+
+        assertThat(options.versionStyle()).isEqualTo(AlignOptions.VersionStyle.INLINE);
+        assertThat(options.versionSource()).isEqualTo(AlignOptions.VersionSource.LITERAL);
+        assertThat(options.namingConvention()).isEqualTo(AlignOptions.PropertyNamingConvention.DOT_SUFFIX);
+    }
+
+    @Test
+    void alignCrossPomMovesVersionsToParent() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.example</groupId>
+                            <artifactId>foo</artifactId>
+                            <version>2.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """;
+        String parentPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0</version>
+                    <packaging>pom</packaging>
+                </project>
+                """;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        int count = tui.alignCrossPom(childEditor, parentEditor);
+
+        assertThat(count).isEqualTo(1);
+        assertThat(childEditor.toXml()).doesNotContain("<version>2.0</version>");
+        assertThat(parentEditor.toXml())
+                .contains("dependencyManagement")
+                .contains("org.example")
+                .contains("foo")
+                .contains("2.0");
+    }
+
+    @Test
+    void alignCrossPomReturnsZeroForNoDeps() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                </project>
+                """;
+        String parentPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0</version>
+                    <packaging>pom</packaging>
+                </project>
+                """;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        int count = tui.alignCrossPom(childEditor, parentEditor);
+        assertThat(count).isZero();
+    }
+
+    @Test
+    void alignCrossPomHandlesMultipleDependencies() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.example</groupId>
+                            <artifactId>foo</artifactId>
+                            <version>2.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.example</groupId>
+                            <artifactId>bar</artifactId>
+                            <version>3.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """;
+        String parentPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0</version>
+                    <packaging>pom</packaging>
+                </project>
+                """;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        int count = tui.alignCrossPom(childEditor, parentEditor);
+
+        assertThat(count).isEqualTo(2);
+        assertThat(parentEditor.toXml())
+                .contains("foo")
+                .contains("bar")
+                .contains("2.0")
+                .contains("3.0");
+    }
+
+    @Test
+    void alignCrossPomSkipsVersionlessDependencies() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.example</groupId>
+                            <artifactId>managed</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.example</groupId>
+                            <artifactId>foo</artifactId>
+                            <version>2.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """;
+        String parentPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0</version>
+                    <packaging>pom</packaging>
+                </project>
+                """;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        int count = tui.alignCrossPom(childEditor, parentEditor);
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void alignCrossPomWithPropertySourceCreatesPropertyInParent() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.example</groupId>
+                            <artifactId>foo</artifactId>
+                            <version>2.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """;
+        String parentPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0</version>
+                    <packaging>pom</packaging>
+                </project>
+                """;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.PROPERTY)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        int count = tui.alignCrossPom(childEditor, parentEditor);
+
+        assertThat(count).isEqualTo(1);
+        assertThat(parentEditor.toXml())
+                .contains("<properties>")
+                .contains("2.0")
+                .contains("dependencyManagement");
+    }
+
+    @Test
+    void alignCrossPomReusesExistingPropertyReference() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                    <properties>
+                        <foo.version>2.0</foo.version>
+                    </properties>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.example</groupId>
+                            <artifactId>foo</artifactId>
+                            <version>${foo.version}</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """;
+        String parentPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0</version>
+                    <packaging>pom</packaging>
+                </project>
+                """;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.PROPERTY)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        int count = tui.alignCrossPom(childEditor, parentEditor);
+
+        assertThat(count).isEqualTo(1);
+        assertThat(parentEditor.toXml()).contains("foo.version").contains("2.0").contains("${foo.version}");
+    }
+
+    @Test
+    void addToParentDepMgmtResolvesPropertyForLiteralSource() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                    <properties>
+                        <foo.version>3.5</foo.version>
+                    </properties>
+                </project>
+                """;
+        String parentPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0</version>
+                    <packaging>pom</packaging>
+                </project>
+                """;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        var coords = Coordinates.of("org.example", "foo", "${foo.version}");
+        tui.addToParentDepMgmt(childEditor, parentEditor, coords);
+
+        assertThat(parentEditor.toXml()).contains("3.5").doesNotContain("${foo.version}");
+    }
+
+    // -- isCrossPomMode tests --
+
+    @Test
+    void isCrossPomModeReturnsTrueWhenManagedWithParent() {
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        assertThat(tui.isCrossPomMode()).isTrue();
+    }
+
+    @Test
+    void isCrossPomModeReturnsFalseWhenNoParent() {
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, null);
+
+        assertThat(tui.isCrossPomMode()).isFalse();
+    }
+
+    @Test
+    void isCrossPomModeReturnsFalseWhenNotManaged() {
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.INLINE)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        assertThat(tui.isCrossPomMode()).isFalse();
+    }
+
+    // -- File-based cross-POM tests --
+
+    private static final String CHILD_POM_WITH_VERSION = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>test</groupId>
+                <artifactId>child</artifactId>
+                <version>1.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.example</groupId>
+                        <artifactId>foo</artifactId>
+                        <version>2.0</version>
+                    </dependency>
+                </dependencies>
+            </project>
+            """;
+
+    private static final String EMPTY_PARENT_POM = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>test</groupId>
+                <artifactId>parent</artifactId>
+                <version>1.0</version>
+                <packaging>pom</packaging>
+            </project>
+            """;
+
+    @Test
+    void applyCrossPomAlignmentWritesBothFiles(@TempDir Path tempDir) throws Exception {
+        Path childPom = tempDir.resolve("child/pom.xml");
+        Path parentPom = tempDir.resolve("parent/pom.xml");
+        Files.createDirectories(childPom.getParent());
+        Files.createDirectories(parentPom.getParent());
+        Files.writeString(childPom, CHILD_POM_WITH_VERSION);
+        Files.writeString(parentPom, EMPTY_PARENT_POM);
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo(parentPom.toString(), "g:parent:1.0", detected);
+        var tui = new AlignTui(childPom.toString(), "g:child:1.0", detected, parentInfo);
+
+        tui.applyCrossPomAlignment();
+
+        String resultChild = Files.readString(childPom);
+        String resultParent = Files.readString(parentPom);
+
+        assertThat(resultChild).doesNotContain("<version>2.0</version>");
+        assertThat(resultParent).contains("dependencyManagement").contains("2.0");
+    }
+
+    @Test
+    void crossPomPreviewThenWriteModifiesBothFiles(@TempDir Path tempDir) throws Exception {
+        Path childPom = tempDir.resolve("child/pom.xml");
+        Path parentPom = tempDir.resolve("parent/pom.xml");
+        Files.createDirectories(childPom.getParent());
+        Files.createDirectories(parentPom.getParent());
+        Files.writeString(childPom, CHILD_POM_WITH_VERSION);
+        Files.writeString(parentPom, EMPTY_PARENT_POM);
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo(parentPom.toString(), "g:parent:1.0", detected);
+        var tui = new AlignTui(childPom.toString(), "g:child:1.0", detected, parentInfo);
+
+        tui.showCrossPomPreview();
+        tui.writeCrossPomChanges();
+
+        String resultChild = Files.readString(childPom);
+        String resultParent = Files.readString(parentPom);
+
+        assertThat(resultChild).doesNotContain("<version>2.0</version>");
+        assertThat(resultParent).contains("dependencyManagement").contains("2.0");
+    }
+
+    @Test
+    void crossPomPreviewNoChangesWhenAlreadyAligned(@TempDir Path tempDir) throws Exception {
+        String alignedChild = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.example</groupId>
+                            <artifactId>foo</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """;
+
+        Path childPom = tempDir.resolve("child/pom.xml");
+        Path parentPom = tempDir.resolve("parent/pom.xml");
+        Files.createDirectories(childPom.getParent());
+        Files.createDirectories(parentPom.getParent());
+        Files.writeString(childPom, alignedChild);
+        Files.writeString(parentPom, EMPTY_PARENT_POM);
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo(parentPom.toString(), "g:parent:1.0", detected);
+        var tui = new AlignTui(childPom.toString(), "g:child:1.0", detected, parentInfo);
+
+        tui.showCrossPomPreview();
+
+        // Files should be unchanged
+        assertThat(Files.readString(childPom)).isEqualTo(alignedChild);
+        assertThat(Files.readString(parentPom)).isEqualTo(EMPTY_PARENT_POM);
+    }
+
+    @Test
+    void addToParentDepMgmtHandlesUnresolvedProperty() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                </project>
+                """;
+        String parentPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0</version>
+                    <packaging>pom</packaging>
+                </project>
+                """;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        // Property reference that doesn't exist in child — should fall back to raw version
+        var coords = Coordinates.of("org.example", "foo", "${missing.version}");
+        tui.addToParentDepMgmt(childEditor, parentEditor, coords);
+
+        assertThat(parentEditor.toXml()).contains("${missing.version}").doesNotContain("<properties>");
+    }
+
+    // -- Constructor convention inheritance tests --
+
+    @Test
+    void constructorInheritsParentConventionsWhenManaged() {
+        var childDetected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentDetected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.PROPERTY)
+                .namingConvention(AlignOptions.PropertyNamingConvention.CAMEL_CASE)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", parentDetected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", childDetected, parentInfo);
+
+        var options = tui.buildSelectedOptions();
+        assertThat(options.versionStyle()).isEqualTo(AlignOptions.VersionStyle.MANAGED);
+        assertThat(options.versionSource()).isEqualTo(AlignOptions.VersionSource.PROPERTY);
+        assertThat(options.namingConvention()).isEqualTo(AlignOptions.PropertyNamingConvention.CAMEL_CASE);
+    }
+
+    @Test
+    void constructorKeepsChildConventionsWhenInline() {
+        var childDetected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.INLINE)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentDetected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.PROPERTY)
+                .namingConvention(AlignOptions.PropertyNamingConvention.CAMEL_CASE)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", parentDetected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", childDetected, parentInfo);
+
+        var options = tui.buildSelectedOptions();
+        assertThat(options.versionSource()).isEqualTo(AlignOptions.VersionSource.LITERAL);
+        assertThat(options.namingConvention()).isEqualTo(AlignOptions.PropertyNamingConvention.DOT_SUFFIX);
+    }
+
+    // -- alignCrossPom edge cases --
+
+    @Test
+    void alignCrossPomReturnsZeroWhenNoDependenciesElement() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                </project>
+                """;
+        String parentPom = EMPTY_PARENT_POM;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        assertThat(tui.alignCrossPom(childEditor, parentEditor)).isZero();
+    }
+
+    @Test
+    void alignCrossPomSkipsDependenciesWithoutVersion() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.example</groupId>
+                            <artifactId>foo</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """;
+        String parentPom = EMPTY_PARENT_POM;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        assertThat(tui.alignCrossPom(childEditor, parentEditor)).isZero();
+    }
+
+    // -- addToParentDepMgmt branch coverage --
+
+    @Test
+    void addToParentDepMgmtWithPropertySourceCreatesNewProperty() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                </project>
+                """;
+        String parentPom = EMPTY_PARENT_POM;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.PROPERTY)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        // Literal version with PROPERTY source → generates property name
+        var coords = Coordinates.of("org.example", "foo", "3.0");
+        tui.addToParentDepMgmt(childEditor, parentEditor, coords);
+
+        assertThat(parentEditor.toXml())
+                .contains("<properties>")
+                .contains("3.0")
+                .contains("dependencyManagement");
+    }
+
+    @Test
+    void addToParentDepMgmtWithPropertySourceSkipsExistingParentProperty() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                    <properties>
+                        <foo.version>2.0</foo.version>
+                    </properties>
+                </project>
+                """;
+        String parentPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>parent</artifactId>
+                    <version>1.0</version>
+                    <packaging>pom</packaging>
+                    <properties>
+                        <foo.version>1.5</foo.version>
+                    </properties>
+                </project>
+                """;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.PROPERTY)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        var coords = Coordinates.of("org.example", "foo", "${foo.version}");
+        tui.addToParentDepMgmt(childEditor, parentEditor, coords);
+
+        // Parent already had foo.version=1.5, should NOT overwrite it
+        assertThat(parentEditor.toXml()).contains("1.5").contains("${foo.version}");
+    }
+
+    @Test
+    void addToParentDepMgmtWithLiteralSourceUsesLiteralVersion() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                </project>
+                """;
+        String parentPom = EMPTY_PARENT_POM;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        var coords = Coordinates.of("org.example", "foo", "4.0");
+        tui.addToParentDepMgmt(childEditor, parentEditor, coords);
+
+        assertThat(parentEditor.toXml())
+                .contains("4.0")
+                .contains("dependencyManagement")
+                .doesNotContain("<properties>");
+    }
+
+    @Test
+    void addToParentDepMgmtWithLiteralSourceResolvesPropertyRef() {
+        String childPom = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>test</groupId>
+                    <artifactId>child</artifactId>
+                    <version>1.0</version>
+                    <properties>
+                        <bar.version>5.0</bar.version>
+                    </properties>
+                </project>
+                """;
+        String parentPom = EMPTY_PARENT_POM;
+
+        var detected = AlignOptions.builder()
+                .versionStyle(AlignOptions.VersionStyle.MANAGED)
+                .versionSource(AlignOptions.VersionSource.LITERAL)
+                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
+                .build();
+        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
+        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
+
+        PomEditor childEditor = new PomEditor(Document.of(childPom));
+        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
+
+        // Property ref with LITERAL source → resolves to literal value
+        var coords = Coordinates.of("org.example", "bar", "${bar.version}");
+        tui.addToParentDepMgmt(childEditor, parentEditor, coords);
+
+        assertThat(parentEditor.toXml())
+                .contains("5.0")
+                .doesNotContain("${bar.version}")
+                .doesNotContain("<properties>");
     }
 }


### PR DESCRIPTION
## Summary

- **Reactor-aware alignment**: When aligning a child module, the align tool now walks the parent chain to find the nearest reactor-local ancestor with `<dependencyManagement>` and uses it as the target for managed dep entries
- **Cross-POM editing**: Selecting MANAGED version style moves inline versions from the child POM to the parent's `<dependencyManagement>` section, stripping versions from child deps — supports both LITERAL and PROPERTY version sources with proper property migration
- **Multi-file preview**: Uses `DiffOverlay.openMulti()` to show changes across both parent and child POMs with distinguishing labels (e.g. `parent/pom.xml`, `core/pom.xml`)
- **Convention merging**: When child deps are already managed by parent, detects version source and property naming conventions from the parent POM for accurate defaults

## Test plan

- [x] All 208 existing tests pass (0 failures, 0 errors)
- [x] Existing `AlignTuiTest` updated for new constructor signature with `null` parentInfo
- [ ] Manual test: run `mvn pilot:align` on a multi-module reactor, select a child module, verify cross-POM preview shows changes in both parent and child POMs
- [ ] Manual test: verify MANAGED + PROPERTY style correctly creates properties in parent POM
- [ ] Manual test: verify single-module projects still work (parentInfo = null, standard behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-POM dependency alignment: detect a reactor parent POM and move inline child versions into parent dependency-management; preview and apply coordinated parent+child changes with a UI indicator and updated help.

* **Tests**
  * Extensive cross-POM unit and file-based integration tests plus new parent-detection test suite covering discovery, fallbacks, and edge cases.

* **Chores**
  * Added reactor-local parent detection and propagated parent context into the alignment UI flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->