### PR TITLE
fix: suppress transfer output during TUI and show inline progress

### DIFF
--- a/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/AuditMojo.java
+++ b/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/AuditMojo.java
@@ -76,7 +76,10 @@ public class AuditMojo extends AbstractMojo {
     }
 
     private void executeSingleProject(MavenProject proj) throws Exception {
-        CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
+        CollectResult result = ResolutionProgress.resolve(
+                "Collecting Dependencies",
+                repoSession,
+                ps -> repoSystem.collectDependencies(ps, MojoHelper.buildCollectRequest(proj)));
         DependencyTreeModel treeModel = MojoHelper.fromDependencyNode(result.getRoot());
         Map<String, AuditTui.AuditEntry> entryMap = new LinkedHashMap<>();
         collectEntries(result.getRoot(), entryMap, null, true);
@@ -89,13 +92,20 @@ public class AuditMojo extends AbstractMojo {
 
     private void executeReactor(List<MavenProject> projects) throws Exception {
         MavenProject root = projects.get(0);
-        CollectResult rootResult = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(root));
-        DependencyTreeModel treeModel = MojoHelper.fromDependencyNode(rootResult.getRoot());
+        List<CollectResult> collectResults = ResolutionProgress.resolve("Collecting Dependencies", repoSession, ps -> {
+            List<CollectResult> results = new ArrayList<>();
+            for (MavenProject proj : projects) {
+                results.add(repoSystem.collectDependencies(ps, MojoHelper.buildCollectRequest(proj)));
+            }
+            return results;
+        });
+        DependencyTreeModel treeModel =
+                MojoHelper.fromDependencyNode(collectResults.get(0).getRoot());
 
         Map<String, AuditTui.AuditEntry> entryMap = new LinkedHashMap<>();
-        for (MavenProject proj : projects) {
-            CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
-            collectEntries(result.getRoot(), entryMap, proj.getArtifactId(), true);
+        for (int i = 0; i < projects.size(); i++) {
+            collectEntries(
+                    collectResults.get(i).getRoot(), entryMap, projects.get(i).getArtifactId(), true);
         }
         List<AuditTui.AuditEntry> entries = new ArrayList<>(entryMap.values());
 

--- a/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/ConflictsMojo.java
+++ b/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/ConflictsMojo.java
@@ -77,7 +77,8 @@ public class ConflictsMojo extends AbstractMojo {
     }
 
     private void executeSingleProject(MavenProject proj) throws Exception {
-        List<ConflictsTui.ConflictGroup> conflicts = collectConflictsForProject(proj);
+        List<ConflictsTui.ConflictGroup> conflicts = ResolutionProgress.resolve(
+                "Collecting Dependencies", repoSession, ps -> collectConflictsForProject(proj, ps));
         String pomPath = proj.getFile().getAbsolutePath();
         String gav = proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion();
         ConflictsTui tui = new ConflictsTui(conflicts, pomPath, gav);
@@ -86,11 +87,15 @@ public class ConflictsMojo extends AbstractMojo {
 
     private void executeReactor(List<MavenProject> projects) throws Exception {
         // Aggregate conflicts across all modules
-        Map<String, List<ConflictsTui.ConflictEntry>> mergedMap = new HashMap<>();
-        for (MavenProject proj : projects) {
-            CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
-            collectConflicts(result.getRoot(), mergedMap, new ArrayList<>(), proj.getArtifactId());
-        }
+        Map<String, List<ConflictsTui.ConflictEntry>> mergedMap =
+                ResolutionProgress.resolve("Collecting Dependencies", repoSession, ps -> {
+                    Map<String, List<ConflictsTui.ConflictEntry>> map = new HashMap<>();
+                    for (MavenProject proj : projects) {
+                        CollectResult result = repoSystem.collectDependencies(ps, MojoHelper.buildCollectRequest(proj));
+                        collectConflicts(result.getRoot(), map, new ArrayList<>(), proj.getArtifactId());
+                    }
+                    return map;
+                });
 
         List<ConflictsTui.ConflictGroup> conflicts = mergedMap.entrySet().stream()
                 .filter(e -> e.getValue().size() > 1
@@ -107,8 +112,9 @@ public class ConflictsMojo extends AbstractMojo {
         tui.runStandalone();
     }
 
-    private List<ConflictsTui.ConflictGroup> collectConflictsForProject(MavenProject proj) throws Exception {
-        CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
+    private List<ConflictsTui.ConflictGroup> collectConflictsForProject(
+            MavenProject proj, RepositorySystemSession session) throws Exception {
+        CollectResult result = repoSystem.collectDependencies(session, MojoHelper.buildCollectRequest(proj));
         Map<String, List<ConflictsTui.ConflictEntry>> conflictMap = new HashMap<>();
         collectConflicts(result.getRoot(), conflictMap, new ArrayList<>());
         return conflictMap.entrySet().stream()

--- a/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/DependenciesMojo.java
+++ b/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/DependenciesMojo.java
@@ -106,7 +106,8 @@ public class DependenciesMojo extends AbstractMojo {
 
         // Resolve full transitive tree and artifact files
         DependencyRequest depRequest = new DependencyRequest(MojoHelper.buildCollectRequest(proj), null);
-        DependencyResult depResult = repoSystem.resolveDependencies(repoSession, depRequest);
+        DependencyResult depResult = ResolutionProgress.resolve(
+                "Resolving Dependencies", repoSession, ps -> repoSystem.resolveDependencies(ps, depRequest));
 
         // Find transitive (undeclared) dependencies
         DependencyTreeModel depTree = MojoHelper.fromDependencyNode(depResult.getRoot());

--- a/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/ResolutionProgress.java
+++ b/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/ResolutionProgress.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot.mvn3;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.transfer.AbstractTransferListener;
+import org.eclipse.aether.transfer.TransferEvent;
+import org.eclipse.aether.transfer.TransferListener;
+
+/**
+ * Inline progress display for artifact resolution in standalone Mojos.
+ * Renders a single spinner line on stderr, avoiding alternate-screen flicker.
+ */
+class ResolutionProgress {
+
+    private static final String[] SPINNER = {
+        "\u280b", "\u2819", "\u2839", "\u2838", "\u283c", "\u2834", "\u2826", "\u2827", "\u2807", "\u280f"
+    };
+
+    private final String title;
+    private int spinnerFrame;
+    private final ConcurrentHashMap<String, TransferInfo> activeTransfers = new ConcurrentHashMap<>();
+    private final AtomicInteger completedCount = new AtomicInteger();
+    private final AtomicLong totalBytes = new AtomicLong();
+
+    private static class TransferInfo {
+        final String name;
+        final long contentLength;
+        volatile long transferred;
+
+        TransferInfo(String name, long contentLength) {
+            this.name = name;
+            this.contentLength = contentLength;
+        }
+    }
+
+    ResolutionProgress(String title) {
+        this.title = title;
+    }
+
+    TransferListener createListener() {
+        return new AbstractTransferListener() {
+            @Override
+            public void transferStarted(TransferEvent event) {
+                String key = event.getResource().getResourceName();
+                String name = key.substring(key.lastIndexOf('/') + 1);
+                activeTransfers.put(
+                        key, new TransferInfo(name, event.getResource().getContentLength()));
+            }
+
+            @Override
+            public void transferProgressed(TransferEvent event) {
+                TransferInfo info = activeTransfers.get(event.getResource().getResourceName());
+                if (info != null) {
+                    info.transferred = event.getTransferredBytes();
+                }
+            }
+
+            @Override
+            public void transferSucceeded(TransferEvent event) {
+                activeTransfers.remove(event.getResource().getResourceName());
+                completedCount.incrementAndGet();
+                totalBytes.addAndGet(event.getTransferredBytes());
+            }
+
+            @Override
+            public void transferFailed(TransferEvent event) {
+                activeTransfers.remove(event.getResource().getResourceName());
+            }
+        };
+    }
+
+    <T> T run(Callable<T> work) throws Exception {
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "pilot-progress");
+            t.setDaemon(true);
+            return t;
+        });
+        scheduler.scheduleAtFixedRate(this::printProgress, 100, 100, TimeUnit.MILLISECONDS);
+        try {
+            return work.call();
+        } finally {
+            scheduler.shutdownNow();
+            clearProgress();
+        }
+    }
+
+    @FunctionalInterface
+    interface SessionCallable<T> {
+        T call(RepositorySystemSession session) throws Exception;
+    }
+
+    /**
+     * Creates a progress session and runs the work with inline progress display.
+     * The work receives the wrapped session with the progress listener installed.
+     */
+    static <T> T resolve(String title, RepositorySystemSession repoSession, SessionCallable<T> work) throws Exception {
+        ResolutionProgress progress = new ResolutionProgress(title);
+        DefaultRepositorySystemSession ps = new DefaultRepositorySystemSession(repoSession);
+        ps.setTransferListener(progress.createListener());
+        return progress.run(() -> work.call(ps));
+    }
+
+    private void printProgress() {
+        spinnerFrame++;
+        String spinner = SPINNER[spinnerFrame % SPINNER.length];
+        int completed = completedCount.get();
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("\r\033[K");
+        sb.append(spinner).append(" ").append(title);
+
+        var iter = activeTransfers.values().iterator();
+        if (iter.hasNext()) {
+            TransferInfo info = iter.next();
+            sb.append("  \u2193 ").append(info.name);
+            if (info.contentLength > 0) {
+                sb.append(" (")
+                        .append(formatBytes(info.transferred))
+                        .append("/")
+                        .append(formatBytes(info.contentLength))
+                        .append(")");
+            }
+        }
+
+        if (completed > 0) {
+            sb.append("  ")
+                    .append(completed)
+                    .append(" done (")
+                    .append(formatBytes(totalBytes.get()))
+                    .append(")");
+        }
+
+        System.err.print(sb);
+        System.err.flush();
+    }
+
+    private void clearProgress() {
+        System.err.print("\r\033[K");
+        System.err.flush();
+    }
+
+    private static String formatBytes(long bytes) {
+        if (bytes < 1024) return bytes + " B";
+        if (bytes < 1024 * 1024) return String.format("%.1f KB", bytes / 1024.0);
+        return String.format("%.1f MB", bytes / (1024.0 * 1024.0));
+    }
+}

--- a/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/TreeMojo.java
+++ b/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/TreeMojo.java
@@ -69,7 +69,10 @@ public class TreeMojo extends AbstractMojo {
     }
 
     private void executeForProject(MavenProject proj) throws Exception {
-        CollectResult result = repoSystem.collectDependencies(repoSession, MojoHelper.buildCollectRequest(proj));
+        CollectResult result = ResolutionProgress.resolve(
+                "Collecting Dependencies",
+                repoSession,
+                ps -> repoSystem.collectDependencies(ps, MojoHelper.buildCollectRequest(proj)));
         String gav = proj.getGroupId() + ":" + proj.getArtifactId() + ":" + proj.getVersion();
         DependencyTreeModel treeModel = MojoHelper.fromDependencyNode(result.getRoot());
         TreeTui tui = new TreeTui(treeModel, scope, gav);

--- a/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/UpdatesMojo.java
+++ b/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/UpdatesMojo.java
@@ -30,12 +30,14 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.DefaultArtifact;
 import org.eclipse.aether.resolution.VersionRangeRequest;
 import org.eclipse.aether.resolution.VersionRangeResolutionException;
 import org.eclipse.aether.resolution.VersionRangeResult;
+import org.eclipse.aether.transfer.AbstractTransferListener;
 
 /**
  * Interactive TUI showing which dependencies have newer versions available.
@@ -127,12 +129,14 @@ public class UpdatesMojo extends AbstractMojo {
     }
 
     private UpdatesTui.VersionResolver createVersionResolver() {
+        DefaultRepositorySystemSession quietSession = new DefaultRepositorySystemSession(repoSession);
+        quietSession.setTransferListener(new AbstractTransferListener() {});
         return (groupId, artifactId) -> {
             try {
                 VersionRangeRequest request = new VersionRangeRequest();
                 request.setArtifact(new DefaultArtifact(groupId, artifactId, "jar", "[0,)"));
                 request.setRepositories(project.getRemoteProjectRepositories());
-                VersionRangeResult result = repoSystem.resolveVersionRange(repoSession, request);
+                VersionRangeResult result = repoSystem.resolveVersionRange(quietSession, request);
                 return UpdatesTui.versionsNewestFirst(result.getVersions());
             } catch (VersionRangeResolutionException e) {
                 throw new IllegalStateException("Failed to resolve versions for " + groupId + ":" + artifactId, e);


### PR DESCRIPTION
## Summary

- Adds `ResolutionProgress` helper that wraps artifact resolution with an inline ANSI spinner on stderr, showing download progress (artifact name, bytes transferred, completion count) during pre-TUI resolution phases
- Wraps `collectDependencies`/`resolveDependencies` calls in `AuditMojo`, `ConflictsMojo`, `DependenciesMojo`, and `TreeMojo` with `ResolutionProgress.resolve()` so users see activity instead of a blank terminal
- Adds a quiet session (no-op transfer listener) in `UpdatesMojo.createVersionResolver()` to suppress transfer output during in-TUI background version resolution

Fixes #24

## Test plan

- [ ] Run `mvn pilot:tree` on a project with uncached dependencies — verify inline spinner appears during resolution, then TUI renders cleanly
- [ ] Run `mvn pilot:audit` on a multi-module project — verify progress during collection, no output bleed into TUI
- [ ] Run `mvn pilot:conflicts` — same verification
- [ ] Run `mvn pilot:dependencies` — verify "Resolving Dependencies" progress appears
- [ ] Run `mvn pilot:updates` — verify no transfer output appears while browsing versions in the TUI
- [ ] Run any tool with fully cached dependencies — verify no visual artifacts (progress clears cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented real-time progress indicators for dependency collection, resolution, and version range lookup operations, displaying transfer progress on the console to improve visibility during long-running artifact operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->