### PR TITLE
test: add integration tests for dependency collection and BOM filtering

### DIFF
--- a/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PilotMojo.java
@@ -442,24 +442,7 @@ public class PilotMojo extends AbstractMojo {
             String reactorGav = gavOf(projects.get(0));
             new ReactorUpdatesTui(result, reactorModel, reactorGav, versionResolver).run();
         } else {
-            List<UpdatesTui.DependencyInfo> dependencies = new ArrayList<>();
-            for (Dependency dep : proj.getDependencies()) {
-                dependencies.add(new UpdatesTui.DependencyInfo(
-                        dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType()));
-            }
-            if (proj.getDependencyManagement() != null) {
-                for (Dependency dep : proj.getDependencyManagement().getDependencies()) {
-                    boolean alreadyListed = dependencies.stream()
-                            .anyMatch(d ->
-                                    d.groupId.equals(dep.getGroupId()) && d.artifactId.equals(dep.getArtifactId()));
-                    if (!alreadyListed) {
-                        var info = new UpdatesTui.DependencyInfo(
-                                dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType());
-                        info.managed = true;
-                        dependencies.add(info);
-                    }
-                }
-            }
+            List<UpdatesTui.DependencyInfo> dependencies = UpdatesHelper.collectDependencies(proj);
             String pomPath = proj.getFile().getAbsolutePath();
             new UpdatesTui(dependencies, pomPath, gavOf(proj), versionResolver).run();
         }

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
@@ -19,10 +19,12 @@
 package eu.maveniverse.maven.pilot;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.maven.model.Dependency;
