### PR TITLE
Fix #32: add scope display and filtering to audit views

### DIFF
--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -308,7 +308,9 @@ class AuditTui {
                 }
             }
         }
-        if (!vulnRows.isEmpty() && vulnTableState.selected() == null) {
+        if (vulnRows.isEmpty()) {
+            vulnTableState.clearSelection();
+        } else if (vulnTableState.selected() == null || vulnTableState.selected() >= vulnRows.size()) {
             vulnTableState.select(0);
         }
     }
@@ -381,7 +383,9 @@ class AuditTui {
             }
         }
 
-        if (!byLicenseRows.isEmpty() && byLicenseTableState.selected() == null) {
+        if (byLicenseRows.isEmpty()) {
+            byLicenseTableState.clearSelection();
+        } else if (byLicenseTableState.selected() == null || byLicenseTableState.selected() >= byLicenseRows.size()) {
             byLicenseTableState.select(0);
         }
     }
@@ -927,14 +931,20 @@ class AuditTui {
 
     private void renderVulnerabilities(Frame frame, Rect area) {
         if (vulnRows.isEmpty()) {
+            String filterLabel = scopeFilter != null ? " [" + scopeFilter + "]" : "";
             Block block = Block.builder()
-                    .title(" Vulnerabilities ")
+                    .title(" Vulnerabilities" + filterLabel + " ")
                     .borderType(BorderType.ROUNDED)
                     .borderStyle(Style.create().fg(Color.DARK_GRAY))
                     .build();
-            String msg = (vulnsLoaded >= entries.size())
-                    ? "No known vulnerabilities found \u2713"
-                    : "Checking vulnerabilities\u2026 " + vulnsLoaded + "/" + entries.size();
+            String msg;
+            if (vulnsLoaded < entries.size()) {
+                msg = "Checking vulnerabilities\u2026 " + vulnsLoaded + "/" + entries.size();
+            } else if (scopeFilter != null) {
+                msg = "No known vulnerabilities in " + scopeFilter + " scope";
+            } else {
+                msg = "No known vulnerabilities found \u2713";
+            }
             Paragraph empty =
                     Paragraph.builder().text(msg).block(block).centered().build();
             frame.renderWidget(empty, area);

--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -33,6 +33,7 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.paragraph.Paragraph;
+import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
@@ -47,6 +48,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -190,6 +192,9 @@ class AuditTui {
     private final TableState tableState = new TableState();
     private final ExecutorService httpPool = MojoHelper.newHttpPool();
     private final OsvClient osvClient = new OsvClient();
+
+    private static final String COL_SCOPE = "scope";
+    private static final String LABEL_SCOPE = "  scope: ";
 
     private final HelpOverlay helpOverlay = new HelpOverlay();
     private final DiffOverlay diffOverlay = new DiffOverlay();
@@ -618,7 +623,7 @@ class AuditTui {
                 .borderStyle(Style.create().fg(Color.DARK_GRAY))
                 .build();
 
-        Row header = Row.from("groupId:artifactId", "version", "license", "scope")
+        Row header = Row.from("groupId:artifactId", "version", "license", COL_SCOPE)
                 .style(Style.create().bold().yellow());
 
         List<Row> rows = new ArrayList<>();
@@ -664,7 +669,7 @@ class AuditTui {
         List<Span> spans = new ArrayList<>();
         String centralUrl = centralUrl(entry.groupId, entry.artifactId);
         spans.add(Span.raw(entry.gav()).bold().cyan().hyperlink(centralUrl));
-        spans.add(Span.raw("  scope: ").fg(Color.DARK_GRAY));
+        spans.add(Span.raw(LABEL_SCOPE).fg(Color.DARK_GRAY));
         spans.add(Span.raw(entry.scope));
         spans.add(Span.raw("  \u2197 ").fg(Color.DARK_GRAY));
         spans.add(Span.raw(centralUrl).fg(Color.BLUE).hyperlink(centralUrl));
@@ -794,7 +799,7 @@ class AuditTui {
             }
         }
 
-        Row header = Row.from("license / artifact", "version", "scope", "")
+        Row header = Row.from("license / artifact", "version", COL_SCOPE, "")
                 .style(Style.create().bold().yellow());
 
         Table table = Table.builder()
@@ -849,7 +854,7 @@ class AuditTui {
             String centralUrl = centralUrl(row.entry.groupId, row.entry.artifactId);
             lines.add(Line.from(
                     Span.raw(row.entry.gav()).bold().cyan().hyperlink(centralUrl),
-                    Span.raw("  scope: ").fg(Color.DARK_GRAY),
+                    Span.raw(LABEL_SCOPE).fg(Color.DARK_GRAY),
                     Span.raw(row.entry.scope),
                     Span.raw("  \u2197 ").fg(Color.DARK_GRAY),
                     Span.raw(centralUrl).fg(Color.BLUE).hyperlink(centralUrl)));
@@ -911,11 +916,16 @@ class AuditTui {
         for (var vr : vulnRows) {
             String severity = normalizeSeverity(vr.vuln.severity);
             String summary = vr.vuln.summary.length() > 60 ? vr.vuln.summary.substring(0, 57) + "..." : vr.vuln.summary;
-            rows.add(Row.from(vr.entry.ga() + ":" + vr.entry.version, vr.vuln.id, severity, vr.entry.scope, summary)
-                    .style(getSeverityStyle(severity)));
+            Style sevStyle = getSeverityStyle(severity);
+            rows.add(Row.from(
+                    Cell.from(vr.entry.ga() + ":" + vr.entry.version).style(sevStyle),
+                    Cell.from(vr.vuln.id).style(sevStyle),
+                    Cell.from(severity).style(sevStyle),
+                    Cell.from(vr.entry.scope).style(getScopeStyle(vr.entry.scope)),
+                    Cell.from(summary).style(sevStyle)));
         }
 
-        Row header = Row.from("artifact", "CVE/ID", "severity", "scope", "summary")
+        Row header = Row.from("artifact", "CVE/ID", "severity", COL_SCOPE, "summary")
                 .style(Style.create().bold().yellow());
 
         Table table = Table.builder()
@@ -961,7 +971,7 @@ class AuditTui {
                 Span.raw(vuln.id).bold().cyan().hyperlink(url),
                 Span.raw("  "),
                 Span.raw(severity).style(getSeverityStyle(severity).bold()),
-                Span.raw("  scope: ").fg(Color.DARK_GRAY),
+                Span.raw(LABEL_SCOPE).fg(Color.DARK_GRAY),
                 Span.raw(vr.entry.scope).style(getScopeStyle(vr.entry.scope)),
                 Span.raw("  "),
                 Span.raw(vr.entry.ga() + ":" + vr.entry.version)
@@ -1034,7 +1044,7 @@ class AuditTui {
 
     private static Style getScopeStyle(String scope) {
         if (scope == null) return Style.create();
-        return switch (scope) {
+        return switch (scope.trim().toLowerCase(Locale.ROOT)) {
             case "test" -> Style.create().fg(Color.DARK_GRAY);
             case "provided" -> Style.create().fg(Color.DARK_GRAY);
             case "runtime" -> Style.create().fg(Color.YELLOW);

--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -294,7 +294,7 @@ class AuditTui {
         }
     }
 
-    private void rebuildVulnRows() {
+    void rebuildVulnRows() {
         vulnRows = new ArrayList<>();
         for (var entry : entries) {
             if (entry.hasVulnerabilities()) {
@@ -1042,7 +1042,7 @@ class AuditTui {
         };
     }
 
-    private static Style getScopeStyle(String scope) {
+    static Style getScopeStyle(String scope) {
         if (scope == null) return Style.create();
         return switch (scope.trim().toLowerCase(Locale.ROOT)) {
             case "test" -> Style.create().fg(Color.DARK_GRAY);

--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -302,7 +302,7 @@ class AuditTui {
         vulnRows = new ArrayList<>();
         for (var entry : entries) {
             if (entry.hasVulnerabilities()) {
-                if (scopeFilter != null && !scopeFilter.equals(entry.scope)) continue;
+                if (scopeFilter != null && !scopeFilter.equalsIgnoreCase(entry.scope)) continue;
                 for (var vuln : entry.vulnerabilities) {
                     vulnRows.add(new VulnRow(entry, vuln));
                 }
@@ -319,7 +319,7 @@ class AuditTui {
         } else {
             filteredEntries = new ArrayList<>();
             for (var entry : entries) {
-                if (scopeFilter.equals(entry.scope)) {
+                if (scopeFilter.equalsIgnoreCase(entry.scope)) {
                     filteredEntries.add(entry);
                 }
             }
@@ -355,7 +355,7 @@ class AuditTui {
         var urls = new HashMap<String, String>();
         for (var entry : entries) {
             if (!entry.licenseLoaded) continue;
-            if (scopeFilter != null && !scopeFilter.equals(entry.scope)) continue;
+            if (scopeFilter != null && !scopeFilter.equalsIgnoreCase(entry.scope)) continue;
             String key = entry.license != null ? normalizeLicense(entry.license, entry.licenseUrl) : "(not specified)";
             groups.computeIfAbsent(key, k -> new ArrayList<>()).add(entry);
             if (entry.licenseUrl != null && !urls.containsKey(key)) {

--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -195,6 +195,7 @@ class AuditTui {
 
     private static final String COL_SCOPE = "scope";
     private static final String LABEL_SCOPE = "  scope: ";
+    private static final List<String> SCOPE_FILTERS = List.of("compile", "runtime", "test", "provided");
 
     private final HelpOverlay helpOverlay = new HelpOverlay();
     private final DiffOverlay diffOverlay = new DiffOverlay();
@@ -210,6 +211,8 @@ class AuditTui {
     private boolean pendingQuit;
     private int lastContentHeight;
     private int lastTableHeight;
+    private String scopeFilter; // null = show all
+    private List<AuditEntry> filteredEntries;
     private List<VulnRow> vulnRows = new ArrayList<>();
     private List<LicenseRow> byLicenseRows = new ArrayList<>();
 
@@ -220,6 +223,7 @@ class AuditTui {
 
     AuditTui(List<AuditEntry> entries, String projectGav, DependencyTreeModel treeModel, String pomPath) {
         this.entries = entries;
+        this.filteredEntries = entries;
         this.projectGav = projectGav;
         this.treeModel = treeModel;
         this.pomPath = pomPath;
@@ -298,6 +302,7 @@ class AuditTui {
         vulnRows = new ArrayList<>();
         for (var entry : entries) {
             if (entry.hasVulnerabilities()) {
+                if (scopeFilter != null && !scopeFilter.equals(entry.scope)) continue;
                 for (var vuln : entry.vulnerabilities) {
                     vulnRows.add(new VulnRow(entry, vuln));
                 }
@@ -306,6 +311,36 @@ class AuditTui {
         if (!vulnRows.isEmpty() && vulnTableState.selected() == null) {
             vulnTableState.select(0);
         }
+    }
+
+    private void rebuildFilteredEntries() {
+        if (scopeFilter == null) {
+            filteredEntries = entries;
+        } else {
+            filteredEntries = new ArrayList<>();
+            for (var entry : entries) {
+                if (scopeFilter.equals(entry.scope)) {
+                    filteredEntries.add(entry);
+                }
+            }
+        }
+        if (filteredEntries.isEmpty()) {
+            tableState.clearSelection();
+        } else if (tableState.selected() != null && tableState.selected() >= filteredEntries.size()) {
+            tableState.select(0);
+        }
+    }
+
+    private void cycleScope() {
+        if (scopeFilter == null) {
+            scopeFilter = SCOPE_FILTERS.get(0);
+        } else {
+            int idx = SCOPE_FILTERS.indexOf(scopeFilter);
+            scopeFilter = (idx + 1 >= SCOPE_FILTERS.size()) ? null : SCOPE_FILTERS.get(idx + 1);
+        }
+        rebuildFilteredEntries();
+        rebuildVulnRows();
+        rebuildByLicenseRows();
     }
 
     private void rebuildByLicenseRows() {
@@ -320,6 +355,7 @@ class AuditTui {
         var urls = new HashMap<String, String>();
         for (var entry : entries) {
             if (!entry.licenseLoaded) continue;
+            if (scopeFilter != null && !scopeFilter.equals(entry.scope)) continue;
             String key = entry.license != null ? normalizeLicense(entry.license, entry.licenseUrl) : "(not specified)";
             groups.computeIfAbsent(key, k -> new ArrayList<>()).add(entry);
             if (entry.licenseUrl != null && !urls.containsKey(key)) {
@@ -470,6 +506,11 @@ class AuditTui {
             return true;
         }
 
+        if (key.isCharIgnoreCase('s')) {
+            cycleScope();
+            return true;
+        }
+
         if (key.isCharIgnoreCase('m')) {
             addManagedDependency();
             return true;
@@ -492,7 +533,7 @@ class AuditTui {
         return switch (view) {
             case LICENSES -> {
                 int idx = tableState.selected() != null ? tableState.selected() : -1;
-                yield (idx >= 0 && idx < entries.size()) ? entries.get(idx) : null;
+                yield (idx >= 0 && idx < filteredEntries.size()) ? filteredEntries.get(idx) : null;
             }
             case VULNERABILITIES -> {
                 int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
@@ -617,8 +658,9 @@ class AuditTui {
                 .split(area);
         lastTableHeight = zones.get(0).height();
 
+        String filterLabel = scopeFilter != null ? " [" + scopeFilter + "]" : "";
         Block block = Block.builder()
-                .title(" Licenses (" + entries.size() + " dependencies) ")
+                .title(" Licenses (" + filteredEntries.size() + " dependencies)" + filterLabel + " ")
                 .borderType(BorderType.ROUNDED)
                 .borderStyle(Style.create().fg(Color.DARK_GRAY))
                 .build();
@@ -627,7 +669,7 @@ class AuditTui {
                 .style(Style.create().bold().yellow());
 
         List<Row> rows = new ArrayList<>();
-        for (var entry : entries) {
+        for (var entry : filteredEntries) {
             String license = entry.license != null
                     ? normalizeLicense(entry.license, entry.licenseUrl)
                     : (entry.licenseLoaded ? "-" : "\u2026");
@@ -660,12 +702,12 @@ class AuditTui {
                 .build();
 
         int idx = tableState.selected() != null ? tableState.selected() : -1;
-        if (idx < 0 || idx >= entries.size()) {
+        if (idx < 0 || idx >= filteredEntries.size()) {
             frame.renderWidget(Paragraph.builder().text("").block(block).build(), area);
             return;
         }
 
-        AuditEntry entry = entries.get(idx);
+        AuditEntry entry = filteredEntries.get(idx);
         List<Span> spans = new ArrayList<>();
         String centralUrl = centralUrl(entry.groupId, entry.artifactId);
         spans.add(Span.raw(entry.gav()).bold().cyan().hyperlink(centralUrl));
@@ -754,7 +796,7 @@ class AuditTui {
         return switch (view) {
             case VULNERABILITIES -> vulnRows.size();
             case BY_LICENSE -> byLicenseRows.size();
-            default -> entries.size();
+            default -> filteredEntries.size();
         };
     }
 
@@ -906,8 +948,9 @@ class AuditTui {
         lastTableHeight = zones.get(0).height();
 
         // -- Vulnerability table --
+        String vFilterLabel = scopeFilter != null ? " [" + scopeFilter + "]" : "";
         Block block = Block.builder()
-                .title(" Vulnerabilities (" + vulnRows.size() + ") ")
+                .title(" Vulnerabilities (" + vulnRows.size() + ")" + vFilterLabel + " ")
                 .borderType(BorderType.ROUNDED)
                 .borderStyle(Style.create().fg(Color.RED))
                 .build();
@@ -1250,6 +1293,9 @@ class AuditTui {
                                 new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
                                 new HelpOverlay.Entry("\u2190 / \u2192", "Collapse / expand (By License view)"),
                                 new HelpOverlay.Entry("Tab", "Switch between Licenses / By License / Vulns"),
+                                new HelpOverlay.Entry(
+                                        "s",
+                                        "Cycle scope filter: all \u2192 compile \u2192 runtime \u2192 test \u2192 provided"),
                                 new HelpOverlay.Entry("m", "Add selected dep to dependencyManagement"),
                                 new HelpOverlay.Entry("d", "Preview POM changes as a unified diff"),
                                 new HelpOverlay.Entry("h", "Toggle this help screen"),
@@ -1286,6 +1332,8 @@ class AuditTui {
             spans.add(Span.raw(":Navigate  "));
             spans.add(Span.raw("Tab").bold());
             spans.add(Span.raw(":Licenses/Vulns  "));
+            spans.add(Span.raw("s").bold());
+            spans.add(Span.raw(":Scope" + (scopeFilter != null ? "=" + scopeFilter : "") + "  "));
             spans.add(Span.raw("m").bold());
             spans.add(Span.raw(":Manage dep  "));
             spans.add(Span.raw("d").bold());

--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -911,19 +911,22 @@ class AuditTui {
         for (var vr : vulnRows) {
             String severity = normalizeSeverity(vr.vuln.severity);
             String summary = vr.vuln.summary.length() > 60 ? vr.vuln.summary.substring(0, 57) + "..." : vr.vuln.summary;
-            rows.add(Row.from(vr.entry.ga() + ":" + vr.entry.version, vr.vuln.id, severity, summary)
+            rows.add(Row.from(vr.entry.ga() + ":" + vr.entry.version, vr.vuln.id, severity, vr.entry.scope, summary)
                     .style(getSeverityStyle(severity)));
         }
 
-        Row header = Row.from("artifact", "CVE/ID", "severity", "summary")
+        Row header = Row.from("artifact", "CVE/ID", "severity", "scope", "summary")
                 .style(Style.create().bold().yellow());
 
         Table table = Table.builder()
                 .header(header)
                 .rows(rows)
                 .widths(
-                        Constraint.percentage(30), Constraint.percentage(18),
-                        Constraint.percentage(10), Constraint.percentage(42))
+                        Constraint.percentage(28),
+                        Constraint.percentage(17),
+                        Constraint.percentage(10),
+                        Constraint.percentage(8),
+                        Constraint.percentage(37))
                 .highlightStyle(Style.create().reversed().bold())
                 .highlightSymbol(HIGHLIGHT_SYMBOL)
                 .block(block)
@@ -958,6 +961,8 @@ class AuditTui {
                 Span.raw(vuln.id).bold().cyan().hyperlink(url),
                 Span.raw("  "),
                 Span.raw(severity).style(getSeverityStyle(severity).bold()),
+                Span.raw("  scope: ").fg(Color.DARK_GRAY),
+                Span.raw(vr.entry.scope).style(getScopeStyle(vr.entry.scope)),
                 Span.raw("  "),
                 Span.raw(vr.entry.ga() + ":" + vr.entry.version)
                         .fg(Color.DARK_GRAY)
@@ -1024,6 +1029,16 @@ class AuditTui {
                 }
                 yield Style.create().fg(Color.DARK_GRAY);
             }
+        };
+    }
+
+    private static Style getScopeStyle(String scope) {
+        if (scope == null) return Style.create();
+        return switch (scope) {
+            case "test" -> Style.create().fg(Color.DARK_GRAY);
+            case "provided" -> Style.create().fg(Color.DARK_GRAY);
+            case "runtime" -> Style.create().fg(Color.YELLOW);
+            default -> Style.create();
         };
     }
 

--- a/src/test/java/eu/maveniverse/maven/pilot/AuditTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AuditTuiTest.java
@@ -20,6 +20,14 @@ package eu.maveniverse.maven.pilot;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tamboui.layout.Size;
+import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.pilot.TuiTestRunner;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +36,7 @@ import org.eclipse.aether.graph.DefaultDependencyNode;
 import org.eclipse.aether.graph.Dependency;
 import org.eclipse.aether.graph.DependencyNode;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class AuditTuiTest {
 
@@ -284,5 +293,87 @@ class AuditTuiTest {
         LinkedHashMap<String, DependencyNode> moduleRoots = new LinkedHashMap<>();
         List<AuditTui.AuditEntry> entries = AuditTui.collectReactorEntries(moduleRoots);
         assertThat(entries).isEmpty();
+    }
+
+    @Test
+    void getScopeStyleReturnsDefaultForNull() {
+        Style style = AuditTui.getScopeStyle(null);
+        assertThat(style).isEqualTo(Style.create());
+    }
+
+    @Test
+    void getScopeStyleReturnsDefaultForCompile() {
+        assertThat(AuditTui.getScopeStyle("compile")).isEqualTo(Style.create());
+    }
+
+    @Test
+    void getScopeStyleReturnsDimForTest() {
+        assertThat(AuditTui.getScopeStyle("test")).isEqualTo(Style.create().fg(Color.DARK_GRAY));
+    }
+
+    @Test
+    void getScopeStyleReturnsDimForProvided() {
+        assertThat(AuditTui.getScopeStyle("provided")).isEqualTo(Style.create().fg(Color.DARK_GRAY));
+    }
+
+    @Test
+    void getScopeStyleReturnsYellowForRuntime() {
+        assertThat(AuditTui.getScopeStyle("runtime")).isEqualTo(Style.create().fg(Color.YELLOW));
+    }
+
+    @Test
+    void getScopeStyleNormalizesCase() {
+        assertThat(AuditTui.getScopeStyle("TEST")).isEqualTo(Style.create().fg(Color.DARK_GRAY));
+        assertThat(AuditTui.getScopeStyle("Runtime")).isEqualTo(Style.create().fg(Color.YELLOW));
+        assertThat(AuditTui.getScopeStyle("Provided")).isEqualTo(Style.create().fg(Color.DARK_GRAY));
+    }
+
+    @Test
+    void getScopeStyleTrimsWhitespace() {
+        assertThat(AuditTui.getScopeStyle("  test  ")).isEqualTo(Style.create().fg(Color.DARK_GRAY));
+        assertThat(AuditTui.getScopeStyle(" runtime ")).isEqualTo(Style.create().fg(Color.YELLOW));
+    }
+
+    @Test
+    void getScopeStyleReturnsDefaultForUnknown() {
+        assertThat(AuditTui.getScopeStyle("system")).isEqualTo(Style.create());
+        assertThat(AuditTui.getScopeStyle("import")).isEqualTo(Style.create());
+    }
+
+    @Test
+    void vulnerabilitiesViewShowsScopeColumn(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
+
+        List<AuditTui.AuditEntry> entries = new ArrayList<>();
+        var e1 = new AuditTui.AuditEntry("org.example", "vuln-lib", "1.0.0", "test");
+        e1.licenseLoaded = true;
+        e1.vulnsLoaded = true;
+        e1.vulnerabilities =
+                List.of(new OsvClient.Vulnerability("CVE-2024-0001", "Test vuln", "HIGH", "2024-01-01", List.of()));
+        entries.add(e1);
+
+        var e2 = new AuditTui.AuditEntry("org.example", "prod-lib", "2.0.0", "compile");
+        e2.licenseLoaded = true;
+        e2.vulnsLoaded = true;
+        e2.vulnerabilities =
+                List.of(new OsvClient.Vulnerability("CVE-2024-0002", "Prod vuln", "CRITICAL", "2024-02-01", List.of()));
+        entries.add(e2);
+
+        AuditTui tui = new AuditTui(entries, "com.example:test:1.0", null, pomPath);
+        tui.rebuildVulnRows();
+
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(120, 30))) {
+            var pilot = testRunner.pilot();
+
+            // Navigate to Vulnerabilities tab (Tab -> By License, Tab -> Vulnerabilities)
+            pilot.press(KeyCode.TAB);
+            pilot.press(KeyCode.TAB);
+            pilot.pause();
+
+            // Navigate down to exercise detail pane rendering with different scopes
+            pilot.press(KeyCode.DOWN);
+            pilot.pause();
+        }
     }
 }

--- a/src/test/java/eu/maveniverse/maven/pilot/AuditTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AuditTuiTest.java
@@ -340,11 +340,7 @@ class AuditTuiTest {
         assertThat(AuditTui.getScopeStyle("import")).isEqualTo(Style.create());
     }
 
-    @Test
-    void vulnerabilitiesViewShowsScopeColumn(@TempDir Path tempDir) throws Exception {
-        String pomPath =
-                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
-
+    private static List<AuditTui.AuditEntry> buildTestEntries() {
         List<AuditTui.AuditEntry> entries = new ArrayList<>();
         var e1 = new AuditTui.AuditEntry("org.example", "vuln-lib", "1.0.0", "test");
         e1.licenseLoaded = true;
@@ -360,6 +356,21 @@ class AuditTuiTest {
                 List.of(new OsvClient.Vulnerability("CVE-2024-0002", "Prod vuln", "CRITICAL", "2024-02-01", List.of()));
         entries.add(e2);
 
+        var e3 = new AuditTui.AuditEntry("org.example", "runtime-lib", "3.0.0", "runtime");
+        e3.licenseLoaded = true;
+        e3.vulnsLoaded = true;
+        e3.vulnerabilities = List.of();
+        entries.add(e3);
+
+        return entries;
+    }
+
+    @Test
+    void vulnerabilitiesViewRendersScopeColumn(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
+
+        List<AuditTui.AuditEntry> entries = buildTestEntries();
         AuditTui tui = new AuditTui(entries, "com.example:test:1.0", null, pomPath);
         tui.rebuildVulnRows();
 
@@ -373,6 +384,55 @@ class AuditTuiTest {
 
             // Navigate down to exercise detail pane rendering with different scopes
             pilot.press(KeyCode.DOWN);
+            pilot.pause();
+        }
+    }
+
+    @Test
+    void scopeFilterCyclesAndFilters(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
+
+        List<AuditTui.AuditEntry> entries = buildTestEntries();
+        AuditTui tui = new AuditTui(entries, "com.example:test:1.0", null, pomPath);
+        tui.rebuildVulnRows();
+
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(120, 30))) {
+            var pilot = testRunner.pilot();
+
+            // Initially shows all entries (3)
+            pilot.pause();
+
+            // Press 's' to filter to compile scope
+            pilot.press('s');
+            pilot.pause();
+
+            // Press 's' again to cycle to runtime
+            pilot.press('s');
+            pilot.pause();
+
+            // Press 's' to cycle to test
+            pilot.press('s');
+            pilot.pause();
+
+            // Press 's' to cycle to provided
+            pilot.press('s');
+            pilot.pause();
+
+            // Press 's' to cycle back to all
+            pilot.press('s');
+            pilot.pause();
+
+            // Also test filtering on the vulnerabilities tab
+            pilot.press(KeyCode.TAB);
+            pilot.press(KeyCode.TAB);
+            pilot.press('s'); // compile — only CVE-2024-0002 visible
+            pilot.pause();
+
+            pilot.press('s'); // runtime — no vulns
+            pilot.pause();
+
+            pilot.press('s'); // test — only CVE-2024-0001 visible
             pilot.pause();
         }
     }

--- a/src/test/java/eu/maveniverse/maven/pilot/AuditTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AuditTuiTest.java
@@ -362,6 +362,13 @@ class AuditTuiTest {
         e3.vulnerabilities = List.of();
         entries.add(e3);
 
+        var e4 = new AuditTui.AuditEntry("org.example", "provided-lib", "4.0.0", "provided");
+        e4.licenseLoaded = true;
+        e4.vulnsLoaded = true;
+        e4.vulnerabilities =
+                List.of(new OsvClient.Vulnerability("CVE-2024-0003", "Provided vuln", "LOW", "2024-03-01", List.of()));
+        entries.add(e4);
+
         return entries;
     }
 
@@ -400,7 +407,7 @@ class AuditTuiTest {
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(120, 30))) {
             var pilot = testRunner.pilot();
 
-            // Initially shows all entries (3)
+            // Initially shows all entries (4)
             pilot.pause();
 
             // Press 's' to filter to compile scope
@@ -433,6 +440,9 @@ class AuditTuiTest {
             pilot.pause();
 
             pilot.press('s'); // test — only CVE-2024-0001 visible
+            pilot.pause();
+
+            pilot.press('s'); // provided — only CVE-2024-0003 visible
             pilot.pause();
         }
     }


### PR DESCRIPTION
## Summary

- Add a **scope** column to the Vulnerabilities table so users can see whether a vulnerable dependency is `compile`, `runtime`, `test`, or `provided`
- Add scope info to the vulnerability detail pane with color-coded styling
- Add scope filtering (`s` key) across all audit views: cycles through all → compile → runtime → test → provided
- Color-code scopes for quick visual triage: compile (default), runtime (yellow), test/provided (dim gray)

## Details

- Per-cell styling in vulnerability rows so scope colors are independent of severity colors
- Scope normalization via `trim().toLowerCase(Locale.ROOT)` and `equalsIgnoreCase` for consistent filtering
- Scope-aware empty-state message when a filtered scope has no vulnerabilities
- Table selection clamping after scope changes to prevent out-of-range indices
- Follows existing `TreeTui` scope cycling pattern for consistency

## Test plan

- [x] Unit tests for `getScopeStyle` covering all scopes, case normalization, whitespace trimming, and unknown scopes
- [x] Integration test exercising vulnerability view rendering with scope column
- [x] Integration test cycling scope filter across Licenses and Vulnerabilities tabs
- [x] "provided" scope entry in test data for full scope coverage
- [x] All 350 tests pass on Java 17/21/25
- [x] SonarCloud quality gate passed
- [x] CodeRabbit review addressed

Closes #32