### PR TITLE
feat: add Panama backend for Maven 4 compatibility

### DIFF
--- a/pilot-core/pom.xml
+++ b/pilot-core/pom.xml
@@ -47,6 +47,10 @@ under the License.
     </dependency>
     <dependency>
       <groupId>dev.tamboui</groupId>
+      <artifactId>tamboui-panama-backend</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>dev.tamboui</groupId>
       <artifactId>tamboui-jline3-backend</artifactId>
     </dependency>
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -174,6 +174,7 @@ public class PilotShell {
     }
 
     public void run() throws Exception {
+        ToolPanel.configureBackend();
         var configured = TuiRunner.builder()
                 .eventHandler(this::handleEvent)
                 .renderer(this::render)

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -188,11 +188,30 @@ public abstract class ToolPanel {
     abstract void renderStandalone(Frame frame);
 
     /**
+     * Configure the TamboUI backend based on the runtime environment.
+     * In mvnd, the daemon process has no real TTY so the Panama backend's native
+     * ioctl() calls fail and corrupt stdin — we must use the JLine backend instead.
+     * For direct Maven (including Maven 4 which bundles JLine), Panama avoids
+     * classloader conflicts with Maven's own JLine.
+     */
+    static void configureBackend() {
+        if (System.getProperty("tamboui.backend") != null) {
+            return; // user has explicitly configured the backend
+        }
+        if (System.getProperty("mvnd.home") != null) {
+            System.setProperty("tamboui.backend", "jline3");
+        } else {
+            System.setProperty("tamboui.backend", "panama,jline3");
+        }
+    }
+
+    /**
      * Run this panel as a standalone TUI (outside of PilotShell).
      * Creates a {@link TuiRunner}, wires up event handling and rendering,
      * and blocks until the user quits.
      */
     public void runStandalone() throws Exception {
+        configureBackend();
         TuiRunner.ConfiguredRunner configured = TuiRunner.builder()
                 .eventHandler(this::handleEvent)
                 .renderer(this::renderStandalone)

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@ under the License.
       </dependency>
       <dependency>
         <groupId>dev.tamboui</groupId>
+        <artifactId>tamboui-panama-backend</artifactId>
+        <version>${tamboui.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>dev.tamboui</groupId>
         <artifactId>tamboui-jline3-backend</artifactId>
         <version>${tamboui.version}</version>
       </dependency>


### PR DESCRIPTION
## Summary
- Add TamboUI's Panama FFI backend to avoid JLine classloader conflicts on Maven 4 (which bundles its own JLine)
- Runtime detection via `mvnd.home` system property: direct Maven uses Panama (primary) with JLine fallback; mvnd uses JLine only (daemon lacks a real TTY for Panama's native ioctl)
- Users can override backend selection with `-Dtamboui.backend=...`

## Test plan
- [x] `mvn pilot:pilot` on Maven 3 — uses Panama backend
- [x] `mvn pilot:pilot` on Maven 4 — uses Panama backend, no JLine classloader conflict
- [x] `mvnd pilot:pilot` on mvnd 1 — uses JLine backend
- [x] `mvnd pilot:pilot` on mvnd 2 — uses JLine backend
- [x] Unit tests pass (`./mvnw test -B`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal/interactive mode now auto-selects and configures the optimal backend at startup for improved compatibility and startup reliability.

* **Chores**
  * Added supporting library to enable the new backend selection and runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->