### PR TITLE
Upgrade to DomTrip 1.2.0 with native cross-POM alignment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@ under the License.
     <maven.compiler.release>17</maven.compiler.release>
     <mavenVersion>3.9.9</mavenVersion>
     <tamboui.version>0.1.0</tamboui.version>
-    <domtrip.version>1.1.0</domtrip.version>
+    <domtrip.version>1.2.0</domtrip.version>
 
     <!-- SonarCloud -->
     <sonar.projectKey>maveniverse_pilot</sonar.projectKey>

--- a/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
@@ -38,7 +38,6 @@ import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.maven.AlignOptions;
-import eu.maveniverse.domtrip.maven.Coordinates;
 import eu.maveniverse.domtrip.maven.PomEditor;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -47,8 +46,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Interactive TUI for dependency convention alignment.
@@ -69,13 +66,10 @@ class AlignTui {
      */
     record ParentPomInfo(String pomPath, String gav, AlignOptions detectedOptions) {}
 
-    private static final Logger LOGGER = Logger.getLogger(AlignTui.class.getName());
-
     private static final int ROW_VERSION_STYLE = 0;
     private static final int ROW_VERSION_SOURCE = 1;
     private static final int ROW_PROPERTY_NAMING = 2;
     private static final int ROW_COUNT = 3;
-    private static final String PROPERTIES_ELEMENT = "properties";
 
     private final String pomPath;
     private final List<String> additionalPomPaths; // batch mode: additional POMs to align
@@ -392,7 +386,7 @@ class AlignTui {
             for (String childPath : additionalPomPaths) {
                 String childContent = Files.readString(Path.of(childPath));
                 PomEditor childEditor = new PomEditor(Document.of(childContent));
-                totalCount += alignCrossPom(childEditor, parentEditor);
+                totalCount += childEditor.dependencies().alignAllToParent(parentEditor, buildSelectedOptions());
                 String childModified = childEditor.toXml();
                 if (!childContent.equals(childModified)) {
                     String label = Path.of(childPath).getParent().getFileName() + "/pom.xml";
@@ -434,7 +428,7 @@ class AlignTui {
             for (String childPath : additionalPomPaths) {
                 String childContent = Files.readString(Path.of(childPath));
                 PomEditor childEditor = new PomEditor(Document.of(childContent));
-                totalCount += alignCrossPom(childEditor, parentEditor);
+                totalCount += childEditor.dependencies().alignAllToParent(parentEditor, buildSelectedOptions());
                 String childModified = childEditor.toXml();
                 if (!childContent.equals(childModified)) {
                     Files.writeString(Path.of(childPath), childModified);
@@ -468,7 +462,7 @@ class AlignTui {
             PomEditor childEditor = new PomEditor(Document.of(childContent));
             PomEditor parentEditor = new PomEditor(Document.of(parentContent));
 
-            int count = alignCrossPom(childEditor, parentEditor);
+            int count = childEditor.dependencies().alignAllToParent(parentEditor, buildSelectedOptions());
 
             String childModified = childEditor.toXml();
             String parentModified = parentEditor.toXml();
@@ -520,7 +514,7 @@ class AlignTui {
             PomEditor childEditor = new PomEditor(Document.of(childContent));
             PomEditor parentEditor = new PomEditor(Document.of(parentContent));
 
-            int count = alignCrossPom(childEditor, parentEditor);
+            int count = childEditor.dependencies().alignAllToParent(parentEditor, buildSelectedOptions());
 
             // Writes are not atomic across the two files; users can roll back via git if interrupted
             Files.writeString(Path.of(parentInfo.pomPath()), parentEditor.toXml());
@@ -543,103 +537,6 @@ class AlignTui {
             alignedPomContent = null;
         } catch (Exception e) {
             status = "Failed to write POMs: " + e.getMessage();
-        }
-    }
-
-    /**
-     * Align dependencies across child and parent POMs.
-     * Moves inline versions from child deps to parent's dependency management.
-     *
-     * @return the number of dependencies aligned
-     */
-    int alignCrossPom(PomEditor childEditor, PomEditor parentEditor) {
-        var depsOpt = childEditor.root().childElement("dependencies");
-        if (depsOpt.isEmpty()) return 0;
-
-        List<Coordinates> toManage = new ArrayList<>();
-
-        // Collect child deps that have inline versions
-        depsOpt.orElseThrow().childElements("dependency").forEach(dep -> {
-            String gid = dep.childTextOr("groupId", "");
-            String aid = dep.childTextOr("artifactId", "");
-            String ver = dep.childTextOr("version", null);
-            if (ver != null && !ver.isEmpty()) {
-                toManage.add(Coordinates.of(gid, aid, ver));
-            }
-        });
-
-        int count = 0;
-        for (var coords : toManage) {
-            addToParentDepMgmt(childEditor, parentEditor, coords);
-            childEditor.dependencies().deleteDependencyVersion(coords);
-            count++;
-        }
-
-        return count;
-    }
-
-    /**
-     * Add a dependency to the parent POM's dependency management section,
-     * following the selected version source and naming conventions.
-     */
-    void addToParentDepMgmt(PomEditor childEditor, PomEditor parentEditor, Coordinates coords) {
-        String version = coords.version();
-
-        if (selectedSource == AlignOptions.VersionSource.PROPERTY) {
-            String propName;
-            String propValue;
-
-            if (version.startsWith("${") && version.endsWith("}")) {
-                // Already a property reference - reuse name and resolve value from child
-                propName = version.substring(2, version.length() - 1);
-                propValue = childEditor
-                        .root()
-                        .childElement(PROPERTIES_ELEMENT)
-                        .map(p -> p.childTextOr(propName, null))
-                        .orElse(null);
-            } else {
-                // Literal version - create new property with selected naming convention
-                propName = AlignOptions.generatePropertyName(coords, selectedNaming);
-                propValue = version;
-            }
-
-            // Add property to parent and determine managed dep version
-            String managedVersion;
-            if (propValue != null) {
-                boolean parentHasProp = parentEditor
-                        .root()
-                        .childElement(PROPERTIES_ELEMENT)
-                        .flatMap(p -> p.childElement(propName))
-                        .isPresent();
-                if (!parentHasProp) {
-                    parentEditor.properties().updateProperty(true, propName, propValue);
-                }
-                managedVersion = "${" + propName + "}";
-            } else {
-                // Property not found in child POM — use raw version reference
-                LOGGER.log(Level.FINE, "Property {0} not found in child POM; using raw version: {1}", new Object[] {
-                    propName, version
-                });
-                managedVersion = version;
-            }
-
-            var managedCoords = Coordinates.of(coords.groupId(), coords.artifactId(), managedVersion);
-            parentEditor.dependencies().updateManagedDependency(true, managedCoords);
-        } else {
-            // LITERAL source - resolve property refs if possible, then add literal version
-            String literalVersion = version;
-            if (version.startsWith("${") && version.endsWith("}")) {
-                String propName = version.substring(2, version.length() - 1);
-                literalVersion = childEditor
-                        .root()
-                        .childElement(PROPERTIES_ELEMENT)
-                        .map(p -> p.childTextOr(propName, version))
-                        .orElse(version);
-            }
-            parentEditor
-                    .dependencies()
-                    .updateManagedDependency(
-                            true, Coordinates.of(coords.groupId(), coords.artifactId(), literalVersion));
         }
     }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
@@ -39,8 +39,11 @@ import dev.tamboui.widgets.table.TableState;
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.maven.AlignOptions;
 import eu.maveniverse.domtrip.maven.PomEditor;
+import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -508,20 +511,50 @@ class AlignTui {
 
     void applyCrossPomAlignment() {
         try {
-            String childContent = Files.readString(Path.of(pomPath));
-            String parentContent = Files.readString(Path.of(parentInfo.pomPath()));
+            Path parentPath = Path.of(parentInfo.pomPath());
+            Path childPath = Path.of(pomPath);
+
+            String childContent = Files.readString(childPath);
+            String parentContent = Files.readString(parentPath);
 
             PomEditor childEditor = new PomEditor(Document.of(childContent));
             PomEditor parentEditor = new PomEditor(Document.of(parentContent));
 
             int count = childEditor.dependencies().alignAllToParent(parentEditor, buildSelectedOptions());
 
-            // Writes are not atomic across the two files; users can roll back via git if interrupted
-            Files.writeString(Path.of(parentInfo.pomPath()), parentEditor.toXml());
-            Files.writeString(Path.of(pomPath), childEditor.toXml());
+            // Write to temp files first, then atomically replace originals
+            atomicWritePair(parentPath, parentEditor.toXml(), childPath, childEditor.toXml());
             status = "Aligned " + count + " dependency(ies) across 2 POMs";
         } catch (Exception e) {
             status = "Failed to apply alignment: " + e.getMessage();
+        }
+    }
+
+    /**
+     * Writes two POM files atomically: first to temp files, then moved to replace originals.
+     * Falls back to non-atomic move if the filesystem does not support ATOMIC_MOVE.
+     */
+    static void atomicWritePair(Path path1, String content1, Path path2, String content2) throws IOException {
+        Path tmp1 = Files.createTempFile(path1.getParent(), ".pom", ".tmp");
+        Path tmp2 = Files.createTempFile(path2.getParent(), ".pom", ".tmp");
+        try {
+            Files.writeString(tmp1, content1);
+            Files.writeString(tmp2, content2);
+            atomicMove(tmp1, path1);
+            tmp1 = null; // moved successfully
+            atomicMove(tmp2, path2);
+            tmp2 = null; // moved successfully
+        } finally {
+            if (tmp1 != null) Files.deleteIfExists(tmp1);
+            if (tmp2 != null) Files.deleteIfExists(tmp2);
+        }
+    }
+
+    private static void atomicMove(Path source, Path target) throws IOException {
+        try {
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+        } catch (AtomicMoveNotSupportedException e) {
+            Files.move(source, target, StandardCopyOption.REPLACE_EXISTING);
         }
     }
 

--- a/src/test/java/eu/maveniverse/maven/pilot/AlignTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AlignTuiTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.maven.AlignOptions;
-import eu.maveniverse.domtrip.maven.Coordinates;
 import eu.maveniverse.domtrip.maven.PomEditor;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -189,13 +188,10 @@ class AlignTuiTest {
                 .versionSource(AlignOptions.VersionSource.LITERAL)
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
         PomEditor childEditor = new PomEditor(Document.of(childPom));
         PomEditor parentEditor = new PomEditor(Document.of(parentPom));
 
-        int count = tui.alignCrossPom(childEditor, parentEditor);
+        int count = childEditor.dependencies().alignAllToParent(parentEditor, detected);
 
         assertThat(count).isEqualTo(1);
         assertThat(childEditor.toXml()).doesNotContain("<version>2.0</version>");
@@ -233,13 +229,10 @@ class AlignTuiTest {
                 .versionSource(AlignOptions.VersionSource.LITERAL)
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
         PomEditor childEditor = new PomEditor(Document.of(childPom));
         PomEditor parentEditor = new PomEditor(Document.of(parentPom));
 
-        int count = tui.alignCrossPom(childEditor, parentEditor);
+        int count = childEditor.dependencies().alignAllToParent(parentEditor, detected);
         assertThat(count).isZero();
     }
 
@@ -282,13 +275,10 @@ class AlignTuiTest {
                 .versionSource(AlignOptions.VersionSource.LITERAL)
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
         PomEditor childEditor = new PomEditor(Document.of(childPom));
         PomEditor parentEditor = new PomEditor(Document.of(parentPom));
 
-        int count = tui.alignCrossPom(childEditor, parentEditor);
+        int count = childEditor.dependencies().alignAllToParent(parentEditor, detected);
 
         assertThat(count).isEqualTo(2);
         assertThat(parentEditor.toXml())
@@ -336,13 +326,10 @@ class AlignTuiTest {
                 .versionSource(AlignOptions.VersionSource.LITERAL)
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
         PomEditor childEditor = new PomEditor(Document.of(childPom));
         PomEditor parentEditor = new PomEditor(Document.of(parentPom));
 
-        int count = tui.alignCrossPom(childEditor, parentEditor);
+        int count = childEditor.dependencies().alignAllToParent(parentEditor, detected);
         assertThat(count).isEqualTo(1);
     }
 
@@ -380,13 +367,10 @@ class AlignTuiTest {
                 .versionSource(AlignOptions.VersionSource.PROPERTY)
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
         PomEditor childEditor = new PomEditor(Document.of(childPom));
         PomEditor parentEditor = new PomEditor(Document.of(parentPom));
 
-        int count = tui.alignCrossPom(childEditor, parentEditor);
+        int count = childEditor.dependencies().alignAllToParent(parentEditor, detected);
 
         assertThat(count).isEqualTo(1);
         assertThat(parentEditor.toXml())
@@ -432,58 +416,13 @@ class AlignTuiTest {
                 .versionSource(AlignOptions.VersionSource.PROPERTY)
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
         PomEditor childEditor = new PomEditor(Document.of(childPom));
         PomEditor parentEditor = new PomEditor(Document.of(parentPom));
 
-        int count = tui.alignCrossPom(childEditor, parentEditor);
+        int count = childEditor.dependencies().alignAllToParent(parentEditor, detected);
 
         assertThat(count).isEqualTo(1);
         assertThat(parentEditor.toXml()).contains("foo.version").contains("2.0").contains("${foo.version}");
-    }
-
-    @Test
-    void addToParentDepMgmtResolvesPropertyForLiteralSource() {
-        String childPom = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>child</artifactId>
-                    <version>1.0</version>
-                    <properties>
-                        <foo.version>3.5</foo.version>
-                    </properties>
-                </project>
-                """;
-        String parentPom = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>parent</artifactId>
-                    <version>1.0</version>
-                    <packaging>pom</packaging>
-                </project>
-                """;
-
-        var detected = AlignOptions.builder()
-                .versionStyle(AlignOptions.VersionStyle.MANAGED)
-                .versionSource(AlignOptions.VersionSource.LITERAL)
-                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
-                .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
-        PomEditor childEditor = new PomEditor(Document.of(childPom));
-        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
-
-        var coords = Coordinates.of("org.example", "foo", "${foo.version}");
-        tui.addToParentDepMgmt(childEditor, parentEditor, coords);
-
-        assertThat(parentEditor.toXml()).contains("3.5").doesNotContain("${foo.version}");
     }
 
     // -- isCrossPomMode tests --
@@ -649,46 +588,6 @@ class AlignTuiTest {
         assertThat(Files.readString(parentPom)).isEqualTo(EMPTY_PARENT_POM);
     }
 
-    @Test
-    void addToParentDepMgmtHandlesUnresolvedProperty() {
-        String childPom = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>child</artifactId>
-                    <version>1.0</version>
-                </project>
-                """;
-        String parentPom = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>parent</artifactId>
-                    <version>1.0</version>
-                    <packaging>pom</packaging>
-                </project>
-                """;
-
-        var detected = AlignOptions.builder()
-                .versionStyle(AlignOptions.VersionStyle.MANAGED)
-                .versionSource(AlignOptions.VersionSource.LITERAL)
-                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
-                .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
-        PomEditor childEditor = new PomEditor(Document.of(childPom));
-        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
-
-        // Property reference that doesn't exist in child — should fall back to raw version
-        var coords = Coordinates.of("org.example", "foo", "${missing.version}");
-        tui.addToParentDepMgmt(childEditor, parentEditor, coords);
-
-        assertThat(parentEditor.toXml()).contains("${missing.version}").doesNotContain("<properties>");
-    }
-
     // -- Constructor convention inheritance tests --
 
     @Test
@@ -752,13 +651,11 @@ class AlignTuiTest {
                 .versionSource(AlignOptions.VersionSource.LITERAL)
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
         PomEditor childEditor = new PomEditor(Document.of(childPom));
         PomEditor parentEditor = new PomEditor(Document.of(parentPom));
 
-        assertThat(tui.alignCrossPom(childEditor, parentEditor)).isZero();
+        assertThat(childEditor.dependencies().alignAllToParent(parentEditor, detected))
+                .isZero();
     }
 
     @Test
@@ -785,164 +682,10 @@ class AlignTuiTest {
                 .versionSource(AlignOptions.VersionSource.LITERAL)
                 .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
                 .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
         PomEditor childEditor = new PomEditor(Document.of(childPom));
         PomEditor parentEditor = new PomEditor(Document.of(parentPom));
 
-        assertThat(tui.alignCrossPom(childEditor, parentEditor)).isZero();
-    }
-
-    // -- addToParentDepMgmt branch coverage --
-
-    @Test
-    void addToParentDepMgmtWithPropertySourceCreatesNewProperty() {
-        String childPom = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>child</artifactId>
-                    <version>1.0</version>
-                </project>
-                """;
-        String parentPom = EMPTY_PARENT_POM;
-
-        var detected = AlignOptions.builder()
-                .versionStyle(AlignOptions.VersionStyle.MANAGED)
-                .versionSource(AlignOptions.VersionSource.PROPERTY)
-                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
-                .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
-        PomEditor childEditor = new PomEditor(Document.of(childPom));
-        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
-
-        // Literal version with PROPERTY source → generates property name
-        var coords = Coordinates.of("org.example", "foo", "3.0");
-        tui.addToParentDepMgmt(childEditor, parentEditor, coords);
-
-        assertThat(parentEditor.toXml())
-                .contains("<properties>")
-                .contains("3.0")
-                .contains("dependencyManagement");
-    }
-
-    @Test
-    void addToParentDepMgmtWithPropertySourceSkipsExistingParentProperty() {
-        String childPom = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>child</artifactId>
-                    <version>1.0</version>
-                    <properties>
-                        <foo.version>2.0</foo.version>
-                    </properties>
-                </project>
-                """;
-        String parentPom = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>parent</artifactId>
-                    <version>1.0</version>
-                    <packaging>pom</packaging>
-                    <properties>
-                        <foo.version>1.5</foo.version>
-                    </properties>
-                </project>
-                """;
-
-        var detected = AlignOptions.builder()
-                .versionStyle(AlignOptions.VersionStyle.MANAGED)
-                .versionSource(AlignOptions.VersionSource.PROPERTY)
-                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
-                .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
-        PomEditor childEditor = new PomEditor(Document.of(childPom));
-        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
-
-        var coords = Coordinates.of("org.example", "foo", "${foo.version}");
-        tui.addToParentDepMgmt(childEditor, parentEditor, coords);
-
-        // Parent already had foo.version=1.5, should NOT overwrite it
-        assertThat(parentEditor.toXml()).contains("1.5").contains("${foo.version}");
-    }
-
-    @Test
-    void addToParentDepMgmtWithLiteralSourceUsesLiteralVersion() {
-        String childPom = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>child</artifactId>
-                    <version>1.0</version>
-                </project>
-                """;
-        String parentPom = EMPTY_PARENT_POM;
-
-        var detected = AlignOptions.builder()
-                .versionStyle(AlignOptions.VersionStyle.MANAGED)
-                .versionSource(AlignOptions.VersionSource.LITERAL)
-                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
-                .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
-        PomEditor childEditor = new PomEditor(Document.of(childPom));
-        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
-
-        var coords = Coordinates.of("org.example", "foo", "4.0");
-        tui.addToParentDepMgmt(childEditor, parentEditor, coords);
-
-        assertThat(parentEditor.toXml())
-                .contains("4.0")
-                .contains("dependencyManagement")
-                .doesNotContain("<properties>");
-    }
-
-    @Test
-    void addToParentDepMgmtWithLiteralSourceResolvesPropertyRef() {
-        String childPom = """
-                <?xml version="1.0" encoding="UTF-8"?>
-                <project>
-                    <modelVersion>4.0.0</modelVersion>
-                    <groupId>test</groupId>
-                    <artifactId>child</artifactId>
-                    <version>1.0</version>
-                    <properties>
-                        <bar.version>5.0</bar.version>
-                    </properties>
-                </project>
-                """;
-        String parentPom = EMPTY_PARENT_POM;
-
-        var detected = AlignOptions.builder()
-                .versionStyle(AlignOptions.VersionStyle.MANAGED)
-                .versionSource(AlignOptions.VersionSource.LITERAL)
-                .namingConvention(AlignOptions.PropertyNamingConvention.DOT_SUFFIX)
-                .build();
-        var parentInfo = new AlignTui.ParentPomInfo("/tmp/parent/pom.xml", "g:parent:1.0", detected);
-        var tui = new AlignTui("/tmp/child/pom.xml", "g:child:1.0", detected, parentInfo);
-
-        PomEditor childEditor = new PomEditor(Document.of(childPom));
-        PomEditor parentEditor = new PomEditor(Document.of(parentPom));
-
-        // Property ref with LITERAL source → resolves to literal value
-        var coords = Coordinates.of("org.example", "bar", "${bar.version}");
-        tui.addToParentDepMgmt(childEditor, parentEditor, coords);
-
-        assertThat(parentEditor.toXml())
-                .contains("5.0")
-                .doesNotContain("${bar.version}")
-                .doesNotContain("<properties>");
+        assertThat(childEditor.dependencies().alignAllToParent(parentEditor, detected))
+                .isZero();
     }
 }


### PR DESCRIPTION
## Summary
- Bump `domtrip.version` from 1.1.0 to 1.2.0
- Replace custom `alignCrossPom()` and `addToParentDepMgmt()` workarounds with DomTrip's native `alignAllToParent()` API (-360 lines)
- Rewrite cross-POM alignment tests to exercise the DomTrip API directly; remove tests for internalized logic

## Test plan
- [x] All 259 tests pass (`mvn test -B`)
- [x] AlignBatchTest (11 tests) — end-to-end batch alignment pipeline verified
- [x] AlignTuiTest — cross-POM and single-POM alignment tests pass with new API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated domtrip library dependency to version 1.2.0.

* **Refactor**
  * Alignment behavior now delegates to the library and uses a safer, atomic update flow for paired file writes.

* **Tests**
  * Updated test suite to reflect the new alignment implementation and removed obsolete alignment-specific test cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->