### PR TITLE
fix: exclude BOM-imported deps from updates tool

### DIFF
--- a/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
@@ -39,6 +39,7 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
 import org.apache.maven.model.InputLocation;
 import org.apache.maven.model.InputLocationTracker;
 import org.apache.maven.model.InputSource;
@@ -447,36 +448,46 @@ public class PilotMojo extends AbstractMojo {
                 dependencies.add(new UpdatesTui.DependencyInfo(
                         dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType()));
             }
-            // Use the original model to only show deps explicitly declared in this POM,
-            // not the hundreds of entries inherited from imported BOMs
-            if (proj.getOriginalModel().getDependencyManagement() != null) {
-                Map<String, String> effectiveVersions = new HashMap<>();
-                if (proj.getDependencyManagement() != null) {
-                    for (Dependency d : proj.getDependencyManagement().getDependencies()) {
-                        effectiveVersions.put(d.getGroupId() + ":" + d.getArtifactId(), d.getVersion());
-                    }
-                }
-                for (Dependency dep :
-                        proj.getOriginalModel().getDependencyManagement().getDependencies()) {
-                    // Skip BOM imports — they are not regular dependencies
-                    if ("pom".equals(dep.getType()) && "import".equals(dep.getScope())) {
-                        continue;
-                    }
-                    boolean alreadyListed = dependencies.stream()
-                            .anyMatch(d ->
-                                    d.groupId.equals(dep.getGroupId()) && d.artifactId.equals(dep.getArtifactId()));
-                    if (!alreadyListed) {
-                        String ga = dep.getGroupId() + ":" + dep.getArtifactId();
-                        String version = effectiveVersions.getOrDefault(ga, dep.getVersion());
-                        var info = new UpdatesTui.DependencyInfo(
-                                dep.getGroupId(), dep.getArtifactId(), version, dep.getScope(), dep.getType());
-                        info.managed = true;
-                        dependencies.add(info);
-                    }
-                }
-            }
+            collectManagedDependencies(
+                    proj.getOriginalModel().getDependencyManagement(), proj.getDependencyManagement(), dependencies);
             String pomPath = proj.getFile().getAbsolutePath();
             new UpdatesTui(dependencies, pomPath, gavOf(proj), versionResolver).run();
+        }
+    }
+
+    /**
+     * Collects managed dependencies from the original model, filtering out BOM imports
+     * and dependencies inherited from imported BOMs. Uses the effective model to resolve
+     * property-based version expressions.
+     */
+    static void collectManagedDependencies(
+            DependencyManagement originalMgmt,
+            DependencyManagement effectiveMgmt,
+            List<UpdatesTui.DependencyInfo> dependencies) {
+        if (originalMgmt == null) {
+            return;
+        }
+        Map<String, String> effectiveVersions = new HashMap<>();
+        if (effectiveMgmt != null) {
+            for (Dependency d : effectiveMgmt.getDependencies()) {
+                effectiveVersions.put(d.getGroupId() + ":" + d.getArtifactId(), d.getVersion());
+            }
+        }
+        for (Dependency dep : originalMgmt.getDependencies()) {
+            // Skip BOM imports — they are not regular dependencies
+            if ("pom".equals(dep.getType()) && "import".equals(dep.getScope())) {
+                continue;
+            }
+            boolean alreadyListed = dependencies.stream()
+                    .anyMatch(d -> d.groupId.equals(dep.getGroupId()) && d.artifactId.equals(dep.getArtifactId()));
+            if (!alreadyListed) {
+                String ga = dep.getGroupId() + ":" + dep.getArtifactId();
+                String version = effectiveVersions.getOrDefault(ga, dep.getVersion());
+                var info = new UpdatesTui.DependencyInfo(
+                        dep.getGroupId(), dep.getArtifactId(), version, dep.getScope(), dep.getType());
+                info.managed = true;
+                dependencies.add(info);
+            }
         }
     }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
@@ -447,14 +447,29 @@ public class PilotMojo extends AbstractMojo {
                 dependencies.add(new UpdatesTui.DependencyInfo(
                         dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType()));
             }
