### PR TITLE
ci: fix snapshot deploy version check

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -20,24 +20,23 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if SNAPSHOT version
-        id: check
-        run: |
-          version=$(git describe --tags --always)
-          echo "Resolved version hint: $version"
-          if [[ "$version" == *SNAPSHOT* ]]; then
-            echo "is_snapshot=true" >> $GITHUB_OUTPUT
-          else
-            echo "is_snapshot=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Setup Java
-        if: steps.check.outputs.is_snapshot == 'true'
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
         with:
           distribution: 'temurin'
           java-version: '21'
           cache: 'maven'
+
+      - name: Check if SNAPSHOT version
+        id: check
+        run: |
+          version=$(./mvnw -B help:evaluate -Dexpression=project.version -q -DforceStdout)
+          echo "Resolved version: $version"
+          if [[ "$version" == *-SNAPSHOT ]]; then
+            echo "is_snapshot=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_snapshot=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Deploy snapshot
         if: steps.check.outputs.is_snapshot == 'true'


### PR DESCRIPTION
## Summary
- The snapshot deploy workflow used `git describe --tags --always` to check for SNAPSHOT versions, which returns tag-based strings like `0.1.0-25-gce6acfc` — never containing "SNAPSHOT", so deploys were always skipped
- Fixed by using `./mvnw help:evaluate -Dexpression=project.version` to resolve the actual POM version (which uses `nisse.jgit.dynamicVersion` and includes `-SNAPSHOT` suffix)
- Moved Java setup before the version check since Maven needs it

## Test plan
- [ ] Verify the workflow runs and the version check resolves to a `-SNAPSHOT` version
- [ ] Verify snapshot artifacts are deployed to OSSRH after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated the GitHub Actions build workflow to unconditionally provision Java 21 with Maven caching for every build, ensuring a consistent build environment.
* Modified snapshot version detection to use Maven's project version evaluation directly, replacing the previous git-based detection approach for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->