### PR TITLE
Fix #52: standardize tab rendering with shared TabBar helper

### DIFF
--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -358,11 +358,7 @@ class AuditTui {
         }
 
         if (key.isKey(KeyCode.TAB)) {
-            view = switch (view) {
-                case LICENSES -> View.BY_LICENSE;
-                case BY_LICENSE -> View.VULNERABILITIES;
-                case VULNERABILITIES -> View.LICENSES;
-            };
+            view = TabBar.next(view, View.values());
             return true;
         }
 
@@ -531,16 +527,15 @@ class AuditTui {
         if (dirty) {
             spans.add(Span.raw("  [modified]").fg(Color.YELLOW));
         }
-        spans.add(Span.raw("  "));
-        spans.add(Span.raw("[" + (view == View.LICENSES ? "\u25B8 " : "  ") + "Licenses]")
-                .fg(view == View.LICENSES ? Color.YELLOW : Color.DARK_GRAY));
-        spans.add(Span.raw("  "));
-        spans.add(Span.raw("[" + (view == View.BY_LICENSE ? "\u25B8 " : "  ") + "By License]")
-                .fg(view == View.BY_LICENSE ? Color.YELLOW : Color.DARK_GRAY));
-        spans.add(Span.raw("  "));
-        spans.add(Span.raw("[" + (view == View.VULNERABILITIES ? "\u25B8 " : "  ") + "Vulnerabilities"
-                        + (vulnCount > 0 ? " (" + vulnCount + ")" : "") + "]")
-                .fg(view == View.VULNERABILITIES ? (vulnCount > 0 ? Color.RED : Color.YELLOW) : Color.DARK_GRAY));
+        spans.addAll(TabBar.render(
+                view,
+                View.values(),
+                v -> switch (v) {
+                    case LICENSES -> "Licenses";
+                    case BY_LICENSE -> "By License";
+                    case VULNERABILITIES -> "Vulnerabilities" + (vulnCount > 0 ? " (" + vulnCount + ")" : "");
+                },
+                v -> v == View.VULNERABILITIES && vulnCount > 0 ? Color.RED : Color.YELLOW));
 
         Paragraph header = Paragraph.builder()
                 .text(dev.tamboui.text.Text.from(Line.from(spans)))

--- a/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -89,6 +89,8 @@ class AuditTui {
         }
     }
 
