### PR TITLE
Fix #51: disambiguate duplicate property names and add detail pane

### DIFF
--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -43,8 +43,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -111,6 +111,7 @@ class ReactorUpdatesTui {
     private Filter filter = Filter.ALL;
     private final DiffOverlay diffOverlay = new DiffOverlay();
     private final HelpOverlay helpOverlay = new HelpOverlay();
+    private final TableState detailTableState = new TableState();
     boolean showDetails = true;
     private int lastContentHeight;
     String status = "Loading updates\u2026";
@@ -241,7 +242,7 @@ class ReactorUpdatesTui {
         for (var group : reactorResult.propertyGroups) {
             propertyCounts.merge(group.propertyName, 1, Integer::sum);
         }
-        duplicatePropertyNames = new HashSet<>();
+        duplicatePropertyNames = new LinkedHashSet<>();
         for (var entry : propertyCounts.entrySet()) {
             if (entry.getValue() > 1) {
                 duplicatePropertyNames.add(entry.getKey());
@@ -889,7 +890,7 @@ class ReactorUpdatesTui {
                     Span.raw("GAV:       ").bold(), Span.raw(dep.groupId + ":" + dep.artifactId + ":" + version))))));
 
             // Scope(s) in use
-            Set<String> scopes = new HashSet<>();
+            Set<String> scopes = new LinkedHashSet<>();
             for (var u : dep.usages) {
                 if (u.scope != null && !u.scope.isEmpty()) {
                     scopes.add(u.scope);
@@ -947,8 +948,7 @@ class ReactorUpdatesTui {
                 .block(block)
                 .build();
 
-        TableState detailState = new TableState();
-        frame.renderStatefulWidget(table, area, detailState);
+        frame.renderStatefulWidget(table, area, detailTableState);
     }
 
     private void renderModulesTable(Frame frame, Rect area) {

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -190,7 +190,7 @@ class ReactorUpdatesTui {
         }
     }
 
-    private void updateStatusIfDone() {
+    void updateStatusIfDone() {
         if (loadedCount >= reactorResult.allDependencies.size()) {
             loading = false;
             for (var group : reactorResult.propertyGroups) {
@@ -234,20 +234,23 @@ class ReactorUpdatesTui {
         reactorModel.recomputeCounts();
     }
 
-    void buildDisplayRows() {
-        displayRows = new ArrayList<>();
-
-        // Identify property names that appear in multiple groups (from different POMs)
+    private static Set<String> computeDuplicatePropertyNames(List<ReactorCollector.PropertyGroup> propertyGroups) {
         Map<String, Integer> propertyCounts = new LinkedHashMap<>();
-        for (var group : reactorResult.propertyGroups) {
+        for (var group : propertyGroups) {
             propertyCounts.merge(group.propertyName, 1, Integer::sum);
         }
-        duplicatePropertyNames = new LinkedHashSet<>();
+        Set<String> duplicates = new LinkedHashSet<>();
         for (var entry : propertyCounts.entrySet()) {
             if (entry.getValue() > 1) {
-                duplicatePropertyNames.add(entry.getKey());
+                duplicates.add(entry.getKey());
             }
         }
+        return duplicates;
+    }
+
+    void buildDisplayRows() {
+        displayRows = new ArrayList<>();
+        duplicatePropertyNames = computeDuplicatePropertyNames(reactorResult.propertyGroups);
 
         for (var group : reactorResult.propertyGroups) {
             boolean groupHasUpdate = group.hasUpdate()
@@ -841,97 +844,16 @@ class ReactorUpdatesTui {
 
         var row = displayRows.get(sel);
         String title;
-        List<Row> rows = new ArrayList<>();
+        List<Row> rows;
 
         if (row.isGroupHeader()) {
             var group = row.propertyGroup;
             title = " " + group.rawExpression + " \u2014 Details ";
-
-            // Origin POM path (relative to reactor root)
-            Path originPath = group.origin.getFile().toPath();
-            Path rootPath = reactorModel.root.project.getBasedir().toPath();
-            String relativePom = rootPath.relativize(originPath).toString();
-            rows.add(Row.from(Cell.from(Line.from(List.of(
-                    Span.raw("Origin:    ").bold(), Span.raw(relativePom).fg(Color.DARK_GRAY))))));
-
-            // Current → available version
-            String value = group.resolvedVersion != null ? group.resolvedVersion : "?";
-            if (group.hasUpdate()) {
-                rows.add(Row.from(Cell.from(Line.from(List.of(
-                        Span.raw("Version:   ").bold(),
-                        Span.raw(value),
-                        Span.raw(" \u2192 ").dim(),
-                        Span.raw(group.newestVersion).fg(Color.GREEN))))));
-            } else {
-                rows.add(Row.from(
-                        Cell.from(Line.from(List.of(Span.raw("Version:   ").bold(), Span.raw(value))))));
-            }
-
-            // Managed artifacts
-            List<Span> artSpans = new ArrayList<>();
-            artSpans.add(Span.raw("Artifacts: ").bold());
-            for (int i = 0; i < group.dependencies.size(); i++) {
-                if (i > 0) artSpans.add(Span.raw(", ").dim());
-                artSpans.add(Span.raw(group.dependencies.get(i).artifactId));
-            }
-            rows.add(Row.from(Cell.from(Line.from(artSpans))));
-
-            // Module count
-            rows.add(Row.from(Cell.from(Line.from(
-                    List.of(Span.raw("Modules:   ").bold(), Span.raw(String.valueOf(group.totalModuleCount())))))));
-
+            rows = buildGroupDetailRows(group);
         } else if (row.dependency != null) {
             var dep = row.dependency;
             title = " " + dep.ga() + " \u2014 Details ";
-
-            // Full GAV
-            String version = dep.primaryVersion != null ? dep.primaryVersion : "?";
-            rows.add(Row.from(Cell.from(Line.from(List.of(
-                    Span.raw("GAV:       ").bold(), Span.raw(dep.groupId + ":" + dep.artifactId + ":" + version))))));
-
-            // Scope(s) in use
-            Set<String> scopes = new LinkedHashSet<>();
-            for (var u : dep.usages) {
-                if (u.scope != null && !u.scope.isEmpty()) {
-                    scopes.add(u.scope);
-                }
-            }
-            if (!scopes.isEmpty()) {
-                rows.add(Row.from(Cell.from(
-                        Line.from(List.of(Span.raw("Scope:     ").bold(), Span.raw(String.join(", ", scopes)))))));
-            }
-
-            // Managed vs direct
-            boolean managed = dep.usages.stream().anyMatch(u -> u.managed);
-            rows.add(Row.from(
-                    Cell.from(Line.from(List.of(Span.raw("Managed:   ").bold(), Span.raw(managed ? "yes" : "no"))))));
-
-            // Update info
-            if (dep.hasUpdate()) {
-                rows.add(Row.from(Cell.from(Line.from(List.of(
-                        Span.raw("Update:    ").bold(),
-                        Span.raw(dep.primaryVersion),
-                        Span.raw(" \u2192 ").dim(),
-                        Span.raw(dep.newestVersion).fg(Color.GREEN))))));
-            }
-
-            // Which modules use this dependency
-            List<Span> modSpans = new ArrayList<>();
-            modSpans.add(Span.raw("Modules:   ").bold());
-            for (int i = 0; i < dep.usages.size(); i++) {
-                if (i > 0) modSpans.add(Span.raw(", ").dim());
-                modSpans.add(Span.raw(dep.usages.get(i).project.getArtifactId()));
-            }
-            rows.add(Row.from(Cell.from(Line.from(modSpans))));
-
-            // Property origin (if property-managed)
-            if (dep.isPropertyManaged()) {
-                String propOrigin = dep.propertyOrigin != null ? dep.propertyOrigin.getArtifactId() : "?";
-                rows.add(Row.from(Cell.from(Line.from(List.of(
-                        Span.raw("Property:  ").bold(),
-                        Span.raw(dep.rawVersionExpr).fg(Color.CYAN),
-                        Span.raw(" (" + propOrigin + ")").dim())))));
-            }
+            rows = buildDependencyDetailRows(dep);
         } else {
             return;
         }
@@ -949,6 +871,100 @@ class ReactorUpdatesTui {
                 .build();
 
         frame.renderStatefulWidget(table, area, detailTableState);
+    }
+
+    private List<Row> buildGroupDetailRows(ReactorCollector.PropertyGroup group) {
+        List<Row> rows = new ArrayList<>();
+
+        // Origin POM path (relative to reactor root)
+        Path originPath = group.origin.getFile().toPath();
+        Path rootPath = reactorModel.root.project.getBasedir().toPath();
+        String relativePom = rootPath.relativize(originPath).toString();
+        rows.add(Row.from(Cell.from(Line.from(
+                List.of(Span.raw("Origin:    ").bold(), Span.raw(relativePom).fg(Color.DARK_GRAY))))));
+
+        // Current → available version
+        String value = group.resolvedVersion != null ? group.resolvedVersion : "?";
+        if (group.hasUpdate()) {
+            rows.add(Row.from(Cell.from(Line.from(List.of(
+                    Span.raw("Version:   ").bold(),
+                    Span.raw(value),
+                    Span.raw(" \u2192 ").dim(),
+                    Span.raw(group.newestVersion).fg(Color.GREEN))))));
+        } else {
+            rows.add(
+                    Row.from(Cell.from(Line.from(List.of(Span.raw("Version:   ").bold(), Span.raw(value))))));
+        }
+
+        // Managed artifacts
+        List<Span> artSpans = new ArrayList<>();
+        artSpans.add(Span.raw("Artifacts: ").bold());
+        for (int i = 0; i < group.dependencies.size(); i++) {
+            if (i > 0) artSpans.add(Span.raw(", ").dim());
+            artSpans.add(Span.raw(group.dependencies.get(i).artifactId));
+        }
+        rows.add(Row.from(Cell.from(Line.from(artSpans))));
+
+        // Module count
+        rows.add(Row.from(Cell.from(Line.from(
+                List.of(Span.raw("Modules:   ").bold(), Span.raw(String.valueOf(group.totalModuleCount())))))));
+
+        return rows;
+    }
+
+    private List<Row> buildDependencyDetailRows(ReactorCollector.AggregatedDependency dep) {
+        List<Row> rows = new ArrayList<>();
+
+        // Full GAV
+        String version = dep.primaryVersion != null ? dep.primaryVersion : "?";
+        rows.add(Row.from(Cell.from(Line.from(List.of(
+                Span.raw("GAV:       ").bold(), Span.raw(dep.groupId + ":" + dep.artifactId + ":" + version))))));
+
+        // Scope(s) in use
+        Set<String> scopes = new LinkedHashSet<>();
+        for (var u : dep.usages) {
+            if (u.scope != null && !u.scope.isEmpty()) {
+                scopes.add(u.scope);
+            }
+        }
+        if (!scopes.isEmpty()) {
+            rows.add(Row.from(Cell.from(
+                    Line.from(List.of(Span.raw("Scope:     ").bold(), Span.raw(String.join(", ", scopes)))))));
+        }
+
+        // Managed vs direct
+        boolean managed = dep.usages.stream().anyMatch(u -> u.managed);
+        rows.add(Row.from(
+                Cell.from(Line.from(List.of(Span.raw("Managed:   ").bold(), Span.raw(managed ? "yes" : "no"))))));
+
+        // Update info
+        if (dep.hasUpdate()) {
+            rows.add(Row.from(Cell.from(Line.from(List.of(
+                    Span.raw("Update:    ").bold(),
+                    Span.raw(dep.primaryVersion),
+                    Span.raw(" \u2192 ").dim(),
+                    Span.raw(dep.newestVersion).fg(Color.GREEN))))));
+        }
+
+        // Which modules use this dependency
+        List<Span> modSpans = new ArrayList<>();
+        modSpans.add(Span.raw("Modules:   ").bold());
+        for (int i = 0; i < dep.usages.size(); i++) {
+            if (i > 0) modSpans.add(Span.raw(", ").dim());
+            modSpans.add(Span.raw(dep.usages.get(i).project.getArtifactId()));
+        }
+        rows.add(Row.from(Cell.from(Line.from(modSpans))));
+
+        // Property origin (if property-managed)
+        if (dep.isPropertyManaged()) {
+            String propOrigin = dep.propertyOrigin != null ? dep.propertyOrigin.getArtifactId() : "?";
+            rows.add(Row.from(Cell.from(Line.from(List.of(
+                    Span.raw("Property:  ").bold(),
+                    Span.raw(dep.rawVersionExpr).fg(Color.CYAN),
+                    Span.raw(" (" + propOrigin + ")").dim())))));
+        }
+
+        return rows;
     }
 
     private void renderModulesTable(Frame frame, Rect area) {

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -75,7 +75,7 @@ class ReactorUpdatesTui {
         MAJOR
     }
 
-    private static class ReactorRow {
+    static class ReactorRow {
         final ReactorCollector.PropertyGroup propertyGroup;
         final ReactorCollector.AggregatedDependency dependency;
 
@@ -106,12 +106,12 @@ class ReactorUpdatesTui {
     private final ExecutorService httpPool = MojoHelper.newHttpPool();
 
     private View view = View.DEPENDENCIES;
-    private List<ReactorRow> displayRows = new ArrayList<>();
-    private Set<String> duplicatePropertyNames = Set.of();
+    List<ReactorRow> displayRows = new ArrayList<>();
+    Set<String> duplicatePropertyNames = Set.of();
     private Filter filter = Filter.ALL;
     private final DiffOverlay diffOverlay = new DiffOverlay();
     private final HelpOverlay helpOverlay = new HelpOverlay();
-    private boolean showDetails = true;
+    boolean showDetails = true;
     private int lastContentHeight;
     String status = "Loading updates\u2026";
     boolean loading = true;
@@ -233,7 +233,7 @@ class ReactorUpdatesTui {
         reactorModel.recomputeCounts();
     }
 
-    private void buildDisplayRows() {
+    void buildDisplayRows() {
         displayRows = new ArrayList<>();
 
         // Identify property names that appear in multiple groups (from different POMs)

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -934,7 +934,14 @@ class ReactorUpdatesTui {
         // Managed vs direct
         boolean anyManaged = dep.usages.stream().anyMatch(u -> u.managed);
         boolean allManaged = dep.usages.stream().allMatch(u -> u.managed);
-        String management = anyManaged ? (allManaged ? "yes" : "mixed") : "no";
+        String management;
+        if (allManaged) {
+            management = "yes";
+        } else if (anyManaged) {
+            management = "mixed";
+        } else {
+            management = "no";
+        }
         rows.add(Row.from(Cell.from(Line.from(List.of(Span.raw("Managed:   ").bold(), Span.raw(management))))));
 
         // Update info

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -33,6 +33,7 @@ import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.paragraph.Paragraph;
+import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
@@ -42,9 +43,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -104,9 +107,11 @@ class ReactorUpdatesTui {
 
     private View view = View.DEPENDENCIES;
     private List<ReactorRow> displayRows = new ArrayList<>();
+    private Set<String> duplicatePropertyNames = Set.of();
     private Filter filter = Filter.ALL;
     private final DiffOverlay diffOverlay = new DiffOverlay();
     private final HelpOverlay helpOverlay = new HelpOverlay();
+    private boolean showDetails = true;
     private int lastContentHeight;
     String status = "Loading updates\u2026";
     boolean loading = true;
@@ -230,6 +235,19 @@ class ReactorUpdatesTui {
 
     private void buildDisplayRows() {
         displayRows = new ArrayList<>();
+
+        // Identify property names that appear in multiple groups (from different POMs)
+        Map<String, Integer> propertyCounts = new LinkedHashMap<>();
+        for (var group : reactorResult.propertyGroups) {
+            propertyCounts.merge(group.propertyName, 1, Integer::sum);
+        }
+        duplicatePropertyNames = new HashSet<>();
+        for (var entry : propertyCounts.entrySet()) {
+            if (entry.getValue() > 1) {
+                duplicatePropertyNames.add(entry.getKey());
+            }
+        }
+
         for (var group : reactorResult.propertyGroups) {
             boolean groupHasUpdate = group.hasUpdate()
                     || group.dependencies.stream().anyMatch(ReactorCollector.AggregatedDependency::hasUpdate);
@@ -371,6 +389,10 @@ class ReactorUpdatesTui {
         }
         if (key.isCharIgnoreCase('h')) {
             helpOverlay.open(buildHelp());
+            return true;
+        }
+        if (key.isCharIgnoreCase('i')) {
+            showDetails = !showDetails;
             return true;
         }
         return false;
@@ -670,8 +692,14 @@ class ReactorUpdatesTui {
     // -- Rendering --
 
     void render(Frame frame) {
+        boolean detailsVisible =
+                showDetails && view == View.DEPENDENCIES && !diffOverlay.isActive() && !helpOverlay.isActive();
         var zones = Layout.vertical()
-                .constraints(Constraint.length(3), Constraint.fill(), Constraint.length(3))
+                .constraints(
+                        Constraint.length(3),
+                        Constraint.fill(),
+                        detailsVisible ? Constraint.percentage(30) : Constraint.length(0),
+                        Constraint.length(3))
                 .split(frame.area());
 
         renderHeader(frame, zones.get(0));
@@ -682,10 +710,13 @@ class ReactorUpdatesTui {
             diffOverlay.render(frame, zones.get(1), " POM Changes ");
         } else if (view == View.DEPENDENCIES) {
             renderDepsTable(frame, zones.get(1));
+            if (detailsVisible) {
+                renderDetailPane(frame, zones.get(2));
+            }
         } else {
             renderModulesTable(frame, zones.get(1));
         }
-        renderInfoBar(frame, zones.get(2));
+        renderInfoBar(frame, zones.get(3));
     }
 
     private void renderHeader(Frame frame, Rect area) {
@@ -766,6 +797,9 @@ class ReactorUpdatesTui {
             var group = row.propertyGroup;
             String check = group.selected ? "[\u2713]" : "[ ]";
             String name = "${" + group.propertyName + "}";
+            if (duplicatePropertyNames.contains(group.propertyName)) {
+                name += " (" + group.origin.getArtifactId() + ")";
+            }
             String current = group.resolvedVersion != null ? group.resolvedVersion : "";
             String arrow = group.hasUpdate() ? "\u2192" : "";
             String available = group.hasUpdate() ? group.newestVersion : "";
@@ -798,6 +832,123 @@ class ReactorUpdatesTui {
 
             return Row.from(check, ga, current, arrow, available, info).style(style);
         }
+    }
+
+    private void renderDetailPane(Frame frame, Rect area) {
+        Integer sel = tableState.selected();
+        if (sel == null || sel >= displayRows.size()) return;
+
+        var row = displayRows.get(sel);
+        String title;
+        List<Row> rows = new ArrayList<>();
+
+        if (row.isGroupHeader()) {
+            var group = row.propertyGroup;
+            title = " " + group.rawExpression + " \u2014 Details ";
+
+            // Origin POM path (relative to reactor root)
+            Path originPath = group.origin.getFile().toPath();
+            Path rootPath = reactorModel.root.project.getBasedir().toPath();
+            String relativePom = rootPath.relativize(originPath).toString();
+            rows.add(Row.from(Cell.from(Line.from(List.of(
+                    Span.raw("Origin:    ").bold(), Span.raw(relativePom).fg(Color.DARK_GRAY))))));
+
+            // Current → available version
+            String value = group.resolvedVersion != null ? group.resolvedVersion : "?";
+            if (group.hasUpdate()) {
+                rows.add(Row.from(Cell.from(Line.from(List.of(
+                        Span.raw("Version:   ").bold(),
+                        Span.raw(value),
+                        Span.raw(" \u2192 ").dim(),
+                        Span.raw(group.newestVersion).fg(Color.GREEN))))));
+            } else {
+                rows.add(Row.from(
+                        Cell.from(Line.from(List.of(Span.raw("Version:   ").bold(), Span.raw(value))))));
+            }
+
+            // Managed artifacts
+            List<Span> artSpans = new ArrayList<>();
+            artSpans.add(Span.raw("Artifacts: ").bold());
+            for (int i = 0; i < group.dependencies.size(); i++) {
+                if (i > 0) artSpans.add(Span.raw(", ").dim());
+                artSpans.add(Span.raw(group.dependencies.get(i).artifactId));
+            }
+            rows.add(Row.from(Cell.from(Line.from(artSpans))));
+
+            // Module count
+            rows.add(Row.from(Cell.from(Line.from(
+                    List.of(Span.raw("Modules:   ").bold(), Span.raw(String.valueOf(group.totalModuleCount())))))));
+
+        } else if (row.dependency != null) {
+            var dep = row.dependency;
+            title = " " + dep.ga() + " \u2014 Details ";
+
+            // Full GAV
+            String version = dep.primaryVersion != null ? dep.primaryVersion : "?";
+            rows.add(Row.from(Cell.from(Line.from(List.of(
+                    Span.raw("GAV:       ").bold(), Span.raw(dep.groupId + ":" + dep.artifactId + ":" + version))))));
+
+            // Scope(s) in use
+            Set<String> scopes = new HashSet<>();
+            for (var u : dep.usages) {
+                if (u.scope != null && !u.scope.isEmpty()) {
+                    scopes.add(u.scope);
+                }
+            }
+            if (!scopes.isEmpty()) {
+                rows.add(Row.from(Cell.from(
+                        Line.from(List.of(Span.raw("Scope:     ").bold(), Span.raw(String.join(", ", scopes)))))));
+            }
+
+            // Managed vs direct
+            boolean managed = dep.usages.stream().anyMatch(u -> u.managed);
+            rows.add(Row.from(
+                    Cell.from(Line.from(List.of(Span.raw("Managed:   ").bold(), Span.raw(managed ? "yes" : "no"))))));
+
+            // Update info
+            if (dep.hasUpdate()) {
+                rows.add(Row.from(Cell.from(Line.from(List.of(
+                        Span.raw("Update:    ").bold(),
+                        Span.raw(dep.primaryVersion),
+                        Span.raw(" \u2192 ").dim(),
+                        Span.raw(dep.newestVersion).fg(Color.GREEN))))));
+            }
+
+            // Which modules use this dependency
+            List<Span> modSpans = new ArrayList<>();
+            modSpans.add(Span.raw("Modules:   ").bold());
+            for (int i = 0; i < dep.usages.size(); i++) {
+                if (i > 0) modSpans.add(Span.raw(", ").dim());
+                modSpans.add(Span.raw(dep.usages.get(i).project.getArtifactId()));
+            }
+            rows.add(Row.from(Cell.from(Line.from(modSpans))));
+
+            // Property origin (if property-managed)
+            if (dep.isPropertyManaged()) {
+                String propOrigin = dep.propertyOrigin != null ? dep.propertyOrigin.getArtifactId() : "?";
+                rows.add(Row.from(Cell.from(Line.from(List.of(
+                        Span.raw("Property:  ").bold(),
+                        Span.raw(dep.rawVersionExpr).fg(Color.CYAN),
+                        Span.raw(" (" + propOrigin + ")").dim())))));
+            }
+        } else {
+            return;
+        }
+
+        Block block = Block.builder()
+                .title(title)
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(Style.create().cyan())
+                .build();
+
+        Table table = Table.builder()
+                .rows(rows)
+                .widths(Constraint.fill())
+                .block(block)
+                .build();
+
+        TableState detailState = new TableState();
+        frame.renderStatefulWidget(table, area, detailState);
     }
 
     private void renderModulesTable(Frame frame, Rect area) {
@@ -917,6 +1068,8 @@ class ReactorUpdatesTui {
                 spans.add(Span.raw(":Apply  "));
                 spans.add(Span.raw("1-4").bold());
                 spans.add(Span.raw(":Filter  "));
+                spans.add(Span.raw("i").bold());
+                spans.add(Span.raw(":Details  "));
                 spans.add(Span.raw("h").bold());
                 spans.add(Span.raw(":Help  "));
             } else {
@@ -968,7 +1121,8 @@ class ReactorUpdatesTui {
                                 new HelpOverlay.Entry("a / n", "Select all / deselect all"),
                                 new HelpOverlay.Entry("Enter", "Apply selected updates to POM files"),
                                 new HelpOverlay.Entry("1-4", "Filter: all / patch / minor / major"),
-                                new HelpOverlay.Entry("d", "Preview changes as a multi-file diff"))),
+                                new HelpOverlay.Entry("d", "Preview changes as a multi-file diff"),
+                                new HelpOverlay.Entry("i", "Toggle detail pane for selected row"))),
                 new HelpOverlay.Section(
                         "Modules View",
                         List.of(

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -191,28 +191,31 @@ class ReactorUpdatesTui {
     }
 
     void updateStatusIfDone() {
-        if (loadedCount >= reactorResult.allDependencies.size()) {
-            loading = false;
-            for (var group : reactorResult.propertyGroups) {
-                for (var dep : group.dependencies) {
-                    if (dep.hasUpdate()) {
-                        if (group.newestVersion == null
-                                || VersionComparator.isNewer(dep.newestVersion, group.newestVersion)) {
-                            // Pick the most conservative (smallest) version available for all deps
-                            group.newestVersion = dep.newestVersion;
-                            group.updateType = dep.updateType;
-                        }
-                    }
+        if (loadedCount < reactorResult.allDependencies.size()) {
+            return;
+        }
+        loading = false;
+        computePropertyGroupVersions();
+        updateReactorCounts();
+        buildDisplayRows();
+        long updates = reactorResult.allDependencies.stream()
+                .filter(ReactorCollector.AggregatedDependency::hasUpdate)
+                .count();
+        status = updates + " update(s) available across " + reactorModel.allModules.size() + " modules";
+        if (failedCount > 0) {
+            status += "; " + failedCount + " lookup(s) failed";
+        }
+    }
+
+    private void computePropertyGroupVersions() {
+        for (var group : reactorResult.propertyGroups) {
+            for (var dep : group.dependencies) {
+                if (dep.hasUpdate()
+                        && (group.newestVersion == null
+                                || VersionComparator.isNewer(dep.newestVersion, group.newestVersion))) {
+                    group.newestVersion = dep.newestVersion;
+                    group.updateType = dep.updateType;
                 }
-            }
-            updateReactorCounts();
-            buildDisplayRows();
-            long updates = reactorResult.allDependencies.stream()
-                    .filter(ReactorCollector.AggregatedDependency::hasUpdate)
-                    .count();
-            status = updates + " update(s) available across " + reactorModel.allModules.size() + " modules";
-            if (failedCount > 0) {
-                status += "; " + failedCount + " lookup(s) failed";
             }
         }
     }
@@ -920,22 +923,19 @@ class ReactorUpdatesTui {
         rows.add(Row.from(Cell.from(Line.from(List.of(
                 Span.raw("GAV:       ").bold(), Span.raw(dep.groupId + ":" + dep.artifactId + ":" + version))))));
 
-        // Scope(s) in use
+        // Scope(s) in use (default to "compile" when omitted)
         Set<String> scopes = new LinkedHashSet<>();
         for (var u : dep.usages) {
-            if (u.scope != null && !u.scope.isEmpty()) {
-                scopes.add(u.scope);
-            }
+            scopes.add(u.scope != null && !u.scope.isEmpty() ? u.scope : "compile");
         }
-        if (!scopes.isEmpty()) {
-            rows.add(Row.from(Cell.from(
-                    Line.from(List.of(Span.raw("Scope:     ").bold(), Span.raw(String.join(", ", scopes)))))));
-        }
+        rows.add(Row.from(
+                Cell.from(Line.from(List.of(Span.raw("Scope:     ").bold(), Span.raw(String.join(", ", scopes)))))));
 
         // Managed vs direct
-        boolean managed = dep.usages.stream().anyMatch(u -> u.managed);
-        rows.add(Row.from(
-                Cell.from(Line.from(List.of(Span.raw("Managed:   ").bold(), Span.raw(managed ? "yes" : "no"))))));
+        boolean anyManaged = dep.usages.stream().anyMatch(u -> u.managed);
+        boolean allManaged = dep.usages.stream().allMatch(u -> u.managed);
+        String management = anyManaged ? (allManaged ? "yes" : "mixed") : "no";
+        rows.add(Row.from(Cell.from(Line.from(List.of(Span.raw("Managed:   ").bold(), Span.raw(management))))));
 
         // Update info
         if (dep.hasUpdate()) {

--- a/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesTuiTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import dev.tamboui.terminal.Terminal;
 import dev.tamboui.terminal.TestBackend;
+import dev.tamboui.tui.event.KeyEvent;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -214,16 +215,16 @@ class ReactorUpdatesTuiTest {
     }
 
     @Test
-    void showDetailsCanBeToggled() {
+    void showDetailsCanBeToggledViaKeyHandler() {
         MavenProject project = createProject("com.example", "app", "1.0", tempDir);
         ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
 
         var tui = createTui(result, List.of(project));
 
         assertThat(tui.showDetails).isTrue();
-        tui.showDetails = !tui.showDetails;
+        tui.handleEvent(KeyEvent.ofChar('i'), null);
         assertThat(tui.showDetails).isFalse();
-        tui.showDetails = !tui.showDetails;
+        tui.handleEvent(KeyEvent.ofChar('i'), null);
         assertThat(tui.showDetails).isTrue();
     }
 
@@ -247,12 +248,19 @@ class ReactorUpdatesTuiTest {
         dep.newestVersion = "2.18.0";
         dep.updateType = VersionComparator.UpdateType.MINOR;
 
-        tui.loadedCount = result.allDependencies.size();
+        // Simulate all dependencies loaded
+        tui.loadedCount = result.allDependencies.size() - 1;
         tui.loading = true;
 
-        // The status message should reflect updates
-        assertThat(dep.hasUpdate()).isTrue();
-        assertThat(result.propertyGroups.get(0).dependencies).contains(dep);
+        // Trigger updateStatusIfDone by incrementing loadedCount to match total
+        tui.loadedCount = result.allDependencies.size();
+        tui.updateStatusIfDone();
+
+        // After completion, loading should be false and group should have computed update
+        assertThat(tui.loading).isFalse();
+        assertThat(result.propertyGroups.get(0).newestVersion).isEqualTo("2.18.0");
+        assertThat(result.propertyGroups.get(0).updateType).isEqualTo(VersionComparator.UpdateType.MINOR);
+        assertThat(tui.status).contains("update");
     }
 
     @Test
@@ -281,6 +289,20 @@ class ReactorUpdatesTuiTest {
 
         // Default filter: ALL - should show both
         tui.buildDisplayRows();
+        assertThat(tui.displayRows).hasSize(2);
+
+        // Filter PATCH (key '2') - only lib-a
+        tui.handleEvent(KeyEvent.ofChar('2'), null);
+        assertThat(tui.displayRows).hasSize(1);
+        assertThat(tui.displayRows.get(0).dependency.artifactId).isEqualTo("lib-a");
+
+        // Filter MAJOR (key '4') - only lib-b
+        tui.handleEvent(KeyEvent.ofChar('4'), null);
+        assertThat(tui.displayRows).hasSize(1);
+        assertThat(tui.displayRows.get(0).dependency.artifactId).isEqualTo("lib-b");
+
+        // Filter ALL (key '1') - both again
+        tui.handleEvent(KeyEvent.ofChar('1'), null);
         assertThat(tui.displayRows).hasSize(2);
     }
 

--- a/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesTuiTest.java
@@ -20,6 +20,8 @@ package eu.maveniverse.maven.pilot;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tamboui.terminal.Terminal;
+import dev.tamboui.terminal.TestBackend;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -68,6 +70,11 @@ class ReactorUpdatesTuiTest {
     private ReactorUpdatesTui createTui(ReactorCollector.CollectionResult result, List<MavenProject> projects) {
         ReactorModel model = ReactorModel.build(projects);
         return new ReactorUpdatesTui(result, model, "com.example:app:1.0", (g, a) -> List.of());
+    }
+
+    private void renderFrame(ReactorUpdatesTui tui) {
+        var terminal = new Terminal<>(new TestBackend(120, 30));
+        terminal.draw(tui::render);
     }
 
     @Test
@@ -325,5 +332,249 @@ class ReactorUpdatesTuiTest {
         assertThat(row.isGroupHeader()).isFalse();
         assertThat(row.dependency).isSameAs(dep);
         assertThat(row.propertyGroup).isNull();
+    }
+
+    // -- Rendering tests (exercise code paths for coverage) --
+
+    @Test
+    void renderWithDetailPaneForPropertyGroup() throws IOException {
+        Path dir = subdir("render1");
+
+        MavenProject project = createProject("com.example", "app", "1.0", dir);
+        Properties props = new Properties();
+        props.setProperty("jackson.version", "2.17.0");
+        project.getOriginalModel().setProperties(props);
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-databind", "2.17.0"));
+        project.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-core", "${jackson.version}"));
+        project.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-databind", "${jackson.version}"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+        var tui = createTui(result, List.of(project));
+
+        for (var dep : result.allDependencies) {
+            dep.newestVersion = "2.18.0";
+            dep.updateType = VersionComparator.UpdateType.MINOR;
+        }
+        result.propertyGroups.get(0).newestVersion = "2.18.0";
+        result.propertyGroups.get(0).updateType = VersionComparator.UpdateType.MINOR;
+
+        tui.loading = false;
+        tui.buildDisplayRows();
+
+        // Selected row 0 = property group header → detail pane shows group info
+        renderFrame(tui);
+    }
+
+    @Test
+    void renderWithDetailPaneForDependency() throws IOException {
+        Path dir = subdir("render2");
+
+        MavenProject project = createProject("com.example", "app", "1.0", dir);
+        Properties props = new Properties();
+        props.setProperty("jackson.version", "2.17.0");
+        project.getOriginalModel().setProperties(props);
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        project.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-core", "${jackson.version}"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+        var tui = createTui(result, List.of(project));
+
+        result.allDependencies.get(0).newestVersion = "2.18.0";
+        result.allDependencies.get(0).updateType = VersionComparator.UpdateType.MINOR;
+        result.propertyGroups.get(0).newestVersion = "2.18.0";
+        result.propertyGroups.get(0).updateType = VersionComparator.UpdateType.MINOR;
+
+        tui.loading = false;
+        tui.buildDisplayRows();
+
+        // Select row 1 = dependency under the group → detail pane shows dep info
+        assertThat(tui.displayRows).hasSizeGreaterThanOrEqualTo(2);
+        var terminal = new Terminal<>(new TestBackend(120, 30));
+        // Move selection to the dependency row
+        terminal.draw(frame -> {
+            // Manually select the dependency row before rendering
+            tui.displayRows.get(1); // just verify it exists
+            tui.render(frame);
+        });
+    }
+
+    @Test
+    void renderWithDetailPaneHidden() throws IOException {
+        Path dir = subdir("render3");
+
+        MavenProject project = createProject("com.example", "app", "1.0", dir);
+        project.getModel().addDependency(dep("com.example", "lib", "1.0"));
+        project.getOriginalModel().addDependency(dep("com.example", "lib", "1.0"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+        var tui = createTui(result, List.of(project));
+
+        result.ungroupedDependencies.get(0).newestVersion = "2.0";
+        result.ungroupedDependencies.get(0).updateType = VersionComparator.UpdateType.MAJOR;
+
+        tui.loading = false;
+        tui.showDetails = false;
+        tui.buildDisplayRows();
+
+        renderFrame(tui);
+    }
+
+    @Test
+    void renderWithDuplicatePropertyNames() throws IOException {
+        Path dir1 = subdir("render4a");
+        Path dir2 = subdir("render4b");
+
+        MavenProject p1 = createProject("com.example", "bom-a", "1.0", dir1);
+        Properties props1 = new Properties();
+        props1.setProperty("lib.version", "1.0");
+        p1.getOriginalModel().setProperties(props1);
+        p1.getModel().addDependency(dep("com.example", "lib-a", "1.0"));
+        p1.getOriginalModel().addDependency(dep("com.example", "lib-a", "${lib.version}"));
+
+        MavenProject p2 = createProject("com.example", "bom-b", "1.0", dir2);
+        Properties props2 = new Properties();
+        props2.setProperty("lib.version", "2.0");
+        p2.getOriginalModel().setProperties(props2);
+        p2.getModel().addDependency(dep("com.example", "lib-b", "2.0"));
+        p2.getOriginalModel().addDependency(dep("com.example", "lib-b", "${lib.version}"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(p1, p2));
+        var tui = createTui(result, List.of(p1, p2));
+
+        for (var dep : result.allDependencies) {
+            dep.newestVersion = "3.0";
+            dep.updateType = VersionComparator.UpdateType.MAJOR;
+        }
+        for (var group : result.propertyGroups) {
+            group.newestVersion = "3.0";
+            group.updateType = VersionComparator.UpdateType.MAJOR;
+        }
+
+        tui.loading = false;
+        tui.buildDisplayRows();
+
+        assertThat(tui.duplicatePropertyNames).containsExactly("lib.version");
+        renderFrame(tui);
+    }
+
+    @Test
+    void renderEmptyDepsView() {
+        MavenProject project = createProject("com.example", "app", "1.0", tempDir);
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        var tui = createTui(result, List.of(project));
+        tui.loading = false;
+        tui.buildDisplayRows();
+
+        renderFrame(tui);
+    }
+
+    @Test
+    void renderLoadingState() {
+        MavenProject project = createProject("com.example", "app", "1.0", tempDir);
+        project.getModel().addDependency(dep("com.example", "lib", "1.0"));
+        project.getOriginalModel().addDependency(dep("com.example", "lib", "1.0"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+        var tui = createTui(result, List.of(project));
+        tui.loading = true;
+        tui.loadedCount = 0;
+
+        renderFrame(tui);
+    }
+
+    @Test
+    void renderWithUngroupedDependency() throws IOException {
+        Path dir = subdir("render5");
+
+        MavenProject project = createProject("com.example", "app", "1.0", dir);
+        project.getModel().addDependency(dep("com.example", "lib", "1.0"));
+        project.getOriginalModel().addDependency(dep("com.example", "lib", "1.0"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+        var tui = createTui(result, List.of(project));
+
+        result.ungroupedDependencies.get(0).newestVersion = "1.0.1";
+        result.ungroupedDependencies.get(0).updateType = VersionComparator.UpdateType.PATCH;
+
+        tui.loading = false;
+        tui.buildDisplayRows();
+
+        renderFrame(tui);
+    }
+
+    @Test
+    void renderWithSelectedUngroupedDependency() throws IOException {
+        Path dir = subdir("render6");
+
+        MavenProject project = createProject("com.example", "app", "1.0", dir);
+        project.getModel().addDependency(dep("com.example", "lib", "1.0"));
+        project.getOriginalModel().addDependency(dep("com.example", "lib", "1.0"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+        var tui = createTui(result, List.of(project));
+
+        var dep = result.ungroupedDependencies.get(0);
+        dep.newestVersion = "2.0.0";
+        dep.updateType = VersionComparator.UpdateType.MAJOR;
+        dep.selected = true;
+
+        tui.loading = false;
+        tui.buildDisplayRows();
+
+        // detail pane for ungrouped dependency (no property info)
+        renderFrame(tui);
+    }
+
+    @Test
+    void renderPropertyGroupWithoutUpdate() throws IOException {
+        Path dir = subdir("render7");
+
+        MavenProject project = createProject("com.example", "app", "1.0", dir);
+        Properties props = new Properties();
+        props.setProperty("jackson.version", "2.17.0");
+        project.getOriginalModel().setProperties(props);
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        project.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-core", "${jackson.version}"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+        var tui = createTui(result, List.of(project));
+
+        // Dependency has update but group doesn't have a computed newest yet
+        result.allDependencies.get(0).newestVersion = "2.18.0";
+        result.allDependencies.get(0).updateType = VersionComparator.UpdateType.MINOR;
+        // Group has no newestVersion → group.hasUpdate() is false but deps do
+
+        tui.loading = false;
+        tui.buildDisplayRows();
+
+        if (!tui.displayRows.isEmpty()) {
+            renderFrame(tui);
+        }
+    }
+
+    @Test
+    void renderWithManagedDependencyScopes() throws IOException {
+        Path dir = subdir("render8");
+
+        MavenProject project = createProject("com.example", "app", "1.0", dir);
+        var d = dep("com.example", "lib", "1.0");
+        d.setScope("compile");
+        project.getModel().addDependency(d);
+        var od = dep("com.example", "lib", "1.0");
+        od.setScope("compile");
+        project.getOriginalModel().addDependency(od);
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+        var tui = createTui(result, List.of(project));
+
+        result.ungroupedDependencies.get(0).newestVersion = "1.1.0";
+        result.ungroupedDependencies.get(0).updateType = VersionComparator.UpdateType.MINOR;
+
+        tui.loading = false;
+        tui.buildDisplayRows();
+
+        renderFrame(tui);
     }
 }

--- a/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesTuiTest.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Properties;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.Model;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ReactorUpdatesTuiTest {
+
+    @TempDir
+    Path tempDir;
+
+    private Path subdir(String name) throws IOException {
+        return Files.createDirectories(tempDir.resolve(name));
+    }
+
+    private MavenProject createProject(String groupId, String artifactId, String version, Path basedir) {
+        Model model = new Model();
+        model.setGroupId(groupId);
+        model.setArtifactId(artifactId);
+        model.setVersion(version);
+
+        Model originalModel = new Model();
+        originalModel.setGroupId(groupId);
+        originalModel.setArtifactId(artifactId);
+        originalModel.setVersion(version);
+
+        MavenProject project = new MavenProject(model);
+        project.setOriginalModel(originalModel);
+        project.setFile(basedir.resolve("pom.xml").toFile());
+        return project;
+    }
+
+    private Dependency dep(String groupId, String artifactId, String version) {
+        Dependency d = new Dependency();
+        d.setGroupId(groupId);
+        d.setArtifactId(artifactId);
+        d.setVersion(version);
+        return d;
+    }
+
+    private ReactorUpdatesTui createTui(ReactorCollector.CollectionResult result, List<MavenProject> projects) {
+        ReactorModel model = ReactorModel.build(projects);
+        return new ReactorUpdatesTui(result, model, "com.example:app:1.0", (g, a) -> List.of());
+    }
+
+    @Test
+    void duplicatePropertyNamesDetected() throws IOException {
+        Path dir1 = subdir("parent");
+        Path dir2 = subdir("child");
+
+        MavenProject parent = createProject("com.example", "parent-bom", "1.0", dir1);
+        Properties parentProps = new Properties();
+        parentProps.setProperty("lib.version", "1.0");
+        parent.getOriginalModel().setProperties(parentProps);
+        parent.getModel().addDependency(dep("com.example", "lib-a", "1.0"));
+        parent.getOriginalModel().addDependency(dep("com.example", "lib-a", "${lib.version}"));
+
+        MavenProject child = createProject("com.example", "child-bom", "1.0", dir2);
+        Properties childProps = new Properties();
+        childProps.setProperty("lib.version", "2.0");
+        child.getOriginalModel().setProperties(childProps);
+        child.getModel().addDependency(dep("com.example", "lib-b", "2.0"));
+        child.getOriginalModel().addDependency(dep("com.example", "lib-b", "${lib.version}"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(parent, child));
+        assertThat(result.propertyGroups).hasSize(2);
+
+        var tui = createTui(result, List.of(parent, child));
+
+        // Set up updates so groups appear in display rows
+        for (var dep : result.allDependencies) {
+            dep.newestVersion = "3.0";
+            dep.updateType = VersionComparator.UpdateType.MAJOR;
+        }
+        for (var group : result.propertyGroups) {
+            group.newestVersion = "3.0";
+            group.updateType = VersionComparator.UpdateType.MAJOR;
+        }
+
+        tui.buildDisplayRows();
+
+        assertThat(tui.duplicatePropertyNames).containsExactly("lib.version");
+    }
+
+    @Test
+    void noDuplicatesWhenPropertyNamesAreUnique() throws IOException {
+        Path dir1 = subdir("mod1");
+        Path dir2 = subdir("mod2");
+
+        MavenProject p1 = createProject("com.example", "mod1", "1.0", dir1);
+        Properties props1 = new Properties();
+        props1.setProperty("jackson.version", "2.17.0");
+        p1.getOriginalModel().setProperties(props1);
+        p1.getModel().addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        p1.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-core", "${jackson.version}"));
+
+        MavenProject p2 = createProject("com.example", "mod2", "1.0", dir2);
+        Properties props2 = new Properties();
+        props2.setProperty("slf4j.version", "2.0.9");
+        p2.getOriginalModel().setProperties(props2);
+        p2.getModel().addDependency(dep("org.slf4j", "slf4j-api", "2.0.9"));
+        p2.getOriginalModel().addDependency(dep("org.slf4j", "slf4j-api", "${slf4j.version}"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(p1, p2));
+
+        var tui = createTui(result, List.of(p1, p2));
+
+        for (var dep : result.allDependencies) {
+            dep.newestVersion = "3.0";
+            dep.updateType = VersionComparator.UpdateType.MAJOR;
+        }
+        for (var group : result.propertyGroups) {
+            group.newestVersion = "3.0";
+            group.updateType = VersionComparator.UpdateType.MAJOR;
+        }
+
+        tui.buildDisplayRows();
+
+        assertThat(tui.duplicatePropertyNames).isEmpty();
+    }
+
+    @Test
+    void buildDisplayRowsCreatesGroupHeadersAndDeps() throws IOException {
+        Path dir = subdir("project");
+
+        MavenProject project = createProject("com.example", "app", "1.0", dir);
+        Properties props = new Properties();
+        props.setProperty("jackson.version", "2.17.0");
+        project.getOriginalModel().setProperties(props);
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-databind", "2.17.0"));
+        project.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-core", "${jackson.version}"));
+        project.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-databind", "${jackson.version}"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+        assertThat(result.propertyGroups).hasSize(1);
+        assertThat(result.propertyGroups.get(0).dependencies).hasSize(2);
+
+        var tui = createTui(result, List.of(project));
+
+        for (var dep : result.allDependencies) {
+            dep.newestVersion = "2.18.0";
+            dep.updateType = VersionComparator.UpdateType.MINOR;
+        }
+        result.propertyGroups.get(0).newestVersion = "2.18.0";
+        result.propertyGroups.get(0).updateType = VersionComparator.UpdateType.MINOR;
+
+        tui.buildDisplayRows();
+
+        // 1 group header + 2 dependencies
+        assertThat(tui.displayRows).hasSize(3);
+        assertThat(tui.displayRows.get(0).isGroupHeader()).isTrue();
+        assertThat(tui.displayRows.get(0).propertyGroup.propertyName).isEqualTo("jackson.version");
+        assertThat(tui.displayRows.get(1).isGroupHeader()).isFalse();
+        assertThat(tui.displayRows.get(2).isGroupHeader()).isFalse();
+    }
+
+    @Test
+    void buildDisplayRowsEmptyWhenNoUpdates() {
+        MavenProject project = createProject("com.example", "app", "1.0", tempDir);
+        project.getModel().addDependency(dep("com.example", "lib", "1.0"));
+        project.getOriginalModel().addDependency(dep("com.example", "lib", "1.0"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        var tui = createTui(result, List.of(project));
+        tui.buildDisplayRows();
+
+        assertThat(tui.displayRows).isEmpty();
+    }
+
+    @Test
+    void showDetailsDefaultsToTrue() {
+        MavenProject project = createProject("com.example", "app", "1.0", tempDir);
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        var tui = createTui(result, List.of(project));
+
+        assertThat(tui.showDetails).isTrue();
+    }
+
+    @Test
+    void showDetailsCanBeToggled() {
+        MavenProject project = createProject("com.example", "app", "1.0", tempDir);
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        var tui = createTui(result, List.of(project));
+
+        assertThat(tui.showDetails).isTrue();
+        tui.showDetails = !tui.showDetails;
+        assertThat(tui.showDetails).isFalse();
+        tui.showDetails = !tui.showDetails;
+        assertThat(tui.showDetails).isTrue();
+    }
+
+    @Test
+    void updateStatusIfDoneComputesPropertyGroupUpdates() throws IOException {
+        Path dir = subdir("project2");
+
+        MavenProject project = createProject("com.example", "app", "1.0", dir);
+        Properties props = new Properties();
+        props.setProperty("jackson.version", "2.17.0");
+        project.getOriginalModel().setProperties(props);
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        project.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-core", "${jackson.version}"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        var tui = createTui(result, List.of(project));
+
+        // Simulate version resolution for the dependency
+        var dep = result.allDependencies.get(0);
+        dep.newestVersion = "2.18.0";
+        dep.updateType = VersionComparator.UpdateType.MINOR;
+
+        tui.loadedCount = result.allDependencies.size();
+        tui.loading = true;
+
+        // The status message should reflect updates
+        assertThat(dep.hasUpdate()).isTrue();
+        assertThat(result.propertyGroups.get(0).dependencies).contains(dep);
+    }
+
+    @Test
+    void buildDisplayRowsWithFilterShowsOnlyMatchingUpdateType() throws IOException {
+        Path dir = subdir("project3");
+
+        MavenProject project = createProject("com.example", "app", "1.0", dir);
+
+        // Direct dependency (ungrouped)
+        project.getModel().addDependency(dep("com.example", "lib-a", "1.0"));
+        project.getOriginalModel().addDependency(dep("com.example", "lib-a", "1.0"));
+        project.getModel().addDependency(dep("com.example", "lib-b", "1.0"));
+        project.getOriginalModel().addDependency(dep("com.example", "lib-b", "1.0"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+
+        var tui = createTui(result, List.of(project));
+
+        // Give lib-a a PATCH update
+        result.ungroupedDependencies.get(0).newestVersion = "1.0.1";
+        result.ungroupedDependencies.get(0).updateType = VersionComparator.UpdateType.PATCH;
+
+        // Give lib-b a MAJOR update
+        result.ungroupedDependencies.get(1).newestVersion = "2.0.0";
+        result.ungroupedDependencies.get(1).updateType = VersionComparator.UpdateType.MAJOR;
+
+        // Default filter: ALL - should show both
+        tui.buildDisplayRows();
+        assertThat(tui.displayRows).hasSize(2);
+    }
+
+    @Test
+    void duplicatePropertyNamesFromSameOriginNotDetectedAsDuplicate() throws IOException {
+        Path dir = subdir("single");
+
+        MavenProject project = createProject("com.example", "app", "1.0", dir);
+        Properties props = new Properties();
+        props.setProperty("jackson.version", "2.17.0");
+        project.getOriginalModel().setProperties(props);
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-core", "2.17.0"));
+        project.getModel().addDependency(dep("com.fasterxml", "jackson-databind", "2.17.0"));
+        project.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-core", "${jackson.version}"));
+        project.getOriginalModel().addDependency(dep("com.fasterxml", "jackson-databind", "${jackson.version}"));
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+        // Same property from same origin → only 1 group
+        assertThat(result.propertyGroups).hasSize(1);
+
+        var tui = createTui(result, List.of(project));
+
+        result.propertyGroups.get(0).newestVersion = "2.18.0";
+        result.propertyGroups.get(0).updateType = VersionComparator.UpdateType.MINOR;
+        for (var dep : result.allDependencies) {
+            dep.newestVersion = "2.18.0";
+            dep.updateType = VersionComparator.UpdateType.MINOR;
+        }
+
+        tui.buildDisplayRows();
+
+        // Same property name from same origin → not a duplicate
+        assertThat(tui.duplicatePropertyNames).isEmpty();
+    }
+
+    @Test
+    void reactorRowIsGroupHeader() {
+        var group = new ReactorCollector.PropertyGroup("lib.version", "${lib.version}", "1.0", null);
+        var row = ReactorUpdatesTui.ReactorRow.group(group);
+        assertThat(row.isGroupHeader()).isTrue();
+        assertThat(row.propertyGroup).isSameAs(group);
+        assertThat(row.dependency).isNull();
+    }
+
+    @Test
+    void reactorRowIsDependency() {
+        var dep = new ReactorCollector.AggregatedDependency("g", "a");
+        var row = ReactorUpdatesTui.ReactorRow.dep(dep);
+        assertThat(row.isGroupHeader()).isFalse();
+        assertThat(row.dependency).isSameAs(dep);
+        assertThat(row.propertyGroup).isNull();
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesTuiTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesTuiTest.java
@@ -19,9 +19,11 @@
 package eu.maveniverse.maven.pilot;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import dev.tamboui.terminal.Terminal;
 import dev.tamboui.terminal.TestBackend;
+import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -74,8 +76,10 @@ class ReactorUpdatesTuiTest {
     }
 
     private void renderFrame(ReactorUpdatesTui tui) {
-        var terminal = new Terminal<>(new TestBackend(120, 30));
-        terminal.draw(tui::render);
+        assertThatNoException().isThrownBy(() -> {
+            var terminal = new Terminal<>(new TestBackend(120, 30));
+            terminal.draw(tui::render);
+        });
     }
 
     @Test
@@ -412,13 +416,9 @@ class ReactorUpdatesTuiTest {
 
         // Select row 1 = dependency under the group → detail pane shows dep info
         assertThat(tui.displayRows).hasSizeGreaterThanOrEqualTo(2);
-        var terminal = new Terminal<>(new TestBackend(120, 30));
-        // Move selection to the dependency row
-        terminal.draw(frame -> {
-            // Manually select the dependency row before rendering
-            tui.displayRows.get(1); // just verify it exists
-            tui.render(frame);
-        });
+        // Move selection down to the dependency row via key handler
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.DOWN), null);
+        renderFrame(tui);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Disambiguate duplicate property names**: When the same property name (e.g., `maven-core.version`) is defined in multiple POMs within the reactor, the origin module's artifactId is appended: `${maven-core.version} (quarkus-bom)` vs `${maven-core.version} (quarkus-core)`
- **Add detail pane**: A toggleable detail pane (30% of content area, press `i`) shows context-sensitive information about the currently selected row:
  - **Property groups**: origin POM path, version with update arrow, managed artifacts list, module count
  - **Dependencies**: full GAV coordinates, scope(s), managed vs direct, update info, modules using this dependency, property origin

Closes #51

## Changes

### `ReactorUpdatesTui.java` (+184/-7)
- Added `computeDuplicatePropertyNames()` static helper to detect property names appearing in multiple POMs
- Added `renderDetailPane()` with extracted `buildGroupDetailRows()` and `buildDependencyDetailRows()` helpers
- Modified `createReactorRow()` to append origin artifactId when property name is duplicated
- Added `i` key binding to toggle detail pane visibility
- Conditional 4-zone layout: header, main table, detail pane (when visible), footer

### `ReactorUpdatesTuiTest.java` (new, 602 lines)
- 11 logic tests: duplicate detection, display row building, ReactorRow factories, filter by update type, toggle via key handler, `updateStatusIfDone()` integration
- 10 rendering tests using TamboUI's `TestBackend` for headless rendering coverage

## Test plan

- [x] 323 tests pass (0 failures, 12 skipped) on Java 17, 21, 25
- [x] SonarCloud quality gate passed (84.1% coverage on new code)
- [x] All CodeRabbit review threads resolved
- [ ] Manual: open a multi-module reactor with duplicate property names and verify disambiguation
- [ ] Manual: press `i` to toggle the detail pane on/off
- [ ] Manual: navigate rows and verify detail pane updates with selection
- [ ] Manual: verify overlays (help `h`, diff `d`) hide the detail pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_