@@ -170,8 +172,22 @@ class ReactorCollector {
                     ? originalMgmt.getDependencies()
                     : List.of();
 
+            // Build set of GA keys from original model to filter out BOM-imported deps
+            Set<String> originalGAs = new HashSet<>();
+            for (Dependency orig : originalMgmtDeps) {
+                if (!("pom".equals(orig.getType()) && "import".equals(orig.getScope()))) {
+                    originalGAs.add(orig.getGroupId() + ":" + orig.getArtifactId());
+                }
+            }
+
             for (Dependency dep : mgmt.getDependencies()) {
                 String ga = dep.getGroupId() + ":" + dep.getArtifactId();
+
+                // Skip deps not explicitly declared in the original model (i.e. BOM-imported)
+                if (!originalGAs.contains(ga)) {
+                    continue;
+                }
+
                 AggregatedDependency agg =
                         byGA.computeIfAbsent(ga, k -> new AggregatedDependency(dep.getGroupId(), dep.getArtifactId()));
 

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesHelper.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesHelper.java
@@ -19,9 +19,12 @@
 package eu.maveniverse.maven.pilot;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
 import org.apache.maven.project.MavenProject;
 
 /**
@@ -46,21 +49,23 @@ final class UpdatesHelper {
      */
     static List<UpdatesTui.DependencyInfo> collectDependencies(MavenProject proj) {
         List<UpdatesTui.DependencyInfo> dependencies = new ArrayList<>();
+        Set<String> seenGAs = new HashSet<>();
 
         for (Dependency dep : proj.getDependencies()) {
+            seenGAs.add(dep.getGroupId() + ":" + dep.getArtifactId());
             dependencies.add(new UpdatesTui.DependencyInfo(
                     dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType()));
         }
 
-        DependencyManagement mgmt = proj.getOriginalModel().getDependencyManagement();
+        Model originalModel = proj.getOriginalModel();
+        DependencyManagement mgmt = originalModel != null ? originalModel.getDependencyManagement() : null;
         if (mgmt != null && mgmt.getDependencies() != null) {
             for (Dependency dep : mgmt.getDependencies()) {
                 if ("pom".equals(dep.getType()) && "import".equals(dep.getScope())) {
                     continue;
                 }
-                boolean alreadyListed = dependencies.stream()
-                        .anyMatch(d -> d.groupId.equals(dep.getGroupId()) && d.artifactId.equals(dep.getArtifactId()));
-                if (!alreadyListed) {
+                String ga = dep.getGroupId() + ":" + dep.getArtifactId();
+                if (seenGAs.add(ga)) {
                     var info = new UpdatesTui.DependencyInfo(
                             dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType());
                     info.managed = true;

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesHelper.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesHelper.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.project.MavenProject;
+
+/**
+ * Shared utility for collecting dependencies for the updates tool.
+ * Uses the original model for dependency management to exclude BOM-imported dependencies.
+ */
+final class UpdatesHelper {
+
+    private UpdatesHelper() {}
+
+    /**
+     * Collect dependencies from a single project for the updates TUI.
+     *
+     * <p>Direct dependencies come from the effective model. Managed dependencies come from
+     * the <em>original</em> model's {@code <dependencyManagement>} section so that
+     * BOM-imported entries (which only appear in the effective model) are excluded.
+     * BOM import entries (type=pom, scope=import) are also filtered out.
+     * Managed deps already present in the direct list are skipped (deduplication).</p>
+     *
+     * @param proj the Maven project
+     * @return collected dependency info list
+     */
+    static List<UpdatesTui.DependencyInfo> collectDependencies(MavenProject proj) {
+        List<UpdatesTui.DependencyInfo> dependencies = new ArrayList<>();
+
+        for (Dependency dep : proj.getDependencies()) {
+            dependencies.add(new UpdatesTui.DependencyInfo(
+                    dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType()));
+        }
+
+        DependencyManagement mgmt = proj.getOriginalModel().getDependencyManagement();
+        if (mgmt != null && mgmt.getDependencies() != null) {
+            for (Dependency dep : mgmt.getDependencies()) {
+                if ("pom".equals(dep.getType()) && "import".equals(dep.getScope())) {
+                    continue;
+                }
+                boolean alreadyListed = dependencies.stream()
+                        .anyMatch(d -> d.groupId.equals(dep.getGroupId()) && d.artifactId.equals(dep.getArtifactId()));
+                if (!alreadyListed) {
+                    var info = new UpdatesTui.DependencyInfo(
+                            dep.getGroupId(), dep.getArtifactId(), dep.getVersion(), dep.getScope(), dep.getType());
+                    info.managed = true;
+                    dependencies.add(info);
+                }
+            }
+        }
+
+        return dependencies;
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/ReactorCollectorTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ReactorCollectorTest.java
@@ -327,4 +327,36 @@ class ReactorCollectorTest {
         assertThat(dep.propertyName).isEqualTo("junit.version");
         assertThat(dep.propertyOrigin).isEqualTo(parent);
     }
+
+    @Test
+    void collectExcludesBomImportedManagedDeps() {
+        MavenProject project = createProject("com.example", "app", "1.0", tempDir);
+
+        // Effective model has many managed deps (as if a BOM was imported)
+        DependencyManagement effectiveMgmt = new DependencyManagement();
+        effectiveMgmt.addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+        effectiveMgmt.addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        effectiveMgmt.addDependency(dep("com.fasterxml", "jackson-databind", "2.17.0"));
+        effectiveMgmt.addDependency(dep("io.netty", "netty-all", "4.1.100"));
+        effectiveMgmt.addDependency(dep("io.micrometer", "micrometer-core", "1.12.0"));
+        project.getModel().setDependencyManagement(effectiveMgmt);
+
+        // Original model only declares 2 managed deps (plus a BOM import)
+        DependencyManagement origMgmt = new DependencyManagement();
+        origMgmt.addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+        origMgmt.addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        Dependency bomImport = dep("org.springframework.boot", "spring-boot-dependencies", "3.2.0");
+        bomImport.setType("pom");
+        bomImport.setScope("import");
+        origMgmt.addDependency(bomImport);
+        project.getOriginalModel().setDependencyManagement(origMgmt);
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        // Only the 2 explicitly declared deps should appear, not the 5 from effective model
+        assertThat(result.allDependencies).hasSize(2);
+        assertThat(result.allDependencies)
+                .extracting(d -> d.groupId + ":" + d.artifactId)
+                .containsExactlyInAnyOrder("org.slf4j:slf4j-api", "com.fasterxml:jackson-core");
+    }
 }

--- a/src/test/java/eu/maveniverse/maven/pilot/UpdatesHelperTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UpdatesHelperTest.java
@@ -92,8 +92,7 @@ class UpdatesHelperTest {
 
         List<UpdatesTui.DependencyInfo> result = UpdatesHelper.collectDependencies(project);
 
-        assertThat(result).hasSize(2);
-        assertThat(result).allMatch(d -> d.managed);
+        assertThat(result).hasSize(2).allMatch(d -> d.managed);
         assertThat(result)
                 .extracting(d -> d.groupId + ":" + d.artifactId)
                 .containsExactly("org.slf4j:slf4j-api", "com.fasterxml:jackson-core");

--- a/src/test/java/eu/maveniverse/maven/pilot/UpdatesHelperTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/UpdatesHelperTest.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class UpdatesHelperTest {
+
+    @TempDir
+    Path tempDir;
+
+    private MavenProject createProject(String groupId, String artifactId, String version) {
+        Model model = new Model();
+        model.setGroupId(groupId);
+        model.setArtifactId(artifactId);
+        model.setVersion(version);
+
+        Model originalModel = new Model();
+        originalModel.setGroupId(groupId);
+        originalModel.setArtifactId(artifactId);
+        originalModel.setVersion(version);
+
+        MavenProject project = new MavenProject(model);
+        project.setOriginalModel(originalModel);
+        project.setFile(tempDir.resolve("pom.xml").toFile());
+        return project;
+    }
+
+    private Dependency dep(String groupId, String artifactId, String version) {
+        Dependency d = new Dependency();
+        d.setGroupId(groupId);
+        d.setArtifactId(artifactId);
+        d.setVersion(version);
+        return d;
+    }
+
+    private Dependency dep(String groupId, String artifactId, String version, String type, String scope) {
+        Dependency d = dep(groupId, artifactId, version);
+        d.setType(type);
+        d.setScope(scope);
+        return d;
+    }
+
+    @Test
+    void directDepsAreCollected() {
+        MavenProject project = createProject("com.example", "app", "1.0");
+        project.getModel().addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+        project.getModel().addDependency(dep("org.junit", "junit", "5.10.0"));
+
+        List<UpdatesTui.DependencyInfo> result = UpdatesHelper.collectDependencies(project);
+
+        assertThat(result).hasSize(2);
+        assertThat(result)
+                .extracting(d -> d.groupId + ":" + d.artifactId)
+                .containsExactly("org.slf4j:slf4j-api", "org.junit:junit");
+        assertThat(result).allMatch(d -> !d.managed);
+    }
+
+    @Test
+    void originalModelManagedDepsAreCollected() {
+        MavenProject project = createProject("com.example", "app", "1.0");
+
+        DependencyManagement origMgmt = new DependencyManagement();
+        origMgmt.addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+        origMgmt.addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        project.getOriginalModel().setDependencyManagement(origMgmt);
+
+        List<UpdatesTui.DependencyInfo> result = UpdatesHelper.collectDependencies(project);
+
+        assertThat(result).hasSize(2);
+        assertThat(result).allMatch(d -> d.managed);
+        assertThat(result)
+                .extracting(d -> d.groupId + ":" + d.artifactId)
+                .containsExactly("org.slf4j:slf4j-api", "com.fasterxml:jackson-core");
+    }
+
+    @Test
+    void bomImportedDepsAreExcluded() {
+        MavenProject project = createProject("com.example", "app", "1.0");
+
+        // Effective model has 50 deps from BOM (simulated with 3 here)
+        DependencyManagement effectiveMgmt = new DependencyManagement();
+        effectiveMgmt.addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+        effectiveMgmt.addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        effectiveMgmt.addDependency(dep("com.fasterxml", "jackson-databind", "2.17.0"));
+        effectiveMgmt.addDependency(dep("io.netty", "netty-all", "4.1.100"));
+        effectiveMgmt.addDependency(dep("io.micrometer", "micrometer-core", "1.12.0"));
+        project.getModel().setDependencyManagement(effectiveMgmt);
+
+        // Original model has only 2 explicitly declared managed deps
+        DependencyManagement origMgmt = new DependencyManagement();
+        origMgmt.addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+        origMgmt.addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        project.getOriginalModel().setDependencyManagement(origMgmt);
+
+        List<UpdatesTui.DependencyInfo> result = UpdatesHelper.collectDependencies(project);
+
+        // Should only have the 2 from the original model, not the 5 from effective
+        assertThat(result).hasSize(2);
+        assertThat(result)
+                .extracting(d -> d.groupId + ":" + d.artifactId)
+                .containsExactly("org.slf4j:slf4j-api", "com.fasterxml:jackson-core");
+    }
+
+    @Test
+    void bomImportEntriesFiltered() {
+        MavenProject project = createProject("com.example", "app", "1.0");
+
+        DependencyManagement origMgmt = new DependencyManagement();
+        origMgmt.addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+        origMgmt.addDependency(dep("org.springframework.boot", "spring-boot-dependencies", "3.2.0", "pom", "import"));
+        origMgmt.addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        project.getOriginalModel().setDependencyManagement(origMgmt);
+
+        List<UpdatesTui.DependencyInfo> result = UpdatesHelper.collectDependencies(project);
+
+        assertThat(result).hasSize(2);
+        assertThat(result)
+                .extracting(d -> d.groupId + ":" + d.artifactId)
+                .containsExactly("org.slf4j:slf4j-api", "com.fasterxml:jackson-core");
+        assertThat(result).noneMatch(d -> "spring-boot-dependencies".equals(d.artifactId));
+    }
+
+    @Test
+    void deduplication() {
+        MavenProject project = createProject("com.example", "app", "1.0");
+
+        // Direct dependency
+        project.getModel().addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+
+        // Same dep also in managed
+        DependencyManagement origMgmt = new DependencyManagement();
+        origMgmt.addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+        origMgmt.addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        project.getOriginalModel().setDependencyManagement(origMgmt);
+
+        List<UpdatesTui.DependencyInfo> result = UpdatesHelper.collectDependencies(project);
+
+        // slf4j appears once (as direct, not managed), jackson appears as managed
+        assertThat(result).hasSize(2);
+        UpdatesTui.DependencyInfo slf4j = result.stream()
+                .filter(d -> "slf4j-api".equals(d.artifactId))
+                .findFirst()
+                .orElseThrow();
+        assertThat(slf4j.managed).isFalse();
+
+        UpdatesTui.DependencyInfo jackson = result.stream()
+                .filter(d -> "jackson-core".equals(d.artifactId))
+                .findFirst()
+                .orElseThrow();
+        assertThat(jackson.managed).isTrue();
+    }
+
+    @Test
+    void emptyProject() {
+        MavenProject project = createProject("com.example", "app", "1.0");
+
+        List<UpdatesTui.DependencyInfo> result = UpdatesHelper.collectDependencies(project);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void nullDependencyManagement() {
+        MavenProject project = createProject("com.example", "app", "1.0");
+        project.getModel().addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+        // originalModel has no dependencyManagement (null)
+
+        List<UpdatesTui.DependencyInfo> result = UpdatesHelper.collectDependencies(project);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).groupId).isEqualTo("org.slf4j");
+        assertThat(result.get(0).managed).isFalse();
+    }
+
+    @Test
+    void propertyVersionsPreserved() {
+        MavenProject project = createProject("com.example", "app", "1.0");
+
+        DependencyManagement origMgmt = new DependencyManagement();
+        origMgmt.addDependency(dep("org.slf4j", "slf4j-api", "${slf4j.version}"));
+        origMgmt.addDependency(dep("com.fasterxml", "jackson-core", "${jackson.version}"));
+        project.getOriginalModel().setDependencyManagement(origMgmt);
+
+        List<UpdatesTui.DependencyInfo> result = UpdatesHelper.collectDependencies(project);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).version).isEqualTo("${slf4j.version}");
+        assertThat(result.get(1).version).isEqualTo("${jackson.version}");
+    }
+}


### PR DESCRIPTION
## Summary

- Extract dependency collection logic from `PilotMojo.runUpdates()` into a new `UpdatesHelper.collectDependencies()` static method, using `getOriginalModel().getDependencyManagement()` instead of the effective model to exclude BOM-imported dependencies
- Fix `ReactorCollector.collectFromProject()` to filter effective model managed deps against the original model, applying the same BOM exclusion logic
- Add 8 test cases in `UpdatesHelperTest` covering: direct deps, original model managed deps, BOM exclusion, BOM import filtering, deduplication, empty project, null dependency management, and property version preservation
- Add BOM filtering test to `ReactorCollectorTest`

Closes #25, closes #27

## Test plan

- [x] All 8 `UpdatesHelperTest` cases pass
- [x] New `ReactorCollectorTest.collectExcludesBomImportedManagedDeps` passes
- [x] Full test suite (275 tests) passes with 0 failures
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected dependency collection so BOM-imported entries are excluded from managed dependency counts and direct vs managed flags are assigned accurately.
* **Tests**
  * Added tests covering dependency collection, deduplication, BOM-import filtering, and managed-flag behavior across scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->