-            if (proj.getDependencyManagement() != null) {
-                for (Dependency dep : proj.getDependencyManagement().getDependencies()) {
+            // Use the original model to only show deps explicitly declared in this POM,
+            // not the hundreds of entries inherited from imported BOMs
+            if (proj.getOriginalModel().getDependencyManagement() != null) {
+                Map<String, String> effectiveVersions = new HashMap<>();
+                if (proj.getDependencyManagement() != null) {
+                    for (Dependency d : proj.getDependencyManagement().getDependencies()) {
+                        effectiveVersions.put(d.getGroupId() + ":" + d.getArtifactId(), d.getVersion());
+                    }
+                }
+                for (Dependency dep :
+                        proj.getOriginalModel().getDependencyManagement().getDependencies()) {
+                    // Skip BOM imports — they are not regular dependencies
+                    if ("pom".equals(dep.getType()) && "import".equals(dep.getScope())) {
+                        continue;
+                    }
                     boolean alreadyListed = dependencies.stream()
                             .anyMatch(d ->
                                     d.groupId.equals(dep.getGroupId()) && d.artifactId.equals(dep.getArtifactId()));
                     if (!alreadyListed) {
+                        String ga = dep.getGroupId() + ":" + dep.getArtifactId();
+                        String version = effectiveVersions.getOrDefault(ga, dep.getVersion());
                         var info = new UpdatesTui.DependencyInfo(
-                                dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType());
+                                dep.getGroupId(), dep.getArtifactId(), version, dep.getScope(), dep.getType());
                         info.managed = true;
                         dependencies.add(info);
                     }

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
@@ -19,10 +19,12 @@
 package eu.maveniverse.maven.pilot;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.maven.model.Dependency;
@@ -170,8 +172,20 @@ class ReactorCollector {
                     ? originalMgmt.getDependencies()
                     : List.of();
 
+            // Only include dependencies explicitly declared in this project's POM,
+            // not those inherited from imported BOMs
+            Set<String> declaredManagedGAs = new HashSet<>();
+            for (Dependency dep : originalMgmtDeps) {
+                if (!("pom".equals(dep.getType()) && "import".equals(dep.getScope()))) {
+                    declaredManagedGAs.add(dep.getGroupId() + ":" + dep.getArtifactId());
+                }
+            }
+
             for (Dependency dep : mgmt.getDependencies()) {
                 String ga = dep.getGroupId() + ":" + dep.getArtifactId();
+                if (!declaredManagedGAs.contains(ga)) {
+                    continue;
+                }
                 AggregatedDependency agg =
                         byGA.computeIfAbsent(ga, k -> new AggregatedDependency(dep.getGroupId(), dep.getArtifactId()));
 

--- a/src/test/java/eu/maveniverse/maven/pilot/PilotMojoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/PilotMojoTest.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.junit.jupiter.api.Test;
+
+class PilotMojoTest {
+
+    private Dependency dep(String groupId, String artifactId, String version) {
+        Dependency d = new Dependency();
+        d.setGroupId(groupId);
+        d.setArtifactId(artifactId);
+        d.setVersion(version);
+        return d;
+    }
+
+    @Test
+    void collectManagedDependenciesExcludesBomImports() {
+        DependencyManagement originalMgmt = new DependencyManagement();
+        Dependency bomImport = dep("io.quarkus", "quarkus-bom", "3.0.0");
+        bomImport.setType("pom");
+        bomImport.setScope("import");
+        originalMgmt.addDependency(bomImport);
+        originalMgmt.addDependency(dep("com.example", "my-lib", "1.0"));
+
+        // Effective model: BOM flattened
+        DependencyManagement effectiveMgmt = new DependencyManagement();
+        effectiveMgmt.addDependency(dep("com.example", "my-lib", "1.0"));
+        effectiveMgmt.addDependency(dep("io.quarkus", "quarkus-core", "3.0.0"));
+        effectiveMgmt.addDependency(dep("io.quarkus", "quarkus-arc", "3.0.0"));
+
+        List<UpdatesTui.DependencyInfo> dependencies = new ArrayList<>();
+        PilotMojo.collectManagedDependencies(originalMgmt, effectiveMgmt, dependencies);
+
+        assertThat(dependencies).hasSize(1);
+        assertThat(dependencies.get(0).groupId).isEqualTo("com.example");
+        assertThat(dependencies.get(0).artifactId).isEqualTo("my-lib");
+        assertThat(dependencies.get(0).managed).isTrue();
+    }
+
+    @Test
+    void collectManagedDependenciesResolvesPropertyVersions() {
+        DependencyManagement originalMgmt = new DependencyManagement();
+        originalMgmt.addDependency(dep("com.example", "my-lib", "${my.version}"));
+
+        DependencyManagement effectiveMgmt = new DependencyManagement();
+        effectiveMgmt.addDependency(dep("com.example", "my-lib", "2.5.0"));
+
+        List<UpdatesTui.DependencyInfo> dependencies = new ArrayList<>();
+        PilotMojo.collectManagedDependencies(originalMgmt, effectiveMgmt, dependencies);
+
+        assertThat(dependencies).hasSize(1);
+        assertThat(dependencies.get(0).version).isEqualTo("2.5.0");
+    }
+
+    @Test
+    void collectManagedDependenciesSkipsAlreadyListed() {
+        DependencyManagement originalMgmt = new DependencyManagement();
+        originalMgmt.addDependency(dep("com.example", "my-lib", "1.0"));
+
+        DependencyManagement effectiveMgmt = new DependencyManagement();
+        effectiveMgmt.addDependency(dep("com.example", "my-lib", "1.0"));
+
+        List<UpdatesTui.DependencyInfo> dependencies = new ArrayList<>();
+        dependencies.add(new UpdatesTui.DependencyInfo("com.example", "my-lib", "1.0", "compile", "jar"));
+
+        PilotMojo.collectManagedDependencies(originalMgmt, effectiveMgmt, dependencies);
+
+        assertThat(dependencies).hasSize(1);
+    }
+
+    @Test
+    void collectManagedDependenciesHandlesNullOriginalMgmt() {
+        List<UpdatesTui.DependencyInfo> dependencies = new ArrayList<>();
+        PilotMojo.collectManagedDependencies(null, null, dependencies);
+        assertThat(dependencies).isEmpty();
+    }
+
+    @Test
+    void collectManagedDependenciesHandlesNullEffectiveMgmt() {
+        DependencyManagement originalMgmt = new DependencyManagement();
+        originalMgmt.addDependency(dep("com.example", "my-lib", "1.0"));
+
+        List<UpdatesTui.DependencyInfo> dependencies = new ArrayList<>();
+        PilotMojo.collectManagedDependencies(originalMgmt, null, dependencies);
+
+        assertThat(dependencies).hasSize(1);
+        assertThat(dependencies.get(0).version).isEqualTo("1.0");
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/ReactorCollectorTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ReactorCollectorTest.java
@@ -304,6 +304,36 @@ class ReactorCollectorTest {
     }
 
     @Test
+    void collectExcludesBomImportedDependencies() {
+        MavenProject project = createProject("com.example", "app", "1.0", tempDir);
+
+        // Original model: one BOM import and one direct managed dep
+        DependencyManagement origMgmt = new DependencyManagement();
+        Dependency bomImport = dep("io.quarkus", "quarkus-bom", "3.0.0");
+        bomImport.setType("pom");
+        bomImport.setScope("import");
+        origMgmt.addDependency(bomImport);
+        origMgmt.addDependency(dep("com.example", "my-lib", "1.0"));
+        project.getOriginalModel().setDependencyManagement(origMgmt);
+
+        // Effective model: BOM is flattened — contains the direct dep
+        // plus all deps from the BOM (simulating Maven's behavior)
+        DependencyManagement mgmt = new DependencyManagement();
+        mgmt.addDependency(dep("com.example", "my-lib", "1.0"));
+        mgmt.addDependency(dep("io.quarkus", "quarkus-core", "3.0.0"));
+        mgmt.addDependency(dep("io.quarkus", "quarkus-arc", "3.0.0"));
+        mgmt.addDependency(dep("jakarta.enterprise", "jakarta.enterprise.cdi-api", "4.0.1"));
+        project.getModel().setDependencyManagement(mgmt);
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        // Only the directly declared managed dep should appear, not BOM-imported ones
+        assertThat(result.allDependencies).hasSize(1);
+        assertThat(result.allDependencies.get(0).groupId).isEqualTo("com.example");
+        assertThat(result.allDependencies.get(0).artifactId).isEqualTo("my-lib");
+    }
+
+    @Test
     void collectWithPropertyInParent() throws IOException {
         Path parentDir = subdir("parent2");
         Path childDir = subdir("child2");


### PR DESCRIPTION
## Summary
- Fixes #25: The updates tool showed updates for all dependencies managed by imported BOMs (e.g., Quarkus BOM with hundreds of entries), which users can't control individually
- Switched from the effective model to the original model for dependency management entries, so only explicitly declared managed deps are shown
- BOM imports themselves (`type=pom, scope=import`) are also filtered out
- Fixed both single-project path (`PilotMojo.runUpdates()`) and reactor-wide path (`ReactorCollector.collectFromProject()`)

## Test plan
- [ ] Run `mvn pilot:updates` on a project that imports a BOM (e.g., quarkus-bom) — only dependencies declared in the project's own POM should appear
- [ ] Run `mvn pilot:pilot` on a multi-module reactor with BOM imports — reactor updates should also filter correctly
- [ ] Verify that managed deps with property-based versions still show resolved versions (not `${property}` expressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed display of managed dependencies to correctly distinguish between explicitly declared dependencies and those inherited via imported BOMs.
  * Improved accuracy of dependency version resolution to properly surface effective versions from the project's dependency management configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->