### PR TITLE
Fix #28: add page up/down and home/end keyboard navigation to all tables

### DIFF
--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -356,6 +356,26 @@ class AuditTui {
             activeTableState().selectNext(activeRowCount());
             return true;
         }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            Integer sel = activeTableState().selected();
+            activeTableState().select(Math.max(0, (sel != null ? sel : 0) - pageSize));
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            Integer sel = activeTableState().selected();
+            activeTableState().select(Math.min(activeRowCount() - 1, (sel != null ? sel : 0) + pageSize));
+            return true;
+        }
+        if (key.isHome()) {
+            activeTableState().select(0);
+            return true;
+        }
+        if (key.isEnd()) {
+            activeTableState().select(activeRowCount() - 1);
+            return true;
+        }
 
         if (key.isKey(KeyCode.TAB)) {
             view = switch (view) {
@@ -1160,6 +1180,8 @@ class AuditTui {
                         "Keys",
                         List.of(
                                 new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
+                                new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
                                 new HelpOverlay.Entry("\u2190 / \u2192", "Collapse / expand (By License view)"),
                                 new HelpOverlay.Entry("Tab", "Switch between Licenses / By License / Vulns"),
                                 new HelpOverlay.Entry("m", "Add selected dep to dependencyManagement"),

--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -506,7 +506,6 @@ class AuditTui {
 
         renderHeader(frame, zones.get(0));
 
-        lastContentHeight = zones.get(1).height();
         if (helpOverlay.isActive()) {
             helpOverlay.render(frame, zones.get(1));
         } else if (diffOverlay.isActive()) {
@@ -557,6 +556,7 @@ class AuditTui {
         var zones = Layout.vertical()
                 .constraints(Constraint.fill(), Constraint.length(1), Constraint.length(6))
                 .split(area);
+        lastContentHeight = zones.get(0).height();
 
         Block block = Block.builder()
                 .title(" Licenses (" + entries.size() + " dependencies) ")
@@ -718,6 +718,7 @@ class AuditTui {
         var zones = Layout.vertical()
                 .constraints(Constraint.fill(), Constraint.length(1), Constraint.length(6))
                 .split(area);
+        lastContentHeight = zones.get(0).height();
 
         Block block = Block.builder()
                 .title(" By License (" + countLicenseGroups() + " licenses) ")
@@ -843,6 +844,7 @@ class AuditTui {
         var zones = Layout.vertical()
                 .constraints(Constraint.fill(), Constraint.length(1), Constraint.length(8))
                 .split(area);
+        lastContentHeight = zones.get(0).height();
 
         // -- Vulnerability table --
         Block block = Block.builder()

--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -147,6 +147,7 @@ class AuditTui {
     private boolean dirty;
     private boolean pendingQuit;
     private int lastContentHeight;
+    private int lastTableHeight;
     private List<VulnRow> vulnRows = new ArrayList<>();
     private List<LicenseRow> byLicenseRows = new ArrayList<>();
 
@@ -356,7 +357,7 @@ class AuditTui {
             activeTableState().selectNext(activeRowCount());
             return true;
         }
-        if (TableNavigation.handlePageKeys(key, activeTableState(), activeRowCount(), lastContentHeight)) {
+        if (TableNavigation.handlePageKeys(key, activeTableState(), activeRowCount(), lastTableHeight)) {
             return true;
         }
 
@@ -505,6 +506,7 @@ class AuditTui {
                 .split(frame.area());
 
         renderHeader(frame, zones.get(0));
+        lastContentHeight = zones.get(1).height();
 
         if (helpOverlay.isActive()) {
             helpOverlay.render(frame, zones.get(1));
@@ -556,7 +558,7 @@ class AuditTui {
         var zones = Layout.vertical()
                 .constraints(Constraint.fill(), Constraint.length(1), Constraint.length(6))
                 .split(area);
-        lastContentHeight = zones.get(0).height();
+        lastTableHeight = zones.get(0).height();
 
         Block block = Block.builder()
                 .title(" Licenses (" + entries.size() + " dependencies) ")
@@ -718,7 +720,7 @@ class AuditTui {
         var zones = Layout.vertical()
                 .constraints(Constraint.fill(), Constraint.length(1), Constraint.length(6))
                 .split(area);
-        lastContentHeight = zones.get(0).height();
+        lastTableHeight = zones.get(0).height();
 
         Block block = Block.builder()
                 .title(" By License (" + countLicenseGroups() + " licenses) ")
@@ -844,7 +846,7 @@ class AuditTui {
         var zones = Layout.vertical()
                 .constraints(Constraint.fill(), Constraint.length(1), Constraint.length(8))
                 .split(area);
-        lastContentHeight = zones.get(0).height();
+        lastTableHeight = zones.get(0).height();
 
         // -- Vulnerability table --
         Block block = Block.builder()

--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -356,24 +356,7 @@ class AuditTui {
             activeTableState().selectNext(activeRowCount());
             return true;
         }
-        if (key.isKey(KeyCode.PAGE_UP)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            Integer sel = activeTableState().selected();
-            activeTableState().select(Math.max(0, (sel != null ? sel : 0) - pageSize));
-            return true;
-        }
-        if (key.isKey(KeyCode.PAGE_DOWN)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            Integer sel = activeTableState().selected();
-            activeTableState().select(Math.min(activeRowCount() - 1, (sel != null ? sel : 0) + pageSize));
-            return true;
-        }
-        if (key.isHome()) {
-            activeTableState().select(0);
-            return true;
-        }
-        if (key.isEnd()) {
-            activeTableState().select(activeRowCount() - 1);
+        if (TableNavigation.handlePageKeys(key, activeTableState(), activeRowCount(), lastContentHeight)) {
             return true;
         }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -249,22 +249,7 @@ class ConflictsTui {
             tableState.selectNext(displayedConflicts().size());
             return true;
         }
-        if (key.isKey(KeyCode.PAGE_UP)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            tableState.select(Math.max(0, selectedIndex() - pageSize));
-            return true;
-        }
-        if (key.isKey(KeyCode.PAGE_DOWN)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            tableState.select(Math.min(displayedConflicts().size() - 1, selectedIndex() + pageSize));
-            return true;
-        }
-        if (key.isHome()) {
-            tableState.select(0);
-            return true;
-        }
-        if (key.isEnd()) {
-            tableState.select(displayedConflicts().size() - 1);
+        if (TableNavigation.handlePageKeys(key, tableState, displayedConflicts().size(), lastContentHeight)) {
             return true;
         }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -249,6 +249,24 @@ class ConflictsTui {
             tableState.selectNext(displayedConflicts().size());
             return true;
         }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            tableState.select(Math.max(0, selectedIndex() - pageSize));
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            tableState.select(Math.min(displayedConflicts().size() - 1, selectedIndex() + pageSize));
+            return true;
+        }
+        if (key.isHome()) {
+            tableState.select(0);
+            return true;
+        }
+        if (key.isEnd()) {
+            tableState.select(displayedConflicts().size() - 1);
+            return true;
+        }
 
         if (key.isKey(KeyCode.ENTER) || key.isCharIgnoreCase(' ')) {
             showDetails = !showDetails;
@@ -378,6 +396,8 @@ class ConflictsTui {
                         "Keys",
                         List.of(
                                 new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
+                                new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
                                 new HelpOverlay.Entry("Enter / Space", "Toggle dependency path details"),
                                 new HelpOverlay.Entry("a", "Toggle between conflicts only / all groups"),
                                 new HelpOverlay.Entry("p", "Pin resolved version in dependencyManagement"),

--- a/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -357,6 +357,24 @@ class DependenciesTui {
             tableState.selectNext(currentList().size());
             return true;
         }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            tableState.select(Math.max(0, selectedIndex() - pageSize));
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            tableState.select(Math.min(currentList().size() - 1, selectedIndex() + pageSize));
+            return true;
+        }
+        if (key.isHome()) {
+            tableState.select(0);
+            return true;
+        }
+        if (key.isEnd()) {
+            tableState.select(currentList().size() - 1);
+            return true;
+        }
 
         if (key.isKey(KeyCode.TAB)) {
             view = (view == View.DECLARED) ? View.TRANSITIVE : View.DECLARED;
@@ -639,6 +657,8 @@ class DependenciesTui {
                         "General",
                         List.of(
                                 new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
+                                new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
                                 new HelpOverlay.Entry("Tab", "Switch between Declared and Transitive views"),
                                 new HelpOverlay.Entry("d", "Preview POM changes as a unified diff"),
                                 new HelpOverlay.Entry("h", "Toggle this help screen"),

--- a/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -357,22 +357,7 @@ class DependenciesTui {
             tableState.selectNext(currentList().size());
             return true;
         }
-        if (key.isKey(KeyCode.PAGE_UP)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            tableState.select(Math.max(0, selectedIndex() - pageSize));
-            return true;
-        }
-        if (key.isKey(KeyCode.PAGE_DOWN)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            tableState.select(Math.min(currentList().size() - 1, selectedIndex() + pageSize));
-            return true;
-        }
-        if (key.isHome()) {
-            tableState.select(0);
-            return true;
-        }
-        if (key.isEnd()) {
-            tableState.select(currentList().size() - 1);
+        if (TableNavigation.handlePageKeys(key, tableState, currentList().size(), lastContentHeight)) {
             return true;
         }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/ModulePickerTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ModulePickerTui.java
@@ -161,24 +161,7 @@ class ModulePickerTui {
             tableState.selectNext(visible.size());
             return true;
         }
-        if (key.isKey(KeyCode.PAGE_UP)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            Integer sel = tableState.selected();
-            tableState.select(Math.max(0, (sel != null ? sel : 0) - pageSize));
-            return true;
-        }
-        if (key.isKey(KeyCode.PAGE_DOWN)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            Integer sel = tableState.selected();
-            tableState.select(Math.min(visible.size() - 1, (sel != null ? sel : 0) + pageSize));
-            return true;
-        }
-        if (key.isHome()) {
-            tableState.select(0);
-            return true;
-        }
-        if (key.isEnd()) {
-            tableState.select(visible.size() - 1);
+        if (TableNavigation.handlePageKeys(key, tableState, visible.size(), lastContentHeight)) {
             return true;
         }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/ModulePickerTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ModulePickerTui.java
@@ -94,6 +94,7 @@ class ModulePickerTui {
     private final TableState tableState = new TableState();
     private final HelpOverlay helpOverlay = new HelpOverlay();
     private PickResult pickResult;
+    private int lastContentHeight;
 
     PickResult getPickResult() {
         return pickResult;
@@ -158,6 +159,26 @@ class ModulePickerTui {
         }
         if (key.isDown()) {
             tableState.selectNext(visible.size());
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            Integer sel = tableState.selected();
+            tableState.select(Math.max(0, (sel != null ? sel : 0) - pageSize));
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            Integer sel = tableState.selected();
+            tableState.select(Math.min(visible.size() - 1, (sel != null ? sel : 0) + pageSize));
+            return true;
+        }
+        if (key.isHome()) {
+            tableState.select(0);
+            return true;
+        }
+        if (key.isEnd()) {
+            tableState.select(visible.size() - 1);
             return true;
         }
 
@@ -252,6 +273,7 @@ class ModulePickerTui {
                 .split(frame.area());
 
         renderHeader(frame, zones.get(0));
+        lastContentHeight = zones.get(1).height();
         if (helpOverlay.isActive()) {
             helpOverlay.render(frame, zones.get(1));
         } else {
@@ -361,6 +383,8 @@ class ModulePickerTui {
     private List<HelpOverlay.Entry> buildKeyEntries() {
         List<HelpOverlay.Entry> entries = new ArrayList<>();
         entries.add(new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"));
+        entries.add(new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"));
+        entries.add(new HelpOverlay.Entry("Home / End", "Jump to first / last row"));
         entries.add(new HelpOverlay.Entry("\u2190 / \u2192", "Collapse / expand tree node"));
         entries.add(new HelpOverlay.Entry("Space", "Expand node or move down"));
         entries.add(new HelpOverlay.Entry("e / w", "Expand all / collapse all"));

--- a/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
@@ -88,6 +88,7 @@ class PomTui {
     private final HelpOverlay helpOverlay = new HelpOverlay();
 
     private TuiRunner runner;
+    private int lastContentHeight;
 
     /**
      * Get the currently selected table row index.
@@ -242,6 +243,24 @@ class PomTui {
             tableState.selectNext(visible.size());
             return true;
         }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            tableState.select(Math.max(0, selectedIndex() - pageSize));
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            tableState.select(Math.min(visible.size() - 1, selectedIndex() + pageSize));
+            return true;
+        }
+        if (key.isHome()) {
+            tableState.select(0);
+            return true;
+        }
+        if (key.isEnd()) {
+            tableState.select(visible.size() - 1);
+            return true;
+        }
 
         int sel = selectedIndex();
         if (sel >= 0 && sel < visible.size()) {
@@ -314,6 +333,8 @@ class PomTui {
                         "Navigation",
                         List.of(
                                 new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
+                                new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
                                 new HelpOverlay.Entry("\u2190 / \u2192", "Collapse / expand tree node"),
                                 new HelpOverlay.Entry("e", "Expand all nodes"),
                                 new HelpOverlay.Entry("w", "Collapse all (keeps root expanded)"),
@@ -447,6 +468,7 @@ class PomTui {
 
         int idx = 0;
         renderHeader(frame, zones.get(idx++));
+        lastContentHeight = zones.get(1).height();
         if (helpOverlay.isActive()) {
             helpOverlay.render(frame, zones.get(idx++));
         } else {

--- a/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
@@ -243,22 +243,7 @@ class PomTui {
             tableState.selectNext(visible.size());
             return true;
         }
-        if (key.isKey(KeyCode.PAGE_UP)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            tableState.select(Math.max(0, selectedIndex() - pageSize));
-            return true;
-        }
-        if (key.isKey(KeyCode.PAGE_DOWN)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            tableState.select(Math.min(visible.size() - 1, selectedIndex() + pageSize));
-            return true;
-        }
-        if (key.isHome()) {
-            tableState.select(0);
-            return true;
-        }
-        if (key.isEnd()) {
-            tableState.select(visible.size() - 1);
+        if (TableNavigation.handlePageKeys(key, tableState, visible.size(), lastContentHeight)) {
             return true;
         }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
@@ -243,7 +243,8 @@ class PomTui {
             tableState.selectNext(visible.size());
             return true;
         }
-        if (TableNavigation.handlePageKeys(key, tableState, visible.size(), lastContentHeight)) {
+        if (TableNavigation.handlePageKeys(
+                key, tableState, visible.size(), lastContentHeight, TableNavigation.BORDERED_NO_HEADER)) {
             return true;
         }
 

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -326,6 +326,26 @@ class ReactorUpdatesTui {
             tableState.selectNext(displayRows.size());
             return true;
         }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            Integer sel = tableState.selected();
+            tableState.select(Math.max(0, (sel != null ? sel : 0) - pageSize));
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            Integer sel = tableState.selected();
+            tableState.select(Math.min(displayRows.size() - 1, (sel != null ? sel : 0) + pageSize));
+            return true;
+        }
+        if (key.isHome()) {
+            tableState.select(0);
+            return true;
+        }
+        if (key.isEnd()) {
+            tableState.select(displayRows.size() - 1);
+            return true;
+        }
         if (key.isCharIgnoreCase(' ')) {
             toggleSelection();
             return true;
@@ -382,6 +402,26 @@ class ReactorUpdatesTui {
         }
         if (key.isDown()) {
             moduleTableState.selectNext(visible.size());
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            Integer sel = moduleTableState.selected();
+            moduleTableState.select(Math.max(0, (sel != null ? sel : 0) - pageSize));
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            Integer sel = moduleTableState.selected();
+            moduleTableState.select(Math.min(visible.size() - 1, (sel != null ? sel : 0) + pageSize));
+            return true;
+        }
+        if (key.isHome()) {
+            moduleTableState.select(0);
+            return true;
+        }
+        if (key.isEnd()) {
+            moduleTableState.select(visible.size() - 1);
             return true;
         }
         if (key.isKey(KeyCode.ENTER) || key.isKey(KeyCode.RIGHT)) {
@@ -966,6 +1006,8 @@ class ReactorUpdatesTui {
                         "Dependencies View",
                         List.of(
                                 new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
+                                new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
                                 new HelpOverlay.Entry("Space", "Toggle selection (group or individual)"),
                                 new HelpOverlay.Entry("a / n", "Select all / deselect all"),
                                 new HelpOverlay.Entry("Enter", "Apply selected updates to POM files"),
@@ -976,6 +1018,8 @@ class ReactorUpdatesTui {
                         List.of(
                                 new HelpOverlay.Entry("", "Shows the reactor module tree with update counts."),
                                 new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
+                                new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
                                 new HelpOverlay.Entry("\u2190 / \u2192", "Collapse / expand module tree"))),
                 new HelpOverlay.Section(
                         "General",

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -326,24 +326,7 @@ class ReactorUpdatesTui {
             tableState.selectNext(displayRows.size());
             return true;
         }
-        if (key.isKey(KeyCode.PAGE_UP)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            Integer sel = tableState.selected();
-            tableState.select(Math.max(0, (sel != null ? sel : 0) - pageSize));
-            return true;
-        }
-        if (key.isKey(KeyCode.PAGE_DOWN)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            Integer sel = tableState.selected();
-            tableState.select(Math.min(displayRows.size() - 1, (sel != null ? sel : 0) + pageSize));
-            return true;
-        }
-        if (key.isHome()) {
-            tableState.select(0);
-            return true;
-        }
-        if (key.isEnd()) {
-            tableState.select(displayRows.size() - 1);
+        if (TableNavigation.handlePageKeys(key, tableState, displayRows.size(), lastContentHeight)) {
             return true;
         }
         if (key.isCharIgnoreCase(' ')) {
@@ -404,24 +387,7 @@ class ReactorUpdatesTui {
             moduleTableState.selectNext(visible.size());
             return true;
         }
-        if (key.isKey(KeyCode.PAGE_UP)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            Integer sel = moduleTableState.selected();
-            moduleTableState.select(Math.max(0, (sel != null ? sel : 0) - pageSize));
-            return true;
-        }
-        if (key.isKey(KeyCode.PAGE_DOWN)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            Integer sel = moduleTableState.selected();
-            moduleTableState.select(Math.min(visible.size() - 1, (sel != null ? sel : 0) + pageSize));
-            return true;
-        }
-        if (key.isHome()) {
-            moduleTableState.select(0);
-            return true;
-        }
-        if (key.isEnd()) {
-            moduleTableState.select(visible.size() - 1);
+        if (TableNavigation.handlePageKeys(key, moduleTableState, visible.size(), lastContentHeight)) {
             return true;
         }
         if (key.isKey(KeyCode.ENTER) || key.isKey(KeyCode.RIGHT)) {

--- a/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
@@ -146,6 +146,7 @@ class SearchTui {
     // Dependencies
     private final SearchClient client;
     private TuiRunner runner;
+    private int lastContentHeight;
 
     /**
      * Get the currently selected table row index, defaulting to -1 when no row is selected.
@@ -342,6 +343,39 @@ class SearchTui {
             fetchPomInfoIfNeeded();
             return true;
         }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            tableState.select(Math.max(0, selectedIndex() - pageSize));
+            fetchPomInfoIfNeeded();
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            int target = Math.min(artifacts.size() - 1, selectedIndex() + pageSize);
+            if (target >= 0) {
+                tableState.select(target);
+                if (target >= artifacts.size() / 2 && artifacts.size() < totalFound) {
+                    prefetchMoreResults();
+                }
+            }
+            fetchPomInfoIfNeeded();
+            return true;
+        }
+        if (key.isHome()) {
+            tableState.select(0);
+            fetchPomInfoIfNeeded();
+            return true;
+        }
+        if (key.isEnd()) {
+            if (!artifacts.isEmpty()) {
+                tableState.select(artifacts.size() - 1);
+                if (artifacts.size() < totalFound) {
+                    prefetchMoreResults();
+                }
+                fetchPomInfoIfNeeded();
+            }
+            return true;
+        }
         if (key.isLeft()) {
             int selected = selectedIndex();
             cycleVersion(selected, -1);
@@ -382,6 +416,7 @@ class SearchTui {
                 .split(frame.area());
 
         renderSearchBar(frame, zones.get(0));
+        lastContentHeight = zones.get(1).height();
         renderResultsTable(frame, zones.get(1));
         renderInfoBar(frame, zones.get(2));
     }

--- a/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
@@ -330,24 +330,11 @@ class SearchTui {
             return true;
         }
         if (key.isDown()) {
-            int before = selectedIndex();
-            tableState.selectNext(artifacts.size());
-            int after = selectedIndex();
-            if (before == after && artifacts.size() < totalFound) {
-                // At the very bottom and prefetch hasn't arrived yet — block
-                fetchMoreResultsSync();
-            } else if (after >= artifacts.size() / 2 && artifacts.size() < totalFound) {
-                // Near the bottom — prefetch next page in the background
-                prefetchMoreResults();
-            }
-            fetchPomInfoIfNeeded();
+            handleDownKey();
             return true;
         }
         if (TableNavigation.handlePageKeys(key, tableState, artifacts.size(), lastContentHeight)) {
-            int sel = selectedIndex();
-            if (sel >= artifacts.size() / 2 && artifacts.size() < totalFound) {
-                prefetchMoreResults();
-            }
+            prefetchIfNearBottom();
             fetchPomInfoIfNeeded();
             return true;
         }
@@ -367,6 +354,25 @@ class SearchTui {
             return true;
         }
         return false;
+    }
+
+    private void handleDownKey() {
+        int before = selectedIndex();
+        tableState.selectNext(artifacts.size());
+        int after = selectedIndex();
+        if (before == after && artifacts.size() < totalFound) {
+            fetchMoreResultsSync();
+        } else {
+            prefetchIfNearBottom();
+        }
+        fetchPomInfoIfNeeded();
+    }
+
+    private void prefetchIfNearBottom() {
+        int sel = selectedIndex();
+        if (sel >= artifacts.size() / 2 && artifacts.size() < totalFound) {
+            prefetchMoreResults();
+        }
     }
 
     private void onQueryChanged() {

--- a/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
@@ -360,7 +360,7 @@ class SearchTui {
         int before = selectedIndex();
         tableState.selectNext(artifacts.size());
         int after = selectedIndex();
-        if (before == after && artifacts.size() < totalFound) {
+        if (before == after && artifacts.size() < totalFound && !prefetchingMore) {
             fetchMoreResultsSync();
         } else {
             prefetchIfNearBottom();

--- a/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
@@ -583,6 +583,10 @@ class SearchTui {
         } else {
             spans.add(Span.raw("\u2191\u2193").bold());
             spans.add(Span.raw(":Navigate  "));
+            spans.add(Span.raw("PgUp/PgDn").bold());
+            spans.add(Span.raw(":Page  "));
+            spans.add(Span.raw("Home/End").bold());
+            spans.add(Span.raw(":Top/Bottom  "));
             spans.add(Span.raw("\u2190\u2192").bold());
             spans.add(Span.raw(":Version  "));
             spans.add(Span.raw("Enter").bold());

--- a/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
@@ -343,37 +343,12 @@ class SearchTui {
             fetchPomInfoIfNeeded();
             return true;
         }
-        if (key.isKey(KeyCode.PAGE_UP)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            tableState.select(Math.max(0, selectedIndex() - pageSize));
-            fetchPomInfoIfNeeded();
-            return true;
-        }
-        if (key.isKey(KeyCode.PAGE_DOWN)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            int target = Math.min(artifacts.size() - 1, selectedIndex() + pageSize);
-            if (target >= 0) {
-                tableState.select(target);
-                if (target >= artifacts.size() / 2 && artifacts.size() < totalFound) {
-                    prefetchMoreResults();
-                }
+        if (TableNavigation.handlePageKeys(key, tableState, artifacts.size(), lastContentHeight)) {
+            int sel = selectedIndex();
+            if (sel >= artifacts.size() / 2 && artifacts.size() < totalFound) {
+                prefetchMoreResults();
             }
             fetchPomInfoIfNeeded();
-            return true;
-        }
-        if (key.isHome()) {
-            tableState.select(0);
-            fetchPomInfoIfNeeded();
-            return true;
-        }
-        if (key.isEnd()) {
-            if (!artifacts.isEmpty()) {
-                tableState.select(artifacts.size() - 1);
-                if (artifacts.size() < totalFound) {
-                    prefetchMoreResults();
-                }
-                fetchPomInfoIfNeeded();
-            }
             return true;
         }
         if (key.isLeft()) {

--- a/src/main/java/eu/maveniverse/maven/pilot/TableNavigation.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/TableNavigation.java
@@ -32,6 +32,21 @@ class TableNavigation {
 
     private TableNavigation() {}
 
+    /** Overhead for a bordered table with a header row (top border + header + bottom border). */
+    static final int BORDERED_WITH_HEADER = 3;
+
+    /** Overhead for a bordered table without a header row (top border + bottom border). */
+    static final int BORDERED_NO_HEADER = 2;
+
+    /**
+     * Handle page-navigation keys for a bordered table with a header row.
+     *
+     * @see #handlePageKeys(KeyEvent, TableState, int, int, int)
+     */
+    static boolean handlePageKeys(KeyEvent key, TableState tableState, int listSize, int contentHeight) {
+        return handlePageKeys(key, tableState, listSize, contentHeight, BORDERED_WITH_HEADER);
+    }
+
     /**
      * Handle page-navigation keys (Page Up/Down, Home/End) for a table.
      *
@@ -39,23 +54,32 @@ class TableNavigation {
      * @param tableState    the table state to update
      * @param listSize      total number of rows in the table
      * @param contentHeight the visible content area height (from the layout zone)
+     * @param overhead      rows consumed by borders and header (subtracted from contentHeight to get page size)
      * @return {@code true} if the key was handled, {@code false} otherwise
      */
-    static boolean handlePageKeys(KeyEvent key, TableState tableState, int listSize, int contentHeight) {
+    static boolean handlePageKeys(KeyEvent key, TableState tableState, int listSize, int contentHeight, int overhead) {
         if (key.isKey(KeyCode.PAGE_UP)) {
-            int pageSize = Math.max(1, contentHeight - 3);
+            if (listSize <= 0) {
+                return true;
+            }
+            int pageSize = Math.max(1, contentHeight - overhead);
             Integer sel = tableState.selected();
             tableState.select(Math.max(0, (sel != null ? sel : 0) - pageSize));
             return true;
         }
         if (key.isKey(KeyCode.PAGE_DOWN)) {
-            int pageSize = Math.max(1, contentHeight - 3);
+            if (listSize <= 0) {
+                return true;
+            }
+            int pageSize = Math.max(1, contentHeight - overhead);
             Integer sel = tableState.selected();
-            tableState.select(Math.min(Math.max(0, listSize - 1), (sel != null ? sel : 0) + pageSize));
+            tableState.select(Math.min(listSize - 1, (sel != null ? sel : 0) + pageSize));
             return true;
         }
         if (key.isHome()) {
-            tableState.select(0);
+            if (listSize > 0) {
+                tableState.select(0);
+            }
             return true;
         }
         if (key.isEnd()) {

--- a/src/main/java/eu/maveniverse/maven/pilot/TableNavigation.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/TableNavigation.java
@@ -30,6 +30,8 @@ import dev.tamboui.widgets.table.TableState;
  */
 class TableNavigation {
 
+    private TableNavigation() {}
+
     /**
      * Handle page-navigation keys (Page Up/Down, Home/End) for a table.
      *

--- a/src/main/java/eu/maveniverse/maven/pilot/TableNavigation.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/TableNavigation.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.widgets.table.TableState;
+
+/**
+ * Shared page-navigation key handler for table views.
+ *
+ * <p>Handles Page Up, Page Down, Home, and End keys by computing the page size
+ * from the visible content height and updating the table selection accordingly.</p>
+ */
+class TableNavigation {
+
+    /**
+     * Handle page-navigation keys (Page Up/Down, Home/End) for a table.
+     *
+     * @param key           the key event
+     * @param tableState    the table state to update
+     * @param listSize      total number of rows in the table
+     * @param contentHeight the visible content area height (from the layout zone)
+     * @return {@code true} if the key was handled, {@code false} otherwise
+     */
+    static boolean handlePageKeys(KeyEvent key, TableState tableState, int listSize, int contentHeight) {
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            int pageSize = Math.max(1, contentHeight - 3);
+            Integer sel = tableState.selected();
+            tableState.select(Math.max(0, (sel != null ? sel : 0) - pageSize));
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            int pageSize = Math.max(1, contentHeight - 3);
+            Integer sel = tableState.selected();
+            tableState.select(Math.min(Math.max(0, listSize - 1), (sel != null ? sel : 0) + pageSize));
+            return true;
+        }
+        if (key.isHome()) {
+            tableState.select(0);
+            return true;
+        }
+        if (key.isEnd()) {
+            if (listSize > 0) {
+                tableState.select(listSize - 1);
+            }
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/eu/maveniverse/maven/pilot/TableNavigation.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/TableNavigation.java
@@ -58,34 +58,26 @@ class TableNavigation {
      * @return {@code true} if the key was handled, {@code false} otherwise
      */
     static boolean handlePageKeys(KeyEvent key, TableState tableState, int listSize, int contentHeight, int overhead) {
+        if (listSize <= 0) {
+            return key.isKey(KeyCode.PAGE_UP) || key.isKey(KeyCode.PAGE_DOWN) || key.isHome() || key.isEnd();
+        }
+        int current = tableState.selected() != null ? tableState.selected() : 0;
         if (key.isKey(KeyCode.PAGE_UP)) {
-            if (listSize <= 0) {
-                return true;
-            }
             int pageSize = Math.max(1, contentHeight - overhead);
-            Integer sel = tableState.selected();
-            tableState.select(Math.max(0, (sel != null ? sel : 0) - pageSize));
+            tableState.select(Math.max(0, current - pageSize));
             return true;
         }
         if (key.isKey(KeyCode.PAGE_DOWN)) {
-            if (listSize <= 0) {
-                return true;
-            }
             int pageSize = Math.max(1, contentHeight - overhead);
-            Integer sel = tableState.selected();
-            tableState.select(Math.min(listSize - 1, (sel != null ? sel : 0) + pageSize));
+            tableState.select(Math.min(listSize - 1, current + pageSize));
             return true;
         }
         if (key.isHome()) {
-            if (listSize > 0) {
-                tableState.select(0);
-            }
+            tableState.select(0);
             return true;
         }
         if (key.isEnd()) {
-            if (listSize > 0) {
-                tableState.select(listSize - 1);
-            }
+            tableState.select(listSize - 1);
             return true;
         }
         return false;

--- a/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -173,25 +173,7 @@ class TreeTui {
             fetchPomInfoIfNeeded();
             return true;
         }
-        if (key.isKey(KeyCode.PAGE_UP)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            tableState.select(Math.max(0, selectedIndex() - pageSize));
-            fetchPomInfoIfNeeded();
-            return true;
-        }
-        if (key.isKey(KeyCode.PAGE_DOWN)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            tableState.select(Math.min(displayNodes.size() - 1, selectedIndex() + pageSize));
-            fetchPomInfoIfNeeded();
-            return true;
-        }
-        if (key.isHome()) {
-            tableState.select(0);
-            fetchPomInfoIfNeeded();
-            return true;
-        }
-        if (key.isEnd()) {
-            tableState.select(displayNodes.size() - 1);
+        if (TableNavigation.handlePageKeys(key, tableState, displayNodes.size(), lastContentHeight)) {
             fetchPomInfoIfNeeded();
             return true;
         }

--- a/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -173,7 +173,8 @@ class TreeTui {
             fetchPomInfoIfNeeded();
             return true;
         }
-        if (TableNavigation.handlePageKeys(key, tableState, displayNodes.size(), lastContentHeight)) {
+        if (TableNavigation.handlePageKeys(
+                key, tableState, displayNodes.size(), lastContentHeight, TableNavigation.BORDERED_NO_HEADER)) {
             fetchPomInfoIfNeeded();
             return true;
         }

--- a/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -80,6 +80,7 @@ class TreeTui {
     private List<DependencyTreeModel.TreeNode> reversePath;
 
     private TuiRunner runner;
+    private int lastContentHeight;
 
     TreeTui(DependencyNode rootNode, String scope, String projectGav) {
         this.rootNode = rootNode;
@@ -169,6 +170,28 @@ class TreeTui {
         }
         if (key.isDown()) {
             tableState.selectNext(displayNodes.size());
+            fetchPomInfoIfNeeded();
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            tableState.select(Math.max(0, selectedIndex() - pageSize));
+            fetchPomInfoIfNeeded();
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            tableState.select(Math.min(displayNodes.size() - 1, selectedIndex() + pageSize));
+            fetchPomInfoIfNeeded();
+            return true;
+        }
+        if (key.isHome()) {
+            tableState.select(0);
+            fetchPomInfoIfNeeded();
+            return true;
+        }
+        if (key.isEnd()) {
+            tableState.select(displayNodes.size() - 1);
             fetchPomInfoIfNeeded();
             return true;
         }
@@ -429,6 +452,8 @@ class TreeTui {
                         "Navigation",
                         List.of(
                                 new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
+                                new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
                                 new HelpOverlay.Entry("\u2190 / \u2192", "Collapse / expand tree node"),
                                 new HelpOverlay.Entry("e", "Expand all nodes"),
                                 new HelpOverlay.Entry("w", "Collapse all (keeps root expanded)"))),
@@ -479,6 +504,7 @@ class TreeTui {
 
         renderHeader(frame, zones.get(0));
 
+        lastContentHeight = zones.get(1).height();
         if (helpOverlay.isActive()) {
             helpOverlay.render(frame, zones.get(1));
         } else if (mode == Mode.REVERSE_PATH) {

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -351,25 +351,7 @@ class UpdatesTui {
             fetchPomInfoIfNeeded();
             return true;
         }
-        if (key.isKey(KeyCode.PAGE_UP)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            tableState.select(Math.max(0, selectedIndex() - pageSize));
-            fetchPomInfoIfNeeded();
-            return true;
-        }
-        if (key.isKey(KeyCode.PAGE_DOWN)) {
-            int pageSize = Math.max(1, lastContentHeight - 3);
-            tableState.select(Math.min(displayDeps.size() - 1, selectedIndex() + pageSize));
-            fetchPomInfoIfNeeded();
-            return true;
-        }
-        if (key.isHome()) {
-            tableState.select(0);
-            fetchPomInfoIfNeeded();
-            return true;
-        }
-        if (key.isEnd()) {
-            tableState.select(displayDeps.size() - 1);
+        if (TableNavigation.handlePageKeys(key, tableState, displayDeps.size(), lastContentHeight)) {
             fetchPomInfoIfNeeded();
             return true;
         }

--- a/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -351,6 +351,28 @@ class UpdatesTui {
             fetchPomInfoIfNeeded();
             return true;
         }
+        if (key.isKey(KeyCode.PAGE_UP)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            tableState.select(Math.max(0, selectedIndex() - pageSize));
+            fetchPomInfoIfNeeded();
+            return true;
+        }
+        if (key.isKey(KeyCode.PAGE_DOWN)) {
+            int pageSize = Math.max(1, lastContentHeight - 3);
+            tableState.select(Math.min(displayDeps.size() - 1, selectedIndex() + pageSize));
+            fetchPomInfoIfNeeded();
+            return true;
+        }
+        if (key.isHome()) {
+            tableState.select(0);
+            fetchPomInfoIfNeeded();
+            return true;
+        }
+        if (key.isEnd()) {
+            tableState.select(displayDeps.size() - 1);
+            fetchPomInfoIfNeeded();
+            return true;
+        }
 
         if (key.isCharIgnoreCase(' ')) {
             toggleSelection();
@@ -794,6 +816,8 @@ class UpdatesTui {
                         "General",
                         List.of(
                                 new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
+                                new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
+                                new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
                                 new HelpOverlay.Entry("d", "Preview POM changes as a unified diff"),
                                 new HelpOverlay.Entry("h", "Toggle this help screen"),
                                 new HelpOverlay.Entry("q / Esc", "Quit (prompts to save if modified)"))));

--- a/src/test/java/eu/maveniverse/maven/pilot/PageNavigationTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/PageNavigationTest.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static eu.maveniverse.maven.pilot.TestProjects.createProject;
+import static eu.maveniverse.maven.pilot.TestProjects.subdir;
+
+import dev.tamboui.layout.Size;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.pilot.Pilot;
+import dev.tamboui.tui.pilot.TuiTestRunner;
+import jakarta.json.Json;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.graph.DefaultDependencyNode;
+import org.eclipse.aether.graph.Dependency;
+import org.eclipse.aether.graph.DependencyNode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Integration tests for page navigation (PgUp/PgDn/Home/End) across TUI views.
+ */
+class PageNavigationTest {
+
+    @TempDir
+    Path tempDir;
+
+    String pomPath;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        pomPath = Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
+    }
+
+    @Test
+    void modulePickerPageNavigation() throws Exception {
+        Path c1 = subdir(tempDir, "c1");
+        Path c2 = subdir(tempDir, "c2");
+        MavenProject root = createProject("parent", tempDir);
+        MavenProject child1 = createProject("c1", c1);
+        MavenProject child2 = createProject("c2", c2);
+
+        ReactorModel model = ReactorModel.build(List.of(root, child1, child2));
+        ModulePickerTui picker = new ModulePickerTui(model, "com.example:parent:1.0", "test");
+
+        try (var testRunner = TuiTestRunner.runTest(picker::handleEvent, picker::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_DOWN);
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_UP);
+            pilot.pause();
+            pilot.press(KeyCode.HOME);
+            pilot.pause();
+            pilot.press(KeyCode.END);
+            pilot.pause();
+            pilot.press('q');
+        }
+    }
+
+    @Test
+    void pomPageNavigation() throws Exception {
+        String pom = """
+                <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>app</artifactId>
+                  <version>1.0</version>
+                  <properties>
+                    <java.version>17</java.version>
+                    <encoding>UTF-8</encoding>
+                  </properties>
+                  <dependencies>
+                    <dependency>
+                      <groupId>org.slf4j</groupId>
+                      <artifactId>slf4j-api</artifactId>
+                      <version>2.0.9</version>
+                    </dependency>
+                  </dependencies>
+                </project>
+                """;
+        PomTui tui = new PomTui(pom, pom, "pom.xml");
+
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_DOWN);
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_UP);
+            pilot.pause();
+            pilot.press(KeyCode.HOME);
+            pilot.pause();
+            pilot.press(KeyCode.END);
+            pilot.pause();
+            pilot.press('q');
+        }
+    }
+
+    @Test
+    void treePageNavigation() throws Exception {
+        var root = new DefaultDependencyNode(new DefaultArtifact("com.example", "app", "", "jar", "1.0"));
+        List<DependencyNode> children = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            children.add(new DefaultDependencyNode(
+                    new Dependency(new DefaultArtifact("com.example", "lib" + i, "", "jar", "1.0"), "compile")));
+        }
+        root.setChildren(children);
+        TreeTui tui = new TreeTui(root, "compile", "com.example:app:1.0");
+
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_DOWN);
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_UP);
+            pilot.pause();
+            pilot.press(KeyCode.HOME);
+            pilot.pause();
+            pilot.press(KeyCode.END);
+            pilot.pause();
+            pilot.press('q');
+        }
+    }
+
+    @Test
+    void conflictsPageNavigation() throws Exception {
+        var groups = new ArrayList<ConflictsTui.ConflictGroup>();
+        for (int i = 0; i < 5; i++) {
+            var entry = new ConflictsTui.ConflictEntry(
+                    "com.example", "lib" + i, "1.0", "1.1", "root > a > lib" + i, "compile");
+            groups.add(new ConflictsTui.ConflictGroup("com.example:lib" + i, List.of(entry)));
+        }
+        ConflictsTui tui = new ConflictsTui(groups, pomPath, "com.example:app:1.0");
+
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_DOWN);
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_UP);
+            pilot.pause();
+            pilot.press(KeyCode.HOME);
+            pilot.pause();
+            pilot.press(KeyCode.END);
+            pilot.pause();
+            pilot.press('q');
+        }
+    }
+
+    @Test
+    void dependenciesPageNavigation() throws Exception {
+        var declared = new ArrayList<DependenciesTui.DepEntry>();
+        for (int i = 0; i < 5; i++) {
+            declared.add(new DependenciesTui.DepEntry("com.example", "lib" + i, "", "1.0", "compile", true));
+        }
+        DependenciesTui tui = new DependenciesTui(declared, List.of(), pomPath, "com.example:app:1.0");
+
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_DOWN);
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_UP);
+            pilot.pause();
+            pilot.press(KeyCode.HOME);
+            pilot.pause();
+            pilot.press(KeyCode.END);
+            pilot.pause();
+            pilot.press('q');
+        }
+    }
+
+    @Test
+    void updatesPageNavigation() throws Exception {
+        var deps = new ArrayList<UpdatesTui.DependencyInfo>();
+        for (int i = 0; i < 5; i++) {
+            deps.add(new UpdatesTui.DependencyInfo("com.example", "lib" + i, "1.0", "compile", "jar"));
+        }
+        UpdatesTui tui = new UpdatesTui(deps, pomPath, "com.example:app:1.0", (g, a) -> List.of());
+        tui.loadedCount = 5;
+        tui.updateStatusIfDone();
+
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_DOWN);
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_UP);
+            pilot.pause();
+            pilot.press(KeyCode.HOME);
+            pilot.pause();
+            pilot.press(KeyCode.END);
+            pilot.pause();
+            pilot.press('q');
+        }
+    }
+
+    @Test
+    void searchPageNavigation() throws Exception {
+        List<String[]> results = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            results.add(new String[] {"com.example", "lib" + i, "1.0." + i, "jar", "10", ""});
+        }
+        SearchTui tui = new SearchTui(
+                (term, rows, start) -> Json.createObjectBuilder()
+                        .add("numFound", 0)
+                        .add("docs", Json.createArrayBuilder())
+                        .build(),
+                "test",
+                results,
+                5);
+
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            // Switch to table focus
+            pilot.press(KeyCode.TAB);
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_DOWN);
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_UP);
+            pilot.pause();
+            pilot.press(KeyCode.HOME);
+            pilot.pause();
+            pilot.press(KeyCode.END);
+            pilot.pause();
+            pilot.press(KeyCode.ESCAPE);
+        }
+    }
+
+    @Test
+    void auditPageNavigation() throws Exception {
+        var entries = new ArrayList<AuditTui.AuditEntry>();
+        for (int i = 0; i < 5; i++) {
+            var entry = new AuditTui.AuditEntry("com.example", "lib" + i, "1.0", "compile");
+            entry.license = "Apache-2.0";
+            entry.licenseLoaded = true;
+            entry.vulnsLoaded = true;
+            entry.vulnerabilities = List.of();
+            entries.add(entry);
+        }
+        var root = new DefaultDependencyNode(new DefaultArtifact("com.example", "app", "", "jar", "1.0"));
+        var treeModel = DependencyTreeModel.fromDependencyNode(root, "compile");
+        AuditTui tui = new AuditTui(entries, "com.example:app:1.0", treeModel, pomPath);
+
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_DOWN);
+            pilot.pause();
+            pilot.press(KeyCode.PAGE_UP);
+            pilot.pause();
+            pilot.press(KeyCode.HOME);
+            pilot.pause();
+            pilot.press(KeyCode.END);
+            pilot.pause();
+            pilot.press('q');
+        }
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/PageNavigationTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/PageNavigationTest.java
@@ -238,6 +238,11 @@ class PageNavigationTest {
             // Switch to table focus
             pilot.press(KeyCode.TAB);
             pilot.pause();
+            // Down key (exercises handleDownKey + prefetchIfNearBottom)
+            pilot.press(KeyCode.DOWN);
+            pilot.pause();
+            pilot.press(KeyCode.DOWN);
+            pilot.pause();
             pilot.press(KeyCode.PAGE_DOWN);
             pilot.pause();
             pilot.press(KeyCode.PAGE_UP);

--- a/src/test/java/eu/maveniverse/maven/pilot/TableNavigationTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/TableNavigationTest.java
@@ -74,7 +74,7 @@ class TableNavigationTest {
         ts.select(3);
         boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.PAGE_UP), ts, 50, 24);
         assertThat(handled).isTrue();
-        assertThat(ts.selected()).isEqualTo(0);
+        assertThat(ts.selected()).isZero();
     }
 
     @Test

--- a/src/test/java/eu/maveniverse/maven/pilot/TableNavigationTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/TableNavigationTest.java
@@ -83,7 +83,7 @@ class TableNavigationTest {
         ts.select(25);
         boolean handled = TableNavigation.handlePageKeys(homeEvent(), ts, 50, 24);
         assertThat(handled).isTrue();
-        assertThat(ts.selected()).isEqualTo(0);
+        assertThat(ts.selected()).isZero();
     }
 
     @Test
@@ -109,7 +109,7 @@ class TableNavigationTest {
         ts.select(0);
         boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.TAB), ts, 50, 24);
         assertThat(handled).isFalse();
-        assertThat(ts.selected()).isEqualTo(0);
+        assertThat(ts.selected()).isZero();
     }
 
     @Test
@@ -125,7 +125,7 @@ class TableNavigationTest {
         TableState ts = new TableState();
         boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.PAGE_UP), ts, 50, 24);
         assertThat(handled).isTrue();
-        assertThat(ts.selected()).isEqualTo(0);
+        assertThat(ts.selected()).isZero();
     }
 
     @Test

--- a/src/test/java/eu/maveniverse/maven/pilot/TableNavigationTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/TableNavigationTest.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.KeyModifiers;
+import dev.tamboui.widgets.table.TableState;
+import org.junit.jupiter.api.Test;
+
+class TableNavigationTest {
+
+    private static KeyEvent keyEvent(KeyCode code) {
+        return new KeyEvent(code, KeyModifiers.NONE, (char) 0);
+    }
+
+    private static KeyEvent homeEvent() {
+        return new KeyEvent(KeyCode.HOME, KeyModifiers.NONE, (char) 0);
+    }
+
+    private static KeyEvent endEvent() {
+        return new KeyEvent(KeyCode.END, KeyModifiers.NONE, (char) 0);
+    }
+
+    @Test
+    void pageDownFromFirstRow() {
+        TableState ts = new TableState();
+        ts.select(0);
+        // contentHeight=24 -> pageSize = max(1, 24-3) = 21
+        boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.PAGE_DOWN), ts, 50, 24);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isEqualTo(21);
+    }
+
+    @Test
+    void pageDownClampsToLastRow() {
+        TableState ts = new TableState();
+        ts.select(0);
+        boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.PAGE_DOWN), ts, 5, 24);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isEqualTo(4);
+    }
+
+    @Test
+    void pageUpFromMiddle() {
+        TableState ts = new TableState();
+        ts.select(25);
+        boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.PAGE_UP), ts, 50, 24);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isEqualTo(4);
+    }
+
+    @Test
+    void pageUpClampsToFirstRow() {
+        TableState ts = new TableState();
+        ts.select(3);
+        boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.PAGE_UP), ts, 50, 24);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isEqualTo(0);
+    }
+
+    @Test
+    void homeSelectsFirstRow() {
+        TableState ts = new TableState();
+        ts.select(25);
+        boolean handled = TableNavigation.handlePageKeys(homeEvent(), ts, 50, 24);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isEqualTo(0);
+    }
+
+    @Test
+    void endSelectsLastRow() {
+        TableState ts = new TableState();
+        ts.select(0);
+        boolean handled = TableNavigation.handlePageKeys(endEvent(), ts, 50, 24);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isEqualTo(49);
+    }
+
+    @Test
+    void endWithEmptyList() {
+        TableState ts = new TableState();
+        boolean handled = TableNavigation.handlePageKeys(endEvent(), ts, 0, 24);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isNull();
+    }
+
+    @Test
+    void unhandledKeyReturnsFalse() {
+        TableState ts = new TableState();
+        ts.select(0);
+        boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.TAB), ts, 50, 24);
+        assertThat(handled).isFalse();
+        assertThat(ts.selected()).isEqualTo(0);
+    }
+
+    @Test
+    void pageDownWithNoSelection() {
+        TableState ts = new TableState();
+        boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.PAGE_DOWN), ts, 50, 24);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isEqualTo(21);
+    }
+
+    @Test
+    void pageUpWithNoSelection() {
+        TableState ts = new TableState();
+        boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.PAGE_UP), ts, 50, 24);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isEqualTo(0);
+    }
+
+    @Test
+    void smallContentHeight() {
+        TableState ts = new TableState();
+        ts.select(5);
+        // contentHeight=4 -> pageSize = max(1, 4-3) = 1
+        boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.PAGE_DOWN), ts, 50, 4);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isEqualTo(6);
+    }
+
+    @Test
+    void tinyContentHeight() {
+        TableState ts = new TableState();
+        ts.select(5);
+        // contentHeight=2 -> pageSize = max(1, 2-3) = max(1, -1) = 1
+        boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.PAGE_DOWN), ts, 50, 2);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isEqualTo(6);
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/TableNavigationTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/TableNavigationTest.java
@@ -147,4 +147,39 @@ class TableNavigationTest {
         assertThat(handled).isTrue();
         assertThat(ts.selected()).isEqualTo(6);
     }
+
+    @Test
+    void homeWithEmptyList() {
+        TableState ts = new TableState();
+        boolean handled = TableNavigation.handlePageKeys(homeEvent(), ts, 0, 24);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isNull();
+    }
+
+    @Test
+    void pageDownWithEmptyList() {
+        TableState ts = new TableState();
+        boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.PAGE_DOWN), ts, 0, 24);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isNull();
+    }
+
+    @Test
+    void pageUpWithEmptyList() {
+        TableState ts = new TableState();
+        boolean handled = TableNavigation.handlePageKeys(keyEvent(KeyCode.PAGE_UP), ts, 0, 24);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isNull();
+    }
+
+    @Test
+    void noHeaderOverheadUsesLargerPageSize() {
+        TableState ts = new TableState();
+        ts.select(0);
+        // contentHeight=24, overhead=2 -> pageSize = max(1, 24-2) = 22
+        boolean handled = TableNavigation.handlePageKeys(
+                keyEvent(KeyCode.PAGE_DOWN), ts, 50, 24, TableNavigation.BORDERED_NO_HEADER);
+        assertThat(handled).isTrue();
+        assertThat(ts.selected()).isEqualTo(22);
+    }
 }


### PR DESCRIPTION
## Summary
- Adds **Page Up / Page Down** keys to jump one page at a time in all table views
- Adds **Home / End** keys to jump to the first / last row in all table views
- Updates help overlay text in all views to document the new shortcuts
- Page size is computed dynamically from the visible content height

Affected views: Dependencies, Updates, Audit, Conflicts, Search, Tree, POM, Module Picker, Reactor Updates (both deps and modules sub-views).

Fixes #28

## Test plan
- [x] All 266 existing tests pass (0 failures)
- [ ] Manual: open a table with many rows, verify Page Up/Down jumps by one page
- [ ] Manual: verify Home jumps to first row, End jumps to last row
- [ ] Manual: verify help overlay (h key) shows the new PgUp/PgDn and Home/End entries
- [ ] Manual: verify Search view prefetches more results on Page Down / End near bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added page-wise table navigation (PgUp / PgDn / Home / End) across all table views for faster jumping and paging.

* **Improvements**
  * Search results now better prefetch when navigating near the bottom to reduce waiting for more items.

* **Documentation**
  * Updated in-app key help to show the new page navigation shortcuts.

* **Tests**
  * Added unit and integration tests to validate consistent page-navigation across views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->