+    private static final String HIGHLIGHT_SYMBOL = "\u25B8 ";
+
     private enum View {
         LICENSES,
         BY_LICENSE,
@@ -575,7 +577,7 @@ class AuditTui {
                         Constraint.percentage(40), Constraint.percentage(15),
                         Constraint.percentage(30), Constraint.percentage(15))
                 .highlightStyle(Style.create().reversed().bold())
-                .highlightSymbol("\u25B8 ")
+                .highlightSymbol(HIGHLIGHT_SYMBOL)
                 .block(block)
                 .build();
 
@@ -720,7 +722,7 @@ class AuditTui {
         List<Row> rows = new ArrayList<>();
         for (var row : byLicenseRows) {
             if (row.isGroup()) {
-                String arrow = row.expanded ? "\u25BE " : "\u25B8 ";
+                String arrow = row.expanded ? "\u25BE " : HIGHLIGHT_SYMBOL;
                 String label = arrow + row.licenseName + " (" + row.deps.size() + ")";
                 rows.add(Row.from(label, "", "", "")
                         .style(getLicenseStyle("(not specified)".equals(row.licenseName) ? null : row.licenseName)
@@ -741,7 +743,7 @@ class AuditTui {
                         Constraint.percentage(55), Constraint.percentage(20),
                         Constraint.percentage(15), Constraint.percentage(10))
                 .highlightStyle(Style.create().reversed().bold())
-                .highlightSymbol("\u25B8 ")
+                .highlightSymbol(HIGHLIGHT_SYMBOL)
                 .block(block)
                 .build();
 
@@ -861,7 +863,7 @@ class AuditTui {
                         Constraint.percentage(30), Constraint.percentage(18),
                         Constraint.percentage(10), Constraint.percentage(42))
                 .highlightStyle(Style.create().reversed().bold())
-                .highlightSymbol("\u25B8 ")
+                .highlightSymbol(HIGHLIGHT_SYMBOL)
                 .block(block)
                 .build();
 

--- a/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -359,7 +359,7 @@ class DependenciesTui {
         }
 
         if (key.isKey(KeyCode.TAB)) {
-            view = (view == View.DECLARED) ? View.TRANSITIVE : View.DECLARED;
+            view = TabBar.next(view, View.values());
             tableState.select(0);
             return true;
         }
@@ -729,32 +729,22 @@ class DependenciesTui {
 
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" " + projectGav).bold().cyan());
-        spans.add(Span.raw("  "));
-
-        String declaredLabel = "Declared: " + declared.size();
-        if (bytecodeAnalyzed) {
-            long unused = declared.stream()
-                    .filter(d -> d.usageStatus == DependencyUsageAnalyzer.UsageStatus.UNUSED)
-                    .count();
-            if (unused > 0) {
-                declaredLabel += " (" + unused + " unused)";
-            }
-        }
-        spans.add(Span.raw("[" + (view == View.DECLARED ? HIGHLIGHT_SYMBOL : "  ") + declaredLabel + "]")
-                .fg(view == View.DECLARED ? Color.YELLOW : Color.DARK_GRAY));
-        spans.add(Span.raw("  "));
-
-        String transitiveLabel = "Transitive: " + transitive.size();
-        if (bytecodeAnalyzed) {
-            long used = transitive.stream()
-                    .filter(d -> d.usageStatus == DependencyUsageAnalyzer.UsageStatus.USED)
-                    .count();
-            if (used > 0) {
-                transitiveLabel += " (" + used + " used)";
-            }
-        }
-        spans.add(Span.raw("[" + (view == View.TRANSITIVE ? HIGHLIGHT_SYMBOL : "  ") + transitiveLabel + "]")
-                .fg(view == View.TRANSITIVE ? Color.YELLOW : Color.DARK_GRAY));
+        long unused = bytecodeAnalyzed
+                ? declared.stream()
+                        .filter(d -> d.usageStatus == DependencyUsageAnalyzer.UsageStatus.UNUSED)
+                        .count()
+                : 0;
+        long used = bytecodeAnalyzed
+                ? transitive.stream()
+                        .filter(d -> d.usageStatus == DependencyUsageAnalyzer.UsageStatus.USED)
+                        .count()
+                : 0;
+        String declaredLabel = "Declared: " + declared.size() + (unused > 0 ? " (" + unused + " unused)" : "");
+        String transitiveLabel = "Transitive: " + transitive.size() + (used > 0 ? " (" + used + " used)" : "");
+        spans.addAll(TabBar.render(view, View.values(), v -> switch (v) {
+            case DECLARED -> declaredLabel;
+            case TRANSITIVE -> transitiveLabel;
+        }));
 
         if (dirty) {
             spans.add(Span.raw("  [modified]").fg(Color.YELLOW));

--- a/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
@@ -203,7 +203,7 @@ class PomTui {
         }
 
         if (key.isKey(KeyCode.TAB)) {
-            view = (view == View.RAW) ? View.EFFECTIVE : View.RAW;
+            view = TabBar.next(view, View.values());
             tableState.select(0);
             activeSearch = null;
             searchMatches = List.of();
@@ -467,14 +467,10 @@ class PomTui {
                 .build();
 
         List<Span> spans = new ArrayList<>();
-        spans.add(Span.raw(" "));
-
-        // View tabs
-        spans.add(Span.raw("[" + (view == View.RAW ? "\u25B8 " : "  ") + "Raw POM]")
-                .fg(view == View.RAW ? Color.YELLOW : Color.DARK_GRAY));
-        spans.add(Span.raw("  "));
-        spans.add(Span.raw("[" + (view == View.EFFECTIVE ? "\u25B8 " : "  ") + "Effective POM]")
-                .fg(view == View.EFFECTIVE ? Color.YELLOW : Color.DARK_GRAY));
+        spans.addAll(TabBar.render(view, View.values(), v -> switch (v) {
+            case RAW -> "Raw POM";
+            case EFFECTIVE -> "Effective POM";
+        }));
 
         if (searchMode) {
             spans.add(Span.raw("   Search: ").fg(Color.YELLOW));

--- a/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -306,7 +306,7 @@ class ReactorUpdatesTui {
         }
 
         if (key.isKey(KeyCode.TAB)) {
-            view = view == View.DEPENDENCIES ? View.MODULES : View.DEPENDENCIES;
+            view = TabBar.next(view, View.values());
             return true;
         }
 
@@ -665,7 +665,7 @@ class ReactorUpdatesTui {
 
     void render(Frame frame) {
         var zones = Layout.vertical()
-                .constraints(Constraint.length(3), Constraint.fill(), Constraint.length(4))
+                .constraints(Constraint.length(3), Constraint.fill(), Constraint.length(3))
                 .split(frame.area());
 
         renderHeader(frame, zones.get(0));
@@ -692,6 +692,10 @@ class ReactorUpdatesTui {
 
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" " + projectGav).bold().cyan());
+        spans.addAll(TabBar.render(view, View.values(), v -> switch (v) {
+            case DEPENDENCIES -> "Dependencies";
+            case MODULES -> "Modules";
+        }));
         spans.add(Span.raw("  (" + reactorModel.allModules.size() + " modules)").dim());
         if (loading) {
             spans.add(Span.raw("  Checking " + loadedCount + "/" + reactorResult.allDependencies.size() + "\u2026")
@@ -861,26 +865,12 @@ class ReactorUpdatesTui {
 
     private void renderInfoBar(Frame frame, Rect area) {
         var rows = Layout.vertical()
-                .constraints(Constraint.length(1), Constraint.length(1), Constraint.length(1), Constraint.length(1))
+                .constraints(Constraint.length(1), Constraint.length(1), Constraint.length(1))
                 .split(area);
-
-        // View indicator
-        List<Span> viewSpans = new ArrayList<>();
-        viewSpans.add(Span.raw(" "));
-        viewSpans.add(
-                view == View.DEPENDENCIES
-                        ? Span.raw("[Dependencies]").bold().cyan()
-                        : Span.raw(" Dependencies ").dim());
-        viewSpans.add(Span.raw(" "));
-        viewSpans.add(
-                view == View.MODULES
-                        ? Span.raw("[Modules]").bold().cyan()
-                        : Span.raw(" Modules ").dim());
-        frame.renderWidget(Paragraph.from(Line.from(viewSpans)), rows.get(0));
 
         // Status
         frame.renderWidget(
-                Paragraph.from(Line.from(List.of(Span.raw(" " + status).fg(Color.GREEN)))), rows.get(1));
+                Paragraph.from(Line.from(List.of(Span.raw(" " + status).fg(Color.GREEN)))), rows.get(0));
 
         // Selected count
         long selectedCount = reactorResult.allDependencies.stream()
@@ -890,7 +880,7 @@ class ReactorUpdatesTui {
             frame.renderWidget(
                     Paragraph.from(Line.from(List.of(Span.raw(" " + selectedCount + " update(s) selected")
                             .fg(Color.CYAN)))),
-                    rows.get(2));
+                    rows.get(1));
         }
 
         // Key bindings
@@ -935,7 +925,7 @@ class ReactorUpdatesTui {
             spans.add(Span.raw(":Quit"));
         }
 
-        frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(3));
+        frame.renderWidget(Paragraph.from(Line.from(spans)), rows.get(2));
     }
 
     private List<HelpOverlay.Section> buildHelp() {

--- a/src/main/java/eu/maveniverse/maven/pilot/TabBar.java
+++ b/src/main/java/eu/maveniverse/maven/pilot/TabBar.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import dev.tamboui.style.Color;
+import dev.tamboui.text.Span;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Shared tab bar rendering and cycling for TUI views.
+ */
+class TabBar {
+
+    private TabBar() {}
+
+    /**
+     * Render tab indicators for the given views using the default active color (YELLOW).
+     */
+    static <V extends Enum<V>> List<Span> render(V currentView, V[] allViews, Function<V, String> labelFn) {
+        return render(currentView, allViews, labelFn, v -> Color.YELLOW);
+    }
+
+    /**
+     * Render tab indicators with a custom active color per view.
+     */
+    static <V extends Enum<V>> List<Span> render(
+            V currentView, V[] allViews, Function<V, String> labelFn, Function<V, Color> activeColorFn) {
+        List<Span> spans = new ArrayList<>();
+        for (V v : allViews) {
+            spans.add(Span.raw("  "));
+            boolean active = v == currentView;
+            String label = labelFn.apply(v);
+            Color fg = active ? activeColorFn.apply(v) : Color.DARK_GRAY;
+            spans.add(Span.raw("[" + (active ? "\u25B8 " : "  ") + label + "]").fg(fg));
+        }
+        return spans;
+    }
+
+    /**
+     * Cycle to the next enum value, wrapping around from last to first.
+     */
+    static <V extends Enum<V>> V next(V current, V[] values) {
+        return values[(current.ordinal() + 1) % values.length];
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/AuditDemoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AuditDemoTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import dev.tamboui.layout.Size;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.pilot.Pilot;
+import dev.tamboui.tui.pilot.TuiTestRunner;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class AuditDemoTest {
+
+    @Test
+    void browseAndSwitchViews(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
+
+        List<AuditTui.AuditEntry> entries = new ArrayList<>();
+        var e1 = new AuditTui.AuditEntry("org.slf4j", "slf4j-api", "2.0.9", "compile");
+        e1.license = "MIT";
+        e1.licenseLoaded = true;
+        e1.vulnsLoaded = true;
+        e1.vulnerabilities = List.of();
+        entries.add(e1);
+
+        var e2 = new AuditTui.AuditEntry("com.google.guava", "guava", "33.0.0-jre", "compile");
+        e2.license = "Apache-2.0";
+        e2.licenseLoaded = true;
+        e2.vulnsLoaded = true;
+        e2.vulnerabilities = List.of();
+        entries.add(e2);
+
+        AuditTui tui = new AuditTui(entries, "com.example:demo:1.0.0", null, pomPath);
+
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+
+            // Switch to By License view
+            pilot.press(KeyCode.TAB);
+            pilot.pause();
+
+            // Switch to Vulnerabilities view
+            pilot.press(KeyCode.TAB);
+            pilot.pause();
+
+            // Switch back to Licenses view
+            pilot.press(KeyCode.TAB);
+            pilot.pause();
+
+            pilot.press('q');
+        }
+    }
+
+    @Test
+    void emptyEntries(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
+
+        AuditTui tui = new AuditTui(new ArrayList<>(), "com.example:demo:1.0.0", null, pomPath);
+
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+
+            // Switch views on empty data
+            pilot.press(KeyCode.TAB);
+            pilot.pause();
+
+            pilot.press('q');
+        }
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/AuditDemoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AuditDemoTest.java
@@ -18,7 +18,12 @@
  */
 package eu.maveniverse.maven.pilot;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tamboui.export.ExportRequest;
 import dev.tamboui.layout.Size;
+import dev.tamboui.terminal.Terminal;
+import dev.tamboui.terminal.TestBackend;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.pilot.Pilot;
 import dev.tamboui.tui.pilot.TuiTestRunner;
@@ -30,6 +35,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class AuditDemoTest {
+
+    private static final int WIDTH = 100;
+    private static final int HEIGHT = 24;
+
+    private String renderToText(dev.tamboui.tui.Renderer renderer) {
+        var terminal = new Terminal<>(new TestBackend(WIDTH, HEIGHT));
+        var frame = terminal.draw(renderer::render);
+        return ExportRequest.export(frame.buffer()).text().toString();
+    }
 
     @Test
     void browseAndSwitchViews(@TempDir Path tempDir) throws Exception {
@@ -53,21 +67,34 @@ class AuditDemoTest {
 
         AuditTui tui = new AuditTui(entries, "com.example:demo:1.0.0", null, pomPath);
 
-        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(WIDTH, HEIGHT))) {
             Pilot pilot = testRunner.pilot();
             pilot.pause();
+
+            // Initial view: Licenses tab
+            String rendered = renderToText(tui::render);
+            assertThat(rendered).contains("Licenses");
 
             // Switch to By License view
             pilot.press(KeyCode.TAB);
             pilot.pause();
 
+            rendered = renderToText(tui::render);
+            assertThat(rendered).contains("By License");
+
             // Switch to Vulnerabilities view
             pilot.press(KeyCode.TAB);
             pilot.pause();
 
+            rendered = renderToText(tui::render);
+            assertThat(rendered).contains("Vulnerabilities");
+
             // Switch back to Licenses view
             pilot.press(KeyCode.TAB);
             pilot.pause();
+
+            rendered = renderToText(tui::render);
+            assertThat(rendered).contains("Licenses");
 
             pilot.press('q');
         }
@@ -80,13 +107,20 @@ class AuditDemoTest {
 
         AuditTui tui = new AuditTui(new ArrayList<>(), "com.example:demo:1.0.0", null, pomPath);
 
-        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(WIDTH, HEIGHT))) {
             Pilot pilot = testRunner.pilot();
             pilot.pause();
+
+            // Verify tab bar renders even with empty data
+            String rendered = renderToText(tui::render);
+            assertThat(rendered).contains("Licenses");
 
             // Switch views on empty data
             pilot.press(KeyCode.TAB);
             pilot.pause();
+
+            rendered = renderToText(tui::render);
+            assertThat(rendered).contains("By License");
 
             pilot.press('q');
         }

--- a/src/test/java/eu/maveniverse/maven/pilot/AuditDemoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/AuditDemoTest.java
@@ -71,30 +71,35 @@ class AuditDemoTest {
             Pilot pilot = testRunner.pilot();
             pilot.pause();
 
-            // Initial view: Licenses tab
+            // Initial view: Licenses tab active
             String rendered = renderToText(tui::render);
-            assertThat(rendered).contains("Licenses");
+            assertThat(rendered).contains("\u25B8 Licenses");
+            assertThat(rendered).doesNotContain("\u25B8 By License");
+            assertThat(rendered).doesNotContain("\u25B8 Vulnerabilities");
 
             // Switch to By License view
             pilot.press(KeyCode.TAB);
             pilot.pause();
 
             rendered = renderToText(tui::render);
-            assertThat(rendered).contains("By License");
+            assertThat(rendered).contains("\u25B8 By License");
+            assertThat(rendered).doesNotContain("\u25B8 Licenses");
 
             // Switch to Vulnerabilities view
             pilot.press(KeyCode.TAB);
             pilot.pause();
 
             rendered = renderToText(tui::render);
-            assertThat(rendered).contains("Vulnerabilities");
+            assertThat(rendered).contains("\u25B8 Vulnerabilities");
+            assertThat(rendered).doesNotContain("\u25B8 By License");
 
             // Switch back to Licenses view
             pilot.press(KeyCode.TAB);
             pilot.pause();
 
             rendered = renderToText(tui::render);
-            assertThat(rendered).contains("Licenses");
+            assertThat(rendered).contains("\u25B8 Licenses");
+            assertThat(rendered).doesNotContain("\u25B8 Vulnerabilities");
 
             pilot.press('q');
         }
@@ -113,14 +118,16 @@ class AuditDemoTest {
 
             // Verify tab bar renders even with empty data
             String rendered = renderToText(tui::render);
-            assertThat(rendered).contains("Licenses");
+            assertThat(rendered).contains("\u25B8 Licenses");
+            assertThat(rendered).doesNotContain("\u25B8 By License");
 
             // Switch views on empty data
             pilot.press(KeyCode.TAB);
             pilot.pause();
 
             rendered = renderToText(tui::render);
-            assertThat(rendered).contains("By License");
+            assertThat(rendered).contains("\u25B8 By License");
+            assertThat(rendered).doesNotContain("\u25B8 Licenses");
 
             pilot.press('q');
         }

--- a/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesDemoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesDemoTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static eu.maveniverse.maven.pilot.TestProjects.createProject;
+
+import dev.tamboui.layout.Size;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.pilot.Pilot;
+import dev.tamboui.tui.pilot.TuiTestRunner;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ReactorUpdatesDemoTest {
+
+    @Test
+    void browseAndSwitchViews(@TempDir java.nio.file.Path tempDir) throws Exception {
+        var root = createProject("parent", tempDir);
+        var model = ReactorModel.build(List.of(root));
+        var result = new ReactorCollector.CollectionResult(new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+
+        ReactorUpdatesTui tui = new ReactorUpdatesTui(result, model, "com.example:parent:1.0", (g, a) -> List.of());
+        // Mark loading as done since we have no deps to resolve
+        tui.loading = false;
+        tui.status = "No updates";
+
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
+            Pilot pilot = testRunner.pilot();
+            pilot.pause();
+
+            // Switch to Modules view
+            pilot.press(KeyCode.TAB);
+            pilot.pause();
+
+            // Switch back to Dependencies view
+            pilot.press(KeyCode.TAB);
+            pilot.pause();
+
+            pilot.press('q');
+        }
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesDemoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesDemoTest.java
@@ -19,8 +19,12 @@
 package eu.maveniverse.maven.pilot;
 
 import static eu.maveniverse.maven.pilot.TestProjects.createProject;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tamboui.export.ExportRequest;
 import dev.tamboui.layout.Size;
+import dev.tamboui.terminal.Terminal;
+import dev.tamboui.terminal.TestBackend;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.pilot.Pilot;
 import dev.tamboui.tui.pilot.TuiTestRunner;
@@ -30,6 +34,15 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class ReactorUpdatesDemoTest {
+
+    private static final int WIDTH = 100;
+    private static final int HEIGHT = 24;
+
+    private String renderToText(dev.tamboui.tui.Renderer renderer) {
+        var terminal = new Terminal<>(new TestBackend(WIDTH, HEIGHT));
+        var frame = terminal.draw(renderer::render);
+        return ExportRequest.export(frame.buffer()).text().toString();
+    }
 
     @Test
     void browseAndSwitchViews(@TempDir java.nio.file.Path tempDir) throws Exception {
@@ -42,17 +55,27 @@ class ReactorUpdatesDemoTest {
         tui.loading = false;
         tui.status = "No updates";
 
-        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(100, 24))) {
+        try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::render, new Size(WIDTH, HEIGHT))) {
             Pilot pilot = testRunner.pilot();
             pilot.pause();
+
+            // Initial view should show Dependencies tab active
+            String rendered = renderToText(tui::render);
+            assertThat(rendered).contains("Dependencies");
 
             // Switch to Modules view
             pilot.press(KeyCode.TAB);
             pilot.pause();
 
+            rendered = renderToText(tui::render);
+            assertThat(rendered).contains("Modules");
+
             // Switch back to Dependencies view
             pilot.press(KeyCode.TAB);
             pilot.pause();
+
+            rendered = renderToText(tui::render);
+            assertThat(rendered).contains("Dependencies");
 
             pilot.press('q');
         }

--- a/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesDemoTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/ReactorUpdatesDemoTest.java
@@ -61,21 +61,24 @@ class ReactorUpdatesDemoTest {
 
             // Initial view should show Dependencies tab active
             String rendered = renderToText(tui::render);
-            assertThat(rendered).contains("Dependencies");
+            assertThat(rendered).contains("\u25B8 Dependencies");
+            assertThat(rendered).doesNotContain("\u25B8 Modules");
 
             // Switch to Modules view
             pilot.press(KeyCode.TAB);
             pilot.pause();
 
             rendered = renderToText(tui::render);
-            assertThat(rendered).contains("Modules");
+            assertThat(rendered).contains("\u25B8 Modules");
+            assertThat(rendered).doesNotContain("\u25B8 Dependencies");
 
             // Switch back to Dependencies view
             pilot.press(KeyCode.TAB);
             pilot.pause();
 
             rendered = renderToText(tui::render);
-            assertThat(rendered).contains("Dependencies");
+            assertThat(rendered).contains("\u25B8 Dependencies");
+            assertThat(rendered).doesNotContain("\u25B8 Modules");
 
             pilot.press('q');
         }

--- a/src/test/java/eu/maveniverse/maven/pilot/TabBarTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/TabBarTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tamboui.style.Color;
+import dev.tamboui.text.Span;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TabBarTest {
+
+    private enum TwoTabs {
+        FIRST,
+        SECOND
+    }
+
+    private enum ThreeTabs {
+        A,
+        B,
+        C
+    }
+
+    @Test
+    void renderProducesCorrectSpanCount() {
+        List<Span> spans = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), v -> v.name());
+        // 2 tabs * 2 spans each (separator + tab label) = 4
+        assertThat(spans).hasSize(4);
+    }
+
+    @Test
+    void renderThreeTabsProducesCorrectSpanCount() {
+        List<Span> spans = TabBar.render(ThreeTabs.A, ThreeTabs.values(), v -> v.name());
+        // 3 tabs * 2 spans each = 6
+        assertThat(spans).hasSize(6);
+    }
+
+    @Test
+    void renderActiveTabHasIndicator() {
+        List<Span> spans = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), v -> switch (v) {
+            case FIRST -> "First";
+            case SECOND -> "Second";
+        });
+        // spans[1] is the first tab label (spans[0] is separator)
+        assertThat(spans.get(1).content()).contains("\u25B8 ");
+        assertThat(spans.get(1).content()).contains("First");
+    }
+
+    @Test
+    void renderInactiveTabHasNoIndicator() {
+        List<Span> spans = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), v -> switch (v) {
+            case FIRST -> "First";
+            case SECOND -> "Second";
+        });
+        // spans[3] is the second tab label (inactive)
+        assertThat(spans.get(3).content()).doesNotContain("\u25B8");
+        assertThat(spans.get(3).content()).contains("Second");
+    }
+
+    @Test
+    void renderWithCustomActiveColor() {
+        List<Span> spans = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), v -> v.name(), v -> Color.RED);
+        // Active tab should use the custom color
+        assertThat(spans.get(1).style().fg()).contains(Color.RED);
+        // Inactive tab should use DARK_GRAY
+        assertThat(spans.get(3).style().fg()).contains(Color.DARK_GRAY);
+    }
+
+    @Test
+    void renderDefaultActiveColorIsYellow() {
+        List<Span> spans = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), v -> v.name());
+        assertThat(spans.get(1).style().fg()).contains(Color.YELLOW);
+    }
+
+    @Test
+    void nextCyclesToNextValue() {
+        assertThat(TabBar.next(TwoTabs.FIRST, TwoTabs.values())).isEqualTo(TwoTabs.SECOND);
+        assertThat(TabBar.next(ThreeTabs.A, ThreeTabs.values())).isEqualTo(ThreeTabs.B);
+        assertThat(TabBar.next(ThreeTabs.B, ThreeTabs.values())).isEqualTo(ThreeTabs.C);
+    }
+
+    @Test
+    void nextWrapsAround() {
+        assertThat(TabBar.next(TwoTabs.SECOND, TwoTabs.values())).isEqualTo(TwoTabs.FIRST);
+        assertThat(TabBar.next(ThreeTabs.C, ThreeTabs.values())).isEqualTo(ThreeTabs.A);
+    }
+
+    @Test
+    void renderSwitchingActiveTab() {
+        List<Span> spansFirst = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), v -> v.name());
+        List<Span> spansSecond = TabBar.render(TwoTabs.SECOND, TwoTabs.values(), v -> v.name());
+
+        // First tab active in spansFirst, inactive in spansSecond
+        assertThat(spansFirst.get(1).style().fg()).contains(Color.YELLOW);
+        assertThat(spansSecond.get(1).style().fg()).contains(Color.DARK_GRAY);
+
+        // Second tab inactive in spansFirst, active in spansSecond
+        assertThat(spansFirst.get(3).style().fg()).contains(Color.DARK_GRAY);
+        assertThat(spansSecond.get(3).style().fg()).contains(Color.YELLOW);
+    }
+}

--- a/src/test/java/eu/maveniverse/maven/pilot/TabBarTest.java
+++ b/src/test/java/eu/maveniverse/maven/pilot/TabBarTest.java
@@ -40,14 +40,14 @@ class TabBarTest {
 
     @Test
     void renderProducesCorrectSpanCount() {
-        List<Span> spans = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), v -> v.name());
+        List<Span> spans = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), Enum::name);
         // 2 tabs * 2 spans each (separator + tab label) = 4
         assertThat(spans).hasSize(4);
     }
 
     @Test
     void renderThreeTabsProducesCorrectSpanCount() {
-        List<Span> spans = TabBar.render(ThreeTabs.A, ThreeTabs.values(), v -> v.name());
+        List<Span> spans = TabBar.render(ThreeTabs.A, ThreeTabs.values(), Enum::name);
         // 3 tabs * 2 spans each = 6
         assertThat(spans).hasSize(6);
     }
