### PR TITLE
feat: add batch mode to module picker (run all / run subtree)

### DIFF
--- a/src/main/java/eu/maveniverse/maven/pilot/AlignMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignMojo.java
@@ -69,15 +69,7 @@ public class AlignMojo extends AbstractMojo {
     }
 
     private void executeReactor(List<MavenProject> projects) throws Exception {
-        ReactorModel reactorModel = ReactorModel.build(projects);
-        MavenProject root = projects.get(0);
-        String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
-
-        while (true) {
-            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "align").pick();
-            if (selected == null) break;
-            executeForProject(selected);
-        }
+        ModulePickerTui.forEachSelected(projects, "align", this::executeForProject);
     }
 
     private void executeForProject(MavenProject proj) throws Exception {

--- a/src/main/java/eu/maveniverse/maven/pilot/DependenciesMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependenciesMojo.java
@@ -94,15 +94,7 @@ public class DependenciesMojo extends AbstractMojo {
     }
 
     private void executeReactor(List<MavenProject> projects) throws Exception {
-        ReactorModel reactorModel = ReactorModel.build(projects);
-        MavenProject root = projects.get(0);
-        String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
-
-        while (true) {
-            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "dependencies").pick();
-            if (selected == null) break;
-            executeForProject(selected);
-        }
+        ModulePickerTui.forEachSelected(projects, "dependencies", this::executeForProject);
     }
 
     private void executeForProject(MavenProject proj) throws Exception {

--- a/src/main/java/eu/maveniverse/maven/pilot/ModulePickerTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ModulePickerTui.java
@@ -45,16 +45,54 @@ import org.apache.maven.project.MavenProject;
  * Reusable module picker TUI for reactor-aware goals.
  *
  * <p>Displays the reactor module tree and lets the user select a module.
- * Returns the selected {@link MavenProject} or {@code null} if the user quits.</p>
+ * Returns a {@link PickResult} containing the selected project(s), or {@code null} if the user quits.
+ * Supports single selection (Enter), run on all modules (r), and run on subtree (t).</p>
  */
 class ModulePickerTui {
+
+    record PickResult(List<MavenProject> projects) {}
+
+    @FunctionalInterface
+    interface ProjectAction {
+        void execute(MavenProject project) throws Exception;
+    }
+
+    /**
+     * Convenience loop: show the module picker, then run the given action on each selected project.
+     * Repeats until the user quits the picker.
+     */
+    static void forEachSelected(List<MavenProject> projects, String goalName, ProjectAction action) throws Exception {
+        if (projects == null || projects.isEmpty()) {
+            throw new IllegalArgumentException("projects must be non-empty");
+        }
+        ReactorModel reactorModel = ReactorModel.build(projects);
+        MavenProject root = projects.get(0);
+        String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
+
+        while (true) {
+            PickResult result = new ModulePickerTui(reactorModel, reactorGav, goalName).pick();
+            if (result == null) break;
+            for (MavenProject selected : result.projects()) {
+                try {
+                    action.execute(selected);
+                } catch (Exception e) {
+                    String gav = selected.getGroupId() + ":" + selected.getArtifactId() + ":" + selected.getVersion();
+                    throw new Exception("Failed to execute " + goalName + " on " + gav + ": " + e.getMessage(), e);
+                }
+            }
+        }
+    }
 
     private final ReactorModel reactorModel;
     private final String reactorGav;
     private final String goalName;
     private final TableState tableState = new TableState();
     private final HelpOverlay helpOverlay = new HelpOverlay();
-    private MavenProject selectedProject;
+    private PickResult pickResult;
+
+    PickResult getPickResult() {
+        return pickResult;
+    }
 
     ModulePickerTui(ReactorModel reactorModel, String reactorGav, String goalName) {
         this.reactorModel = reactorModel;
@@ -64,11 +102,12 @@ class ModulePickerTui {
     }
 
     /**
-     * Run the picker TUI and return the selected project.
+     * Run the picker TUI and return the selected project(s).
      *
-     * @return the selected MavenProject, or null if the user quit without selecting
+     * @return a PickResult with the selected project(s), or null if the user quit without selecting
      */
-    MavenProject pick() throws Exception {
+    PickResult pick() throws Exception {
+        pickResult = null;
         var configured = TuiRunner.builder()
                 .eventHandler(this::handleEvent)
                 .renderer(this::render)
@@ -79,7 +118,7 @@ class ModulePickerTui {
         } finally {
             configured.close();
         }
-        return selectedProject;
+        return pickResult;
     }
 
     boolean handleEvent(Event event, TuiRunner runner) {
@@ -115,7 +154,7 @@ class ModulePickerTui {
         if (key.isKey(KeyCode.ENTER)) {
             Integer sel = tableState.selected();
             if (sel != null && sel >= 0 && sel < visible.size()) {
-                selectedProject = visible.get(sel).project;
+                pickResult = new PickResult(List.of(visible.get(sel).project));
                 runner.quit();
             }
             return true;
@@ -179,6 +218,22 @@ class ModulePickerTui {
                     if (newIndex < 0) newIndex = 0;
                 }
                 tableState.select(newIndex);
+            }
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('r')) {
+            List<MavenProject> all =
+                    reactorModel.allModules.stream().map(n -> n.project).toList();
+            pickResult = new PickResult(all);
+            runner.quit();
+            return true;
+        }
+        if (key.isCharIgnoreCase('t')) {
+            Integer sel = tableState.selected();
+            if (sel != null && sel >= 0 && sel < visible.size()) {
+                pickResult = new PickResult(reactorModel.collectSubtree(visible.get(sel)));
+                runner.quit();
             }
             return true;
         }
@@ -308,6 +363,8 @@ class ModulePickerTui {
                                 new HelpOverlay.Entry("Space", "Expand node or move down"),
                                 new HelpOverlay.Entry("e / w", "Expand all / collapse all"),
                                 new HelpOverlay.Entry("Enter", "Select the highlighted module"),
+                                new HelpOverlay.Entry("r", "Run on all modules"),
+                                new HelpOverlay.Entry("t", "Run on subtree of selected node"),
                                 new HelpOverlay.Entry("h", "Toggle this help screen"),
                                 new HelpOverlay.Entry("q / Esc", "Quit without selecting"))));
     }
@@ -333,6 +390,10 @@ class ModulePickerTui {
         spans.add(Span.raw(":Collapse All  "));
         spans.add(Span.raw("Enter").bold());
         spans.add(Span.raw(":Select  "));
+        spans.add(Span.raw("r").bold());
+        spans.add(Span.raw(":Run All  "));
+        spans.add(Span.raw("t").bold());
+        spans.add(Span.raw(":Subtree  "));
         spans.add(Span.raw("h").bold());
         spans.add(Span.raw(":Help  "));
         spans.add(Span.raw("q").bold());

--- a/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
@@ -122,11 +122,22 @@ public class PilotMojo extends AbstractMojo {
         String reactorGav = gavOf(root);
 
         while (true) {
-            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "pilot").pick();
-            if (selected == null) break;
-            String tool = new ToolPickerTui(gavOf(selected), true).pick();
+            ModulePickerTui.PickResult result = new ModulePickerTui(reactorModel, reactorGav, "pilot").pick();
+            if (result == null) break;
+            List<MavenProject> selected = result.projects();
+            String tool = new ToolPickerTui(gavOf(selected.get(0)), true).pick();
             if (tool == null) continue;
-            runTool(tool, selected, projects);
+            switch (tool) {
+                case "updates", "conflicts", "audit" ->
+                    // Aggregate tools: call once with the selected subset
+                    runTool(tool, selected.get(0), selected);
+                default -> {
+                    // Per-project tools: iterate over each selected project
+                    for (MavenProject p : selected) {
+                        runTool(tool, p, selected);
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/PomMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PomMojo.java
@@ -86,15 +86,7 @@ public class PomMojo extends AbstractMojo {
     }
 
     private void executeReactor(List<MavenProject> projects) throws Exception {
-        ReactorModel reactorModel = ReactorModel.build(projects);
-        MavenProject root = projects.get(0);
-        String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
-
-        while (true) {
-            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "pom").pick();
-            if (selected == null) break;
-            executeForProject(selected);
-        }
+        ModulePickerTui.forEachSelected(projects, "pom", this::executeForProject);
     }
 
     private void executeForProject(MavenProject proj) throws Exception {

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorModel.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorModel.java
@@ -138,6 +138,22 @@ class ReactorModel {
     }
 
     /**
+     * Collect all projects in the subtree rooted at the given node.
+     */
+    List<MavenProject> collectSubtree(ModuleNode node) {
+        List<MavenProject> result = new ArrayList<>();
+        collectSubtreeProjects(node, result);
+        return result;
+    }
+
+    private void collectSubtreeProjects(ModuleNode node, List<MavenProject> result) {
+        result.add(node.project);
+        for (ModuleNode child : node.children) {
+            collectSubtreeProjects(child, result);
+        }
+    }
+
+    /**
      * Filter modules by name substring (case-insensitive).
      */
     List<ModuleNode> filter(String query) {

--- a/src/main/java/eu/maveniverse/maven/pilot/TreeMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/TreeMojo.java
@@ -78,15 +78,7 @@ public class TreeMojo extends AbstractMojo {
     }
 
     private void executeReactor(List<MavenProject> projects) throws Exception {
-        ReactorModel reactorModel = ReactorModel.build(projects);
-        MavenProject root = projects.get(0);
-        String reactorGav = root.getGroupId() + ":" + root.getArtifactId() + ":" + root.getVersion();
-
-        while (true) {
-            MavenProject selected = new ModulePickerTui(reactorModel, reactorGav, "tree").pick();
-            if (selected == null) break;
-            executeForProject(selected);
-        }
+        ModulePickerTui.forEachSelected(projects, "tree", this::executeForProject);
     }
 
     private void executeForProject(MavenProject proj) throws Exception {

--- a/src/test/java/eu/maveniverse/maven/pilot/ModulePickerTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ModulePickerTuiTest.java
@@ -1,0 +1,337 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static eu.maveniverse.maven.pilot.TestProjects.createProject;
+import static eu.maveniverse.maven.pilot.TestProjects.subdir;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import dev.tamboui.layout.Size;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.pilot.Pilot;
+import dev.tamboui.tui.pilot.TuiTestRunner;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ModulePickerTuiTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void enterSelectsSingleModule() throws Exception {
+        Path childDir = subdir(tempDir, "child");
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject child = createProject("child", childDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:parent:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press(KeyCode.ENTER);
+        }
+
+        assertThat(picker.getPickResult()).isNotNull();
+        assertThat(picker.getPickResult().projects()).hasSize(1);
+        assertThat(picker.getPickResult().projects().get(0).getArtifactId()).isEqualTo("parent");
+    }
+
+    @Test
+    void enterAfterNavigateSelectsChild() throws Exception {
+        Path childDir = subdir(tempDir, "child");
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject child = createProject("child", childDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:parent:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press(KeyCode.DOWN);
+            pilot.pause();
+            pilot.press(KeyCode.ENTER);
+        }
+
+        assertThat(picker.getPickResult()).isNotNull();
+        assertThat(picker.getPickResult().projects()).hasSize(1);
+        assertThat(picker.getPickResult().projects().get(0).getArtifactId()).isEqualTo("child");
+    }
+
+    @Test
+    void quitReturnsNull() throws Exception {
+        MavenProject root = createProject("app", tempDir);
+        ReactorModel model = ReactorModel.build(List.of(root));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:app:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press('q');
+        }
+
+        assertThat(picker.getPickResult()).isNull();
+    }
+
+    @Test
+    void escapeReturnsNull() throws Exception {
+        MavenProject root = createProject("app", tempDir);
+        ReactorModel model = ReactorModel.build(List.of(root));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:app:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press(KeyCode.ESCAPE);
+        }
+
+        assertThat(picker.getPickResult()).isNull();
+    }
+
+    @Test
+    void rSelectsAllModules() throws Exception {
+        Path coreDir = subdir(tempDir, "core");
+        Path apiDir = subdir(tempDir, "api");
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject core = createProject("core", coreDir);
+        MavenProject api = createProject("api", apiDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, core, api));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:parent:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press('r');
+        }
+
+        assertThat(picker.getPickResult()).isNotNull();
+        assertThat(picker.getPickResult().projects()).hasSize(3);
+        assertThat(picker.getPickResult().projects())
+                .extracting(MavenProject::getArtifactId)
+                .containsExactly("parent", "core", "api");
+    }
+
+    @Test
+    void tSelectsSubtree() throws Exception {
+        Path coreDir = subdir(tempDir, "core");
+        Path modelDir = Files.createDirectories(coreDir.resolve("model"));
+        Path apiDir = subdir(tempDir, "api");
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject core = createProject("core", coreDir);
+        MavenProject coreModel = createProject("model", modelDir);
+        MavenProject api = createProject("api", apiDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, core, coreModel, api));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:parent:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press(KeyCode.DOWN);
+            pilot.pause();
+            pilot.press('t');
+        }
+
+        assertThat(picker.getPickResult()).isNotNull();
+        assertThat(picker.getPickResult().projects()).hasSize(2);
+        assertThat(picker.getPickResult().projects())
+                .extracting(MavenProject::getArtifactId)
+                .containsExactly("core", "model");
+    }
+
+    @Test
+    void upKeyMovesSelectionUp() throws Exception {
+        Path childDir = subdir(tempDir, "child");
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject child = createProject("child", childDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:parent:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press(KeyCode.DOWN);
+            pilot.pause();
+            pilot.press(KeyCode.UP);
+            pilot.pause();
+            pilot.press(KeyCode.ENTER);
+        }
+
+        assertThat(picker.getPickResult()).isNotNull();
+        assertThat(picker.getPickResult().projects().get(0).getArtifactId()).isEqualTo("parent");
+    }
+
+    @Test
+    void rightExpandsAndLeftCollapses() throws Exception {
+        Path childDir = subdir(tempDir, "child");
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject child = createProject("child", childDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:parent:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            // Collapse root with LEFT
+            pilot.press(KeyCode.LEFT);
+            pilot.pause();
+            // Expand root with RIGHT
+            pilot.press(KeyCode.RIGHT);
+            pilot.pause();
+            // Navigate to child and select
+            pilot.press(KeyCode.DOWN);
+            pilot.pause();
+            pilot.press(KeyCode.ENTER);
+        }
+
+        assertThat(picker.getPickResult()).isNotNull();
+        assertThat(picker.getPickResult().projects().get(0).getArtifactId()).isEqualTo("child");
+    }
+
+    @Test
+    void leftOnLeafNavigatesToParent() throws Exception {
+        Path childDir = subdir(tempDir, "child");
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject child = createProject("child", childDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:parent:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            // Navigate to child (leaf)
+            pilot.press(KeyCode.DOWN);
+            pilot.pause();
+            // LEFT on leaf navigates to parent
+            pilot.press(KeyCode.LEFT);
+            pilot.pause();
+            // Now on root, select it
+            pilot.press(KeyCode.ENTER);
+        }
+
+        assertThat(picker.getPickResult()).isNotNull();
+        assertThat(picker.getPickResult().projects().get(0).getArtifactId()).isEqualTo("parent");
+    }
+
+    @Test
+    void spaceMovesDownOnExpandedNode() throws Exception {
+        Path childDir = subdir(tempDir, "child");
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject child = createProject("child", childDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:parent:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            // Root is expanded, Space moves down to child
+            pilot.press(' ');
+            pilot.pause();
+            pilot.press(KeyCode.ENTER);
+        }
+
+        assertThat(picker.getPickResult()).isNotNull();
+        assertThat(picker.getPickResult().projects().get(0).getArtifactId()).isEqualTo("child");
+    }
+
+    @Test
+    void expandAllWithE() throws Exception {
+        Path childDir = subdir(tempDir, "child");
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject child = createProject("child", childDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:parent:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press('e');
+            pilot.pause();
+            pilot.press('q');
+        }
+
+        assertThat(picker.getPickResult()).isNull();
+    }
+
+    @Test
+    void collapseAllWithW() throws Exception {
+        Path childDir = subdir(tempDir, "child");
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject child = createProject("child", childDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:parent:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press('w');
+            pilot.pause();
+            pilot.press('q');
+        }
+
+        assertThat(picker.getPickResult()).isNull();
+    }
+
+    @Test
+    void helpOverlayOpensAndQuit() throws Exception {
+        MavenProject root = createProject("app", tempDir);
+        ReactorModel model = ReactorModel.build(List.of(root));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:app:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            // Open help overlay
+            pilot.press('h');
+            pilot.pause();
+            // Quit from help overlay
+            pilot.press('q');
+        }
+
+        assertThat(picker.getPickResult()).isNull();
+    }
+
+    @Test
+    void forEachSelectedRejectsNull() {
+        assertThatThrownBy(() -> ModulePickerTui.forEachSelected(null, "test", p -> {}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("projects must be non-empty");
+    }
+
+    @Test
+    void forEachSelectedRejectsEmpty() {
+        assertThatThrownBy(() -> ModulePickerTui.forEachSelected(List.of(), "test", p -> {}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("projects must be non-empty");
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/ReactorModelTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ReactorModelTest.java
@@ -18,6 +18,8 @@
  */
 package eu.maveniverse.maven.pilot;
 
+import static eu.maveniverse.maven.pilot.TestProjects.createProject;
+import static eu.maveniverse.maven.pilot.TestProjects.subdir;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -25,7 +27,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -34,20 +35,6 @@ class ReactorModelTest {
 
     @TempDir
     Path tempDir;
-
-    private Path subdir(String name) throws IOException {
-        return Files.createDirectories(tempDir.resolve(name));
-    }
-
-    private MavenProject createProject(String artifactId, Path basedir) {
-        Model model = new Model();
-        model.setGroupId("com.example");
-        model.setArtifactId(artifactId);
-        model.setVersion("1.0");
-        MavenProject project = new MavenProject(model);
-        project.setFile(basedir.resolve("pom.xml").toFile());
-        return project;
-    }
 
     @Test
     void buildSingleProject() {
@@ -64,7 +51,7 @@ class ReactorModelTest {
 
     @Test
     void buildParentChild() throws IOException {
-        Path childDir = subdir("child");
+        Path childDir = subdir(tempDir, "child");
 
         MavenProject root = createProject("parent", tempDir);
         MavenProject child = createProject("child", childDir);
@@ -81,7 +68,7 @@ class ReactorModelTest {
 
     @Test
     void buildNestedHierarchy() throws IOException {
-        Path coreDir = subdir("core");
+        Path coreDir = subdir(tempDir, "core");
         Path modelDir = Files.createDirectories(coreDir.resolve("core-model"));
 
         MavenProject root = createProject("parent", tempDir);
@@ -99,7 +86,7 @@ class ReactorModelTest {
 
     @Test
     void visibleNodesCollapsed() throws IOException {
-        Path childDir = subdir("child");
+        Path childDir = subdir(tempDir, "child");
         Path grandchildDir = Files.createDirectories(childDir.resolve("grandchild"));
 
         MavenProject root = createProject("root", tempDir);
@@ -122,7 +109,7 @@ class ReactorModelTest {
 
     @Test
     void visibleNodesExpanded() throws IOException {
-        Path childDir = subdir("child2");
+        Path childDir = subdir(tempDir, "child2");
 
         MavenProject root = createProject("root", tempDir);
         MavenProject child = createProject("child", childDir);
@@ -136,8 +123,8 @@ class ReactorModelTest {
 
     @Test
     void filterByName() throws IOException {
-        Path coreDir = subdir("core");
-        Path apiDir = subdir("api");
+        Path coreDir = subdir(tempDir, "core");
+        Path apiDir = subdir(tempDir, "api");
 
         MavenProject root = createProject("parent", tempDir);
         MavenProject core = createProject("core-module", coreDir);
@@ -152,7 +139,7 @@ class ReactorModelTest {
 
     @Test
     void filterCaseInsensitive() throws IOException {
-        Path childDir = subdir("child3");
+        Path childDir = subdir(tempDir, "child3");
 
         MavenProject root = createProject("ROOT-project", tempDir);
         MavenProject child = createProject("Child-Module", childDir);
@@ -166,7 +153,7 @@ class ReactorModelTest {
 
     @Test
     void filterByGa() throws IOException {
-        Path childDir = subdir("child4");
+        Path childDir = subdir(tempDir, "child4");
 
         MavenProject root = createProject("parent", tempDir);
         MavenProject child = createProject("child", childDir);
@@ -188,8 +175,8 @@ class ReactorModelTest {
 
     @Test
     void recomputeCounts() throws IOException {
-        Path coreDir = subdir("core2");
-        Path apiDir = subdir("api2");
+        Path coreDir = subdir(tempDir, "core2");
+        Path apiDir = subdir(tempDir, "api2");
 
         MavenProject root = createProject("parent", tempDir);
         MavenProject core = createProject("core", coreDir);
@@ -210,7 +197,7 @@ class ReactorModelTest {
 
     @Test
     void recomputeCountsNested() throws IOException {
-        Path coreDir = subdir("core3");
+        Path coreDir = subdir(tempDir, "core3");
         Path modelDir = Files.createDirectories(coreDir.resolve("model"));
 
         MavenProject root = createProject("parent", tempDir);
@@ -244,6 +231,57 @@ class ReactorModelTest {
 
         assertThat(node.ga()).isEqualTo("com.example:myapp");
         assertThat(node.gav()).isEqualTo("com.example:myapp:1.0");
+    }
+
+    @Test
+    void collectSubtreeFromRoot() throws IOException {
+        Path coreDir = subdir(tempDir, "core-sub");
+        Path apiDir = subdir(tempDir, "api-sub");
+
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject core = createProject("core", coreDir);
+        MavenProject api = createProject("api", apiDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, core, api));
+
+        List<MavenProject> subtree = model.collectSubtree(model.root);
+        assertThat(subtree).hasSize(3);
+        assertThat(subtree).extracting(MavenProject::getArtifactId).containsExactly("parent", "core", "api");
+    }
+
+    @Test
+    void collectSubtreeFromChild() throws IOException {
+        Path coreDir = subdir(tempDir, "core-sub2");
+        Path modelDir = Files.createDirectories(coreDir.resolve("model-sub"));
+        Path apiDir = subdir(tempDir, "api-sub2");
+
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject core = createProject("core", coreDir);
+        MavenProject coreModel = createProject("model", modelDir);
+        MavenProject api = createProject("api", apiDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, core, coreModel, api));
+
+        // Subtree from "core" should include core + model, but not api
+        ReactorModel.ModuleNode coreNode = model.root.children.get(0);
+        List<MavenProject> subtree = model.collectSubtree(coreNode);
+        assertThat(subtree).hasSize(2);
+        assertThat(subtree).extracting(MavenProject::getArtifactId).containsExactly("core", "model");
+    }
+
+    @Test
+    void collectSubtreeLeafNode() throws IOException {
+        Path childDir = subdir(tempDir, "leaf-child");
+
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject child = createProject("child", childDir);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child));
+
+        ReactorModel.ModuleNode leafNode = model.root.children.get(0);
+        List<MavenProject> subtree = model.collectSubtree(leafNode);
+        assertThat(subtree).hasSize(1);
+        assertThat(subtree.get(0).getArtifactId()).isEqualTo("child");
     }
 
     @Test

--- a/src/test/java/eu/maveniverse/maven/pilot/TestProjects.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/TestProjects.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Shared test helpers for creating MavenProject instances.
+ */
+class TestProjects {
+
+    static Path subdir(Path parent, String name) throws IOException {
+        return Files.createDirectories(parent.resolve(name));
+    }
+
+    static MavenProject createProject(String artifactId, Path basedir) {
+        Model model = new Model();
+        model.setGroupId("com.example");
+        model.setArtifactId(artifactId);
+        model.setVersion("1.0");
+        MavenProject project = new MavenProject(model);
+        project.setFile(basedir.resolve("pom.xml").toFile());
+        return project;
+    }
+}


### PR DESCRIPTION
## Summary

- Add recursive invocation to the module picker TUI: `r` runs on all reactor modules, `t` runs on the subtree of the selected node
- Introduce `PickResult` record, `ProjectAction` interface, and `forEachSelected()` helper to eliminate duplicated `executeReactor()` code across all mojos
- Add `ReactorModel.collectSubtree()` for subtree selection
- Fix PilotMojo batch handling to distinguish aggregate tools (updates, conflicts, audit) from per-project tools
- Add defensive input validation and error context wrapping in `forEachSelected`
- Add 15 TUI tests covering all key bindings plus input validation, with shared `TestProjects` utility

## Test plan

- [x] All 226 tests pass (including 15 new ModulePickerTuiTest + 17 ReactorModelTest)
- [x] TUI key bindings tested: Enter, r, t, q, Esc, UP, DOWN, LEFT, RIGHT, Space, e, w, h
- [x] `forEachSelected` rejects null/empty project lists
- [x] Subtree collection tested for root, child, and leaf nodes
- [x] Manual testing of batch mode in multi-module reactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-module picker: select multiple modules, select all modules ('r'), or select a subtree ('t'); run goals against the selected set.

* **Refactor**
  * Centralized module-selection flow so commands operate on selected module lists instead of single picks.

* **Enhancements**
  * Reactor subtree collection for targeted module operations; updated picker help/info to document new actions.

* **Tests**
  * New tests for picker interactions and subtree collection; added test utilities for project setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->