### PR TITLE
fix: suppress Maven transfer listener to prevent TUI corruption

### DIFF
--- a/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
@@ -49,6 +49,7 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
@@ -60,6 +61,7 @@ import org.eclipse.aether.resolution.DependencyRequest;
 import org.eclipse.aether.resolution.DependencyResult;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.transfer.AbstractTransferListener;
 
 /**
  * Interactive launcher that displays the reactor module tree and lets the user
@@ -95,6 +97,11 @@ public class PilotMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        // Suppress transfer progress output to prevent corruption of TUI rendering
+        DefaultRepositorySystemSession quietSession = new DefaultRepositorySystemSession(repoSession);
+        quietSession.setTransferListener(new AbstractTransferListener() {});
+        this.repoSession = quietSession;
+
         try {
             List<MavenProject> projects = session.getProjects();
             if (projects.size() > 1) {


### PR DESCRIPTION
Fixes #24

## Summary
- Wraps the injected `RepositorySystemSession` with a `DefaultRepositorySystemSession` that uses a no-op `AbstractTransferListener`
- Suppresses Maven download progress output that was bleeding into stderr and corrupting the TUI display
- Applies to all resolution paths (version range, artifact, dependency collection) since `repoSession` is replaced at the top of `execute()`

## Test plan
- [ ] Run `mvn pilot:updates -B` on a project with dependencies not in the local cache — TUI should render cleanly without download progress lines mixed in
- [ ] Verify all tools (tree, dependencies, updates, conflicts, audit, search) still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed verbose repository transfer progress output during execution for a cleaner console experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->