@@ -76,7 +76,7 @@ class TabBarTest {
 
     @Test
     void renderWithCustomActiveColor() {
-        List<Span> spans = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), v -> v.name(), v -> Color.RED);
+        List<Span> spans = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), Enum::name, v -> Color.RED);
         // Active tab should use the custom color
         assertThat(spans.get(1).style().fg()).contains(Color.RED);
         // Inactive tab should use DARK_GRAY
@@ -85,7 +85,7 @@ class TabBarTest {
 
     @Test
     void renderDefaultActiveColorIsYellow() {
-        List<Span> spans = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), v -> v.name());
+        List<Span> spans = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), Enum::name);
         assertThat(spans.get(1).style().fg()).contains(Color.YELLOW);
     }
 
@@ -104,8 +104,8 @@ class TabBarTest {
 
     @Test
     void renderSwitchingActiveTab() {
-        List<Span> spansFirst = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), v -> v.name());
-        List<Span> spansSecond = TabBar.render(TwoTabs.SECOND, TwoTabs.values(), v -> v.name());
+        List<Span> spansFirst = TabBar.render(TwoTabs.FIRST, TwoTabs.values(), Enum::name);
+        List<Span> spansSecond = TabBar.render(TwoTabs.SECOND, TwoTabs.values(), Enum::name);
 
         // First tab active in spansFirst, inactive in spansSecond
         assertThat(spansFirst.get(1).style().fg()).contains(Color.YELLOW);


### PR DESCRIPTION
## Summary

- Move ReactorUpdatesTui tabs from bottom info bar to top header, consistent with other TUIs
- Extract shared `TabBar` utility class to eliminate ~30 lines of duplicated tab rendering code
- Standardize TAB key cycling logic across all 4 TUI classes using `TabBar.next()`
- Extract `HIGHLIGHT_SYMBOL` constant in AuditTui to avoid duplicated string literals

## Changes

- **TabBar.java** (new): Generic `render()` and `next()` methods for enum-based tab bars
- **ReactorUpdatesTui.java**: Tabs moved from `renderInfoBar()` to `renderHeader()`, layout adjusted
- **AuditTui.java**: Tab rendering/cycling delegated to TabBar, highlight symbol extracted to constant
- **DependenciesTui.java**: Tab rendering/cycling delegated to TabBar
- **PomTui.java**: Tab rendering/cycling delegated to TabBar
- **TabBarTest.java**: 9 unit tests covering render output, colors, cycling, wraparound
- **AuditDemoTest.java**: TUI rendering assertions verifying tab switching
- **ReactorUpdatesDemoTest.java**: TUI rendering assertions verifying tab switching

Fixes #52

## Test plan

- [x] All 278 tests pass (JDK 17, 21, 25)
- [x] TabBarTest covers render span count, active/inactive indicators, colors, cycling
- [x] AuditDemoTest verifies tab labels render correctly after each TAB press
- [x] ReactorUpdatesDemoTest verifies tab labels render correctly after each TAB press
- [x] SonarCloud quality gate passed (90.2% coverage, 0 new issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized tab navigation and rendering across multiple screens using a shared tab utility for consistent cycling and active-state display

* **Style**
  * Unified highlight/arrow indicator and conditional vulnerability highlight; adjusted Reactor Updates vertical spacing for cleaner layout

* **Tests**
  * Added UI tests validating tab rendering, cycling and active-tab behavior across Audit, Reactor Updates and tab utility scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->