### PR TITLE
refactor: replace verbose help definitions with text-based format

### DIFF
--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
@@ -599,7 +599,7 @@ public class AlignTui extends ToolPanel {
 
     private List<HelpOverlay.Section> buildHelpStandalone() {
         List<HelpOverlay.Section> sections = new ArrayList<>(helpSections());
-        sections.set(sections.size() - 1, HelpOverlay.parse("""
+        List<HelpOverlay.Section> parsed = HelpOverlay.parse("""
                 ## Keys
                 ↑ / ↓           Move between options
                 ← / → / Enter  Cycle through option values
@@ -607,7 +607,10 @@ public class AlignTui extends ToolPanel {
                 w               Apply alignment and write to POM
                 h               Toggle this help screen
                 q / Esc         Quit
-                """).get(0));
+                """);
+        if (!parsed.isEmpty()) {
+            sections.set(sections.size() - 1, parsed.get(0));
+        }
         return sections;
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
@@ -566,54 +566,48 @@ public class AlignTui extends ToolPanel {
 
     @Override
     public List<HelpOverlay.Section> helpSections() {
-        List<HelpOverlay.Entry> descEntries = new ArrayList<>();
-        descEntries.add(new HelpOverlay.Entry("", "Restructures dependency declarations to follow a"));
-        descEntries.add(new HelpOverlay.Entry("", "consistent convention. Configure three options:"));
-        descEntries.add(new HelpOverlay.Entry("", ""));
-        descEntries.add(new HelpOverlay.Entry("", "Version Style: how versions are expressed — inline"));
-        descEntries.add(new HelpOverlay.Entry("", "in <version> tags, via <properties>, or managed"));
-        descEntries.add(new HelpOverlay.Entry("", "through <dependencyManagement>."));
-        descEntries.add(new HelpOverlay.Entry("", ""));
-        descEntries.add(new HelpOverlay.Entry("", "Version Source: where version values come from —"));
-        descEntries.add(new HelpOverlay.Entry("", "keep current versions, import from a BOM, etc."));
-        descEntries.add(new HelpOverlay.Entry("", ""));
-        descEntries.add(new HelpOverlay.Entry("", "Property Naming: convention for property names"));
-        descEntries.add(new HelpOverlay.Entry("", "(e.g. groupId.artifactId.version or artifact.version)."));
-        descEntries.add(new HelpOverlay.Entry("", ""));
-        descEntries.add(new HelpOverlay.Entry("", "Preview the diff before applying to verify changes."));
-
+        String desc = """
+                ## BOM Alignment
+                Restructures dependency declarations to follow a
+                consistent convention. Configure three options:
+                Version Style: how versions are expressed — inline
+                in <version> tags, via <properties>, or managed
+                through <dependencyManagement>.
+                Version Source: where version values come from —
+                keep current versions, import from a BOM, etc.
+                Property Naming: convention for property names
+                (e.g. groupId.artifactId.version or artifact.version).
+                Preview the diff before applying to verify changes.
+                """;
         if (parentInfo != null) {
-            descEntries.add(new HelpOverlay.Entry("", ""));
-            descEntries.add(new HelpOverlay.Entry("", "Cross-POM mode: when MANAGED style is selected,"));
-            descEntries.add(new HelpOverlay.Entry("", "managed deps are written to the parent POM and"));
-            descEntries.add(new HelpOverlay.Entry("", "child deps become version-less."));
-            descEntries.add(new HelpOverlay.Entry("", "Parent: " + parentInfo.gav()));
+            desc += """
+                    Cross-POM mode: when MANAGED style is selected,
+                    managed deps are written to the parent POM and
+                    child deps become version-less.
+                    Parent:\u0020""" + parentInfo.gav() + "\n";
         }
+        desc += """
 
-        return List.of(
-                new HelpOverlay.Section("BOM Alignment", descEntries),
-                new HelpOverlay.Section(
-                        "Alignment Actions",
-                        List.of(
-                                new HelpOverlay.Entry("↑ / ↓", "Move between options"),
-                                new HelpOverlay.Entry("← / → / Enter", "Cycle through option values"),
-                                new HelpOverlay.Entry("p", "Preview the POM changes as a diff"),
-                                new HelpOverlay.Entry("w", "Apply alignment and write to POM"))));
+                ## Alignment Actions
+                ↑ / ↓           Move between options
+                ← / → / Enter  Cycle through option values
+                p               Preview the POM changes as a diff
+                w               Apply alignment and write to POM
+                """;
+        return HelpOverlay.parse(desc);
     }
 
     private List<HelpOverlay.Section> buildHelpStandalone() {
         List<HelpOverlay.Section> sections = new ArrayList<>(helpSections());
-        sections.set(
-                sections.size() - 1,
-                new HelpOverlay.Section(
-                        "Keys",
-                        List.of(
-                                new HelpOverlay.Entry("↑ / ↓", "Move between options"),
-                                new HelpOverlay.Entry("← / → / Enter", "Cycle through option values"),
-                                new HelpOverlay.Entry("p", "Preview the POM changes as a diff"),
-                                new HelpOverlay.Entry("w", "Apply alignment and write to POM"),
-                                new HelpOverlay.Entry("h", "Toggle this help screen"),
-                                new HelpOverlay.Entry("q / Esc", "Quit"))));
+        sections.set(sections.size() - 1, HelpOverlay.parse("""
+                ## Keys
+                ↑ / ↓           Move between options
+                ← / → / Enter  Cycle through option values
+                p               Preview the POM changes as a diff
+                w               Apply alignment and write to POM
+                h               Toggle this help screen
+                q / Esc         Quit
+                """).get(0));
         return sections;
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -1373,61 +1373,54 @@ public class AuditTui extends ToolPanel {
 
     @Override
     public List<HelpOverlay.Section> helpSections() {
-        return List.of(
-                new HelpOverlay.Section(
-                        "License & Security Audit",
-                        List.of(
-                                new HelpOverlay.Entry("", "Audits all resolved dependencies for license"),
-                                new HelpOverlay.Entry("", "compliance and known security vulnerabilities."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "Licenses view: shows each dependency's license"),
-                                new HelpOverlay.Entry("", "(from POM metadata). Review for compatibility"),
-                                new HelpOverlay.Entry("", "with your project's licensing requirements."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "Vulnerabilities view: queries for known CVEs"),
-                                new HelpOverlay.Entry("", "affecting your dependencies. Shows severity,"),
-                                new HelpOverlay.Entry("", "CVE identifier, and affected version range."))),
-                new HelpOverlay.Section(
-                        "License Colors",
-                        List.of(
-                                new HelpOverlay.Entry("default", "Permissive license (Apache, MIT, BSD)"),
-                                new HelpOverlay.Entry("yellow", "Weak copyleft (LGPL, MPL, EPL, CDDL)"),
-                                new HelpOverlay.Entry("red", "Strong copyleft (GPL, AGPL)"),
-                                new HelpOverlay.Entry("dim", "Unknown or not yet loaded"))),
-                new HelpOverlay.Section(
-                        "Vulnerability Colors",
-                        List.of(
-                                new HelpOverlay.Entry("red bold", "Critical severity"),
-                                new HelpOverlay.Entry("yellow", "High severity"),
-                                new HelpOverlay.Entry("yellow", "Medium severity"),
-                                new HelpOverlay.Entry("default", "Low severity"),
-                                new HelpOverlay.Entry("dim", "Unknown severity"))),
-                new HelpOverlay.Section(
-                        "Audit Actions",
-                        List.of(
-                                new HelpOverlay.Entry("↑ / ↓", "Move selection up / down"),
-                                new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
-                                new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
-                                new HelpOverlay.Entry("← / →", "Collapse / expand (By License view)"),
-                                new HelpOverlay.Entry("Tab", "Switch between Licenses / By License / Vulns"),
-                                new HelpOverlay.Entry(
-                                        "s", "Cycle scope filter: all → compile → runtime → test → provided"),
-                                new HelpOverlay.Entry("m", "Add selected dep to dependencyManagement"),
-                                new HelpOverlay.Entry("d", "Preview POM changes as unified diff"))));
+        return HelpOverlay.parse("""
+                ## License & Security Audit
+                Audits all resolved dependencies for license
+                compliance and known security vulnerabilities.
+                Licenses view: shows each dependency's license
+                (from POM metadata). Review for compatibility
+                with your project's licensing requirements.
+                Vulnerabilities view: queries for known CVEs
+                affecting your dependencies. Shows severity,
+                CVE identifier, and affected version range.
+
+                ## License Colors
+                default         Permissive license (Apache, MIT, BSD)
+                yellow          Weak copyleft (LGPL, MPL, EPL, CDDL)
+                red             Strong copyleft (GPL, AGPL)
+                dim             Unknown or not yet loaded
+
+                ## Vulnerability Colors
+                red bold        Critical severity
+                yellow          High severity
+                yellow          Medium severity
+                default         Low severity
+                dim             Unknown severity
+
+                ## Audit Actions
+                ↑ / ↓           Move selection up / down
+                PgUp / PgDn     Move selection up / down by one page
+                Home / End      Jump to first / last row
+                ← / →           Collapse / expand (By License view)
+                Tab             Switch between Licenses / By License / Vulns
+                s               Cycle scope filter: all → compile → runtime → test → provided
+                m               Add selected dep to dependencyManagement
+                d               Preview POM changes as unified diff
+                """);
     }
 
     private List<HelpOverlay.Section> buildHelpStandalone() {
         List<HelpOverlay.Section> sections = new ArrayList<>(helpSections());
-        sections.add(new HelpOverlay.Section(
-                "Keys",
-                List.of(
-                        new HelpOverlay.Entry("↑ / ↓", "Move selection up / down"),
-                        new HelpOverlay.Entry("← / →", "Collapse / expand (By License view)"),
-                        new HelpOverlay.Entry("Tab", "Switch between Licenses / By License / Vulns"),
-                        new HelpOverlay.Entry("m", "Add selected dep to dependencyManagement"),
-                        new HelpOverlay.Entry("d", "Preview POM changes as a unified diff"),
-                        new HelpOverlay.Entry("h", "Toggle this help screen"),
-                        new HelpOverlay.Entry("q / Esc", "Quit (prompts to save if modified)"))));
+        sections.addAll(HelpOverlay.parse("""
+                ## Keys
+                ↑ / ↓           Move selection up / down
+                ← / →           Collapse / expand (By License view)
+                Tab             Switch between Licenses / By License / Vulns
+                m               Add selected dep to dependencyManagement
+                d               Preview POM changes as a unified diff
+                h               Toggle this help screen
+                q / Esc         Quit (prompts to save if modified)
+                """));
         return sections;
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -1414,6 +1414,7 @@ public class AuditTui extends ToolPanel {
                 ↑ / ↓           Move selection up / down
                 ← / →           Collapse / expand (By License view)
                 Tab             Switch between Licenses / By License / Vulns
+                s               Cycle scope filter: all → compile → runtime → test → provided
                 m               Add selected dep to dependencyManagement
                 d               Preview POM changes as a unified diff
                 h               Toggle this help screen

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -1398,9 +1398,7 @@ public class AuditTui extends ToolPanel {
                 dim             Unknown severity
 
                 ## Audit Actions
-                ↑ / ↓           Move selection up / down
-                PgUp / PgDn     Move selection up / down by one page
-                Home / End      Jump to first / last row
+                """ + NAV_KEYS + """
                 ← / →           Collapse / expand (By License view)
                 Tab             Switch between Licenses / By License / Vulns
                 s               Cycle scope filter: all → compile → runtime → test → provided

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -517,8 +517,7 @@ public class ConflictsTui extends ToolPanel {
 
     private List<HelpOverlay.Section> buildHelpStandalone() {
         List<HelpOverlay.Section> sections = new ArrayList<>(helpSections());
-        sections.set(
-                sections.size() - 1, HelpOverlay.parse("""
+        List<HelpOverlay.Section> parsed = HelpOverlay.parse("""
                 ## Keys
                 """ + NAV_KEYS + """
                 Enter / Space   Toggle dependency path details
@@ -527,7 +526,10 @@ public class ConflictsTui extends ToolPanel {
                 d               Preview POM changes as a unified diff
                 h               Toggle this help screen
                 q / Esc         Quit (prompts to save if modified)
-                """).get(0));
+                """);
+        if (!parsed.isEmpty()) {
+            sections.set(sections.size() - 1, parsed.get(0));
+        }
         return sections;
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -394,42 +394,36 @@ public class ConflictsTui extends ToolPanel {
 
     @Override
     public List<HelpOverlay.Section> helpSections() {
-        return List.of(
-                new HelpOverlay.Section(
-                        "Conflict Resolution",
-                        List.of(
-                                new HelpOverlay.Entry("", "When multiple dependencies request different versions"),
-                                new HelpOverlay.Entry("", "of the same artifact, Maven picks one (the 'resolved'"),
-                                new HelpOverlay.Entry("", "version). This screen shows all such groups."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "The details pane shows the dependency path for each"),
-                                new HelpOverlay.Entry("", "request, so you can see which transitive chain"),
-                                new HelpOverlay.Entry("", "asked for which version."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "Use 'p' to pin a group's resolved version into"),
-                                new HelpOverlay.Entry("", "<dependencyManagement>, ensuring all modules use"),
-                                new HelpOverlay.Entry("", "that version explicitly."))),
-                new HelpOverlay.Section(
-                        "Table Columns",
-                        List.of(
-                                new HelpOverlay.Entry("status", "⚠ = conflict (versions differ), ✓ = consistent"),
-                                new HelpOverlay.Entry("dependency", "groupId:artifactId"),
-                                new HelpOverlay.Entry("resolved", "The version Maven selected"),
-                                new HelpOverlay.Entry("versions", "All distinct versions requested"))),
-                new HelpOverlay.Section(
-                        "Colors",
-                        List.of(
-                                new HelpOverlay.Entry("yellow", "Actual conflict — different versions requested"),
-                                new HelpOverlay.Entry("default", "No conflict — all requests agree on version"),
-                                new HelpOverlay.Entry("dim", "Dependency path in details pane"))),
-                new HelpOverlay.Section(
-                        "Conflict Actions",
-                        List.of(
-                                new HelpOverlay.Entry("↑ / ↓", "Move selection up / down"),
-                                new HelpOverlay.Entry("Enter / Space", "Toggle dependency path details"),
-                                new HelpOverlay.Entry("a", "Toggle between conflicts only / all groups"),
-                                new HelpOverlay.Entry("p", "Pin resolved version in dependencyManagement"),
-                                new HelpOverlay.Entry("d", "Preview POM changes as a unified diff"))));
+        return HelpOverlay.parse("""
+                ## Conflict Resolution
+                When multiple dependencies request different versions
+                of the same artifact, Maven picks one (the 'resolved'
+                version). This screen shows all such groups.
+                The details pane shows the dependency path for each
+                request, so you can see which transitive chain
+                asked for which version.
+                Use 'p' to pin a group's resolved version into
+                <dependencyManagement>, ensuring all modules use
+                that version explicitly.
+
+                ## Table Columns
+                status          ⚠ = conflict (versions differ), ✓ = consistent
+                dependency      groupId:artifactId
+                resolved        The version Maven selected
+                versions        All distinct versions requested
+
+                ## Colors
+                yellow          Actual conflict — different versions requested
+                default         No conflict — all requests agree on version
+                dim             Dependency path in details pane
+
+                ## Conflict Actions
+                ↑ / ↓           Move selection up / down
+                Enter / Space   Toggle dependency path details
+                a               Toggle between conflicts only / all groups
+                p               Pin resolved version in dependencyManagement
+                d               Preview POM changes as a unified diff
+                """);
     }
 
     @Override
@@ -523,20 +517,18 @@ public class ConflictsTui extends ToolPanel {
 
     private List<HelpOverlay.Section> buildHelpStandalone() {
         List<HelpOverlay.Section> sections = new ArrayList<>(helpSections());
-        sections.set(
-                sections.size() - 1,
-                new HelpOverlay.Section(
-                        "Keys",
-                        List.of(
-                                new HelpOverlay.Entry("↑ / ↓", "Move selection up / down"),
-                                new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
-                                new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
-                                new HelpOverlay.Entry("Enter / Space", "Toggle dependency path details"),
-                                new HelpOverlay.Entry("a", "Toggle between conflicts only / all groups"),
-                                new HelpOverlay.Entry("p", "Pin resolved version in dependencyManagement"),
-                                new HelpOverlay.Entry("d", "Preview POM changes as a unified diff"),
-                                new HelpOverlay.Entry("h", "Toggle this help screen"),
-                                new HelpOverlay.Entry("q / Esc", "Quit (prompts to save if modified)"))));
+        sections.set(sections.size() - 1, HelpOverlay.parse("""
+                ## Keys
+                ↑ / ↓           Move selection up / down
+                PgUp / PgDn     Move selection up / down by one page
+                Home / End      Jump to first / last row
+                Enter / Space   Toggle dependency path details
+                a               Toggle between conflicts only / all groups
+                p               Pin resolved version in dependencyManagement
+                d               Preview POM changes as a unified diff
+                h               Toggle this help screen
+                q / Esc         Quit (prompts to save if modified)
+                """).get(0));
         return sections;
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -517,11 +517,10 @@ public class ConflictsTui extends ToolPanel {
 
     private List<HelpOverlay.Section> buildHelpStandalone() {
         List<HelpOverlay.Section> sections = new ArrayList<>(helpSections());
-        sections.set(sections.size() - 1, HelpOverlay.parse("""
+        sections.set(
+                sections.size() - 1, HelpOverlay.parse("""
                 ## Keys
-                ↑ / ↓           Move selection up / down
-                PgUp / PgDn     Move selection up / down by one page
-                Home / End      Jump to first / last row
+                """ + NAV_KEYS + """
                 Enter / Space   Toggle dependency path details
                 a               Toggle between conflicts only / all groups
                 p               Pin resolved version in dependencyManagement

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -846,9 +846,7 @@ public class DependenciesTui extends ToolPanel {
         List<HelpOverlay.Section> sections = new ArrayList<>(helpSections());
         sections.addAll(HelpOverlay.parse("""
                 ## General
-                ↑ / ↓           Move selection up / down
-                PgUp / PgDn     Move selection up / down by one page
-                Home / End      Jump to first / last row
+                """ + NAV_KEYS + """
                 Tab             Switch between Declared and Transitive views
                 d               Preview POM changes as a unified diff
                 h               Toggle this help screen

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -526,43 +526,37 @@ public class DependenciesTui extends ToolPanel {
 
     @Override
     public List<HelpOverlay.Section> helpSections() {
-        return List.of(
-                new HelpOverlay.Section(
-                        "Dependency Analysis",
-                        List.of(
-                                new HelpOverlay.Entry("", "Uses bytecode analysis to compare what is declared"),
-                                new HelpOverlay.Entry("", "in the POM against what is actually used in code."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "Declared view: dependencies in the POM that are not"),
-                                new HelpOverlay.Entry("", "referenced in compiled bytecode. These may be safe"),
-                                new HelpOverlay.Entry("", "to remove (but check for runtime/reflection use)."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "Transitive view: classes used in your code that come"),
-                                new HelpOverlay.Entry("", "from transitive dependencies. These should be declared"),
-                                new HelpOverlay.Entry("", "explicitly to avoid breakage when transitives change."))),
-                new HelpOverlay.Section(
-                        "Table Columns",
-                        List.of(
-                                new HelpOverlay.Entry("status", "unused (declared) or undeclared (transitive)"),
-                                new HelpOverlay.Entry("dependency", "groupId:artifactId"),
-                                new HelpOverlay.Entry("scope", "Maven scope (compile, test, runtime, provided)"),
-                                new HelpOverlay.Entry("classifier", "Artifact classifier (e.g. test-fixtures)"))),
-                new HelpOverlay.Section(
-                        "Colors",
-                        List.of(
-                                new HelpOverlay.Entry("yellow", "Issue flag — unused or undeclared dependency"),
-                                new HelpOverlay.Entry("cyan", "Header and view tab indicators"),
-                                new HelpOverlay.Entry("dim", "Informational / secondary text"))),
-                new HelpOverlay.Section(
-                        "Dependencies Actions",
-                        List.of(
-                                new HelpOverlay.Entry("↑ / ↓", "Move selection up / down"),
-                                new HelpOverlay.Entry("← / →", "Switch Declared / Transitive view"),
-                                new HelpOverlay.Entry("x / Enter", "Remove selected (Declared view)"),
-                                new HelpOverlay.Entry("a / Enter", "Add to POM (Transitive view)"),
-                                new HelpOverlay.Entry("c", "Cycle scope (compile → test → runtime → ...)"),
-                                new HelpOverlay.Entry("s / S", "Sort by column / reverse direction"),
-                                new HelpOverlay.Entry("d", "Preview POM changes as unified diff"))));
+        return HelpOverlay.parse("""
+                ## Dependency Analysis
+                Uses bytecode analysis to compare what is declared
+                in the POM against what is actually used in code.
+                Declared view: dependencies in the POM that are not
+                referenced in compiled bytecode. These may be safe
+                to remove (but check for runtime/reflection use).
+                Transitive view: classes used in your code that come
+                from transitive dependencies. These should be declared
+                explicitly to avoid breakage when transitives change.
+
+                ## Table Columns
+                status          unused (declared) or undeclared (transitive)
+                dependency      groupId:artifactId
+                scope           Maven scope (compile, test, runtime, provided)
+                classifier      Artifact classifier (e.g. test-fixtures)
+
+                ## Colors
+                yellow          Issue flag — unused or undeclared dependency
+                cyan            Header and view tab indicators
+                dim             Informational / secondary text
+
+                ## Dependencies Actions
+                ↑ / ↓           Move selection up / down
+                ← / →           Switch Declared / Transitive view
+                x / Enter       Remove selected (Declared view)
+                a / Enter       Add to POM (Transitive view)
+                c               Cycle scope (compile → test → runtime → ...)
+                s / S           Sort by column / reverse direction
+                d               Preview POM changes as unified diff
+                """);
     }
 
     @Override
@@ -850,16 +844,16 @@ public class DependenciesTui extends ToolPanel {
 
     private List<HelpOverlay.Section> buildHelpStandalone() {
         List<HelpOverlay.Section> sections = new ArrayList<>(helpSections());
-        sections.add(new HelpOverlay.Section(
-                "General",
-                List.of(
-                        new HelpOverlay.Entry("↑ / ↓", "Move selection up / down"),
-                        new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
-                        new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
-                        new HelpOverlay.Entry("Tab", "Switch between Declared and Transitive views"),
-                        new HelpOverlay.Entry("d", "Preview POM changes as a unified diff"),
-                        new HelpOverlay.Entry("h", "Toggle this help screen"),
-                        new HelpOverlay.Entry("q / Esc", "Quit (prompts to save if modified)"))));
+        sections.addAll(HelpOverlay.parse("""
+                ## General
+                ↑ / ↓           Move selection up / down
+                PgUp / PgDn     Move selection up / down by one page
+                Home / End      Jump to first / last row
+                Tab             Switch between Declared and Transitive views
+                d               Preview POM changes as a unified diff
+                h               Toggle this help screen
+                q / Esc         Quit (prompts to save if modified)
+                """));
         return sections;
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/HelpOverlay.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/HelpOverlay.java
@@ -48,6 +48,36 @@ class HelpOverlay {
 
     record Section(String title, List<Entry> entries) {}
 
+    static List<Section> parse(String text) {
+        List<Section> sections = new ArrayList<>();
+        String currentTitle = null;
+        List<Entry> currentEntries = null;
+        for (String line : text.split("\n")) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            if (trimmed.startsWith("## ")) {
+                if (currentTitle != null) {
+                    sections.add(new Section(currentTitle, currentEntries));
+                }
+                currentTitle = trimmed.substring(3).trim();
+                currentEntries = new ArrayList<>();
+            } else if (currentEntries != null) {
+                String[] parts = trimmed.split(" {2,}", 2);
+                if (parts.length == 2) {
+                    currentEntries.add(new Entry(parts[0], parts[1]));
+                } else {
+                    currentEntries.add(new Entry("", trimmed));
+                }
+            }
+        }
+        if (currentTitle != null) {
+            sections.add(new Section(currentTitle, currentEntries));
+        }
+        return sections;
+    }
+
     private List<Line> lines;
     private int scroll;
     private int currentHeight;

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
@@ -367,10 +367,8 @@ public class PomTui extends ToolPanel {
                 dim             XML structure characters, metadata
 
                 ## Navigation
-                \u2191 / \u2193           Move selection up / down
-                PgUp / PgDn     Move selection up / down by one page
-                Home / End      Jump to first / last row
-                \u2190 / \u2192           Collapse / expand tree node
+                """ + NAV_KEYS + """
+                ← / →           Collapse / expand tree node
                 e               Expand all nodes
                 w               Collapse all (keeps root expanded)
                 Tab             Switch Raw POM / Effective POM

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
@@ -349,44 +349,32 @@ public class PomTui extends ToolPanel {
 
     @Override
     public List<HelpOverlay.Section> helpSections() {
-        return List.of(
-                new HelpOverlay.Section(
-                        "POM Browser",
-                        List.of(
-                                new HelpOverlay.Entry("", "Browse the project's POM as an expandable XML tree."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "Raw POM: the actual pom.xml file content as written."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "Effective POM: the fully resolved POM after parent"),
-                                new HelpOverlay.Entry("", "inheritance, profile activation, and property"),
-                                new HelpOverlay.Entry("", "interpolation. Shows what Maven actually uses."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "The detail pane (bottom) shows origin info: which"),
-                                new HelpOverlay.Entry("", "POM file defines the selected element (useful for"),
-                                new HelpOverlay.Entry("", "understanding inherited configuration)."))),
-                new HelpOverlay.Section(
-                        "Colors",
-                        List.of(
-                                new HelpOverlay.Entry("cyan", "XML element names"),
-                                new HelpOverlay.Entry("yellow", "Attribute values and search highlights"),
-                                new HelpOverlay.Entry("green", "Search match count indicator"),
-                                new HelpOverlay.Entry("dim", "XML structure characters, metadata"))),
-                new HelpOverlay.Section(
-                        "Navigation",
-                        List.of(
-                                new HelpOverlay.Entry("\u2191 / \u2193", "Move selection up / down"),
-                                new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
-                                new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
-                                new HelpOverlay.Entry("\u2190 / \u2192", "Collapse / expand tree node"),
-                                new HelpOverlay.Entry("e", "Expand all nodes"),
-                                new HelpOverlay.Entry("w", "Collapse all (keeps root expanded)"),
-                                new HelpOverlay.Entry("Tab", "Switch Raw POM / Effective POM"))),
-                new HelpOverlay.Section(
-                        "Search",
-                        List.of(
-                                new HelpOverlay.Entry("/", "Enter search mode — type to search"),
-                                new HelpOverlay.Entry("n / N", "Next / previous search match"),
-                                new HelpOverlay.Entry("Esc", "Clear search or quit"))));
+        return HelpOverlay.parse("""
+                ## POM Browser
+                Browse the project's POM as an expandable XML tree.
+                Raw POM: the actual pom.xml file content as written.
+                Effective POM: the fully resolved POM after parent
+                inheritance, profile activation, and property
+                interpolation. Shows what Maven actually uses.
+                The detail pane (bottom) shows origin info: which
+                POM file defines the selected element (useful for
+                understanding inherited configuration).
+
+                ## Colors
+                cyan            XML element names
+                yellow          Attribute values and search highlights
+                green           Search match count indicator
+                dim             XML structure characters, metadata
+
+                ## Navigation
+                \u2191 / \u2193           Move selection up / down
+                PgUp / PgDn     Move selection up / down by one page
+                Home / End      Jump to first / last row
+                \u2190 / \u2192           Collapse / expand tree node
+                e               Expand all nodes
+                w               Collapse all (keeps root expanded)
+                Tab             Switch Raw POM / Effective POM
+                """ + SEARCH_HELP);
     }
 
     @Override
@@ -417,11 +405,7 @@ public class PomTui extends ToolPanel {
 
     private List<HelpOverlay.Section> buildHelpStandalone() {
         List<HelpOverlay.Section> sections = new ArrayList<>(helpSections());
-        sections.add(new HelpOverlay.Section(
-                "General",
-                List.of(
-                        new HelpOverlay.Entry("h", "Toggle this help screen"),
-                        new HelpOverlay.Entry("q / Esc", "Quit"))));
+        sections.addAll(HelpOverlay.parse(GENERAL_STANDALONE_HELP));
         return sections;
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -1295,41 +1295,36 @@ public class ReactorUpdatesTui extends ToolPanel {
 
     @Override
     public List<HelpOverlay.Section> helpSections() {
-        return List.of(
-                new HelpOverlay.Section(
-                        "Reactor Dependency Updates",
-                        List.of(
-                                new HelpOverlay.Entry("", "Aggregates dependency updates across all reactor"),
-                                new HelpOverlay.Entry("", "modules. Dependencies managed via properties (e.g."),
-                                new HelpOverlay.Entry("", "${jackson.version}) are grouped together — selecting"),
-                                new HelpOverlay.Entry("", "the group header toggles all dependencies in it."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "The 'N mod' column shows how many reactor modules"),
-                                new HelpOverlay.Entry("", "use each dependency. 'M' indicates a managed"),
-                                new HelpOverlay.Entry("", "dependency (from dependencyManagement)."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "When you apply updates, property-based deps edit"),
-                                new HelpOverlay.Entry("", "the <properties> in the POM that defines them;"),
-                                new HelpOverlay.Entry("", "direct deps edit the module's own POM."))),
-                new HelpOverlay.Section(
-                        "Colors",
-                        List.of(
-                                new HelpOverlay.Entry("green", "Patch update — bug fixes, safe to apply"),
-                                new HelpOverlay.Entry("yellow", "Minor update — new features, usually compatible"),
-                                new HelpOverlay.Entry("red", "Major update — breaking changes possible"),
-                                new HelpOverlay.Entry("cyan", "Property group header (${property.name})"))),
-                new HelpOverlay.Section(
-                        "Reactor Updates Actions",
-                        List.of(
-                                new HelpOverlay.Entry("↑ / ↓", "Move selection up / down"),
-                                new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
-                                new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
-                                new HelpOverlay.Entry("Space", "Toggle selection (group or individual)"),
-                                new HelpOverlay.Entry("a / n", "Select all / deselect all"),
-                                new HelpOverlay.Entry("Enter", "Apply selected updates to POM files"),
-                                new HelpOverlay.Entry("f / F", "Cycle filter: all → patch → minor → major"),
-                                new HelpOverlay.Entry("d", "Preview changes as a multi-file diff"),
-                                new HelpOverlay.Entry("i", "Toggle detail pane for selected row"))));
+        return HelpOverlay.parse("""
+                ## Reactor Dependency Updates
+                Aggregates dependency updates across all reactor
+                modules. Dependencies managed via properties (e.g.
+                ${jackson.version}) are grouped together — selecting
+                the group header toggles all dependencies in it.
+                The 'N mod' column shows how many reactor modules
+                use each dependency. 'M' indicates a managed
+                dependency (from dependencyManagement).
+                When you apply updates, property-based deps edit
+                the <properties> in the POM that defines them;
+                direct deps edit the module's own POM.
+
+                ## Colors
+                green           Patch update — bug fixes, safe to apply
+                yellow          Minor update — new features, usually compatible
+                red             Major update — breaking changes possible
+                cyan            Property group header (${property.name})
+
+                ## Reactor Updates Actions
+                ↑ / ↓           Move selection up / down
+                PgUp / PgDn     Move selection up / down by one page
+                Home / End      Jump to first / last row
+                Space           Toggle selection (group or individual)
+                a / n           Select all / deselect all
+                Enter           Apply selected updates to POM files
+                f / F           Cycle filter: all → patch → minor → major
+                d               Preview changes as a multi-file diff
+                i               Toggle detail pane for selected row
+                """);
     }
 
     @Override
@@ -1349,20 +1344,19 @@ public class ReactorUpdatesTui extends ToolPanel {
 
     private List<HelpOverlay.Section> buildHelpStandalone() {
         List<HelpOverlay.Section> sections = new ArrayList<>(helpSections());
-        sections.add(new HelpOverlay.Section(
-                "Modules View",
-                List.of(
-                        new HelpOverlay.Entry("", "Shows the reactor module tree with update counts."),
-                        new HelpOverlay.Entry("↑ / ↓", "Move selection up / down"),
-                        new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
-                        new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
-                        new HelpOverlay.Entry("← / →", "Collapse / expand module tree"))));
-        sections.add(new HelpOverlay.Section(
-                "General",
-                List.of(
-                        new HelpOverlay.Entry("Tab", "Switch Dependencies / Modules view"),
-                        new HelpOverlay.Entry("h", "Toggle this help screen"),
-                        new HelpOverlay.Entry("q / Esc", "Quit"))));
+        sections.addAll(HelpOverlay.parse("""
+                ## Modules View
+                Shows the reactor module tree with update counts.
+                ↑ / ↓           Move selection up / down
+                PgUp / PgDn     Move selection up / down by one page
+                Home / End      Jump to first / last row
+                ← / →           Collapse / expand module tree
+
+                ## General
+                Tab             Switch Dependencies / Modules view
+                h               Toggle this help screen
+                q / Esc         Quit
+                """));
         return sections;
     }
 }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReactorUpdatesTui.java
@@ -1315,9 +1315,7 @@ public class ReactorUpdatesTui extends ToolPanel {
                 cyan            Property group header (${property.name})
 
                 ## Reactor Updates Actions
-                ↑ / ↓           Move selection up / down
-                PgUp / PgDn     Move selection up / down by one page
-                Home / End      Jump to first / last row
+                """ + NAV_KEYS + """
                 Space           Toggle selection (group or individual)
                 a / n           Select all / deselect all
                 Enter           Apply selected updates to POM files
@@ -1347,9 +1345,7 @@ public class ReactorUpdatesTui extends ToolPanel {
         sections.addAll(HelpOverlay.parse("""
                 ## Modules View
                 Shows the reactor module tree with update counts.
-                ↑ / ↓           Move selection up / down
-                PgUp / PgDn     Move selection up / down by one page
-                Home / End      Jump to first / last row
+                """ + NAV_KEYS + """
                 ← / →           Collapse / expand module tree
 
                 ## General

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
@@ -331,26 +331,23 @@ public class SearchTui extends ToolPanel {
 
     @Override
     public List<HelpOverlay.Section> helpSections() {
-        return List.of(
-                new HelpOverlay.Section(
-                        "Maven Central Search",
-                        List.of(
-                                new HelpOverlay.Entry("", "Search for artifacts on Maven Central."),
-                                new HelpOverlay.Entry("", "Type to search, use arrows to navigate."))),
-                new HelpOverlay.Section(
-                        "Search Syntax",
-                        List.of(
-                                new HelpOverlay.Entry("free text", "Full-text search"),
-                                new HelpOverlay.Entry("g:groupId", "Search by groupId"),
-                                new HelpOverlay.Entry("a:artifactId", "Search by artifactId"),
-                                new HelpOverlay.Entry("g:... AND a:...", "Combined search"))),
-                new HelpOverlay.Section(
-                        "Search Actions",
-                        List.of(
-                                new HelpOverlay.Entry("↑ / ↓", "Navigate results"),
-                                new HelpOverlay.Entry("← / →", "Cycle through versions"),
-                                new HelpOverlay.Entry("Enter", "Select artifact / confirm search"),
-                                new HelpOverlay.Entry("Esc", "Back to search / quit"))));
+        return HelpOverlay.parse("""
+                ## Maven Central Search
+                Search for artifacts on Maven Central.
+                Type to search, use arrows to navigate.
+
+                ## Search Syntax
+                free text       Full-text search
+                g:groupId       Search by groupId
+                a:artifactId    Search by artifactId
+                g:... AND a:...  Combined search
+
+                ## Search Actions
+                ↑ / ↓           Navigate results
+                ← / →           Cycle through versions
+                Enter           Select artifact / confirm search
+                Esc             Back to search / quit
+                """);
     }
 
     @Override

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -67,7 +67,7 @@ public abstract class ToolPanel {
             ## Search
             /               Enter search mode — type to search
             n / N           Next / previous search match
-            Esc             Clear search or quit
+            Esc             Exit search mode
             """;
 
     protected static final String GENERAL_STANDALONE_HELP = """

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -56,6 +56,13 @@ public abstract class ToolPanel {
     /** Help overlay for standalone mode (shell has its own for panel mode). */
     protected final HelpOverlay helpOverlay = new HelpOverlay();
 
+    /** Navigation key entries shared across multiple TUI help screens. No section header. */
+    protected static final String NAV_KEYS = """
+            ↑ / ↓           Move selection up / down
+            PgUp / PgDn     Move selection up / down by one page
+            Home / End      Jump to first / last row
+            """;
+
     protected static final String SEARCH_HELP = """
             ## Search
             /               Enter search mode — type to search

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -56,6 +56,32 @@ public abstract class ToolPanel {
     /** Help overlay for standalone mode (shell has its own for panel mode). */
     protected final HelpOverlay helpOverlay = new HelpOverlay();
 
+    protected static final String NAVIGATION_HELP = """
+            ## Navigation
+            ↑ / ↓           Move selection up / down
+            PgUp / PgDn     Move selection up / down by one page
+            Home / End       Jump to first / last row
+            """;
+
+    protected static final String SEARCH_HELP = """
+            ## Search
+            /               Enter search mode — type to search
+            n / N           Next / previous search match
+            Esc             Clear search or quit
+            """;
+
+    protected static final String GENERAL_STANDALONE_HELP = """
+            ## General
+            h               Toggle this help screen
+            q / Esc         Quit
+            """;
+
+    protected static final String GENERAL_STANDALONE_SAVE_HELP = """
+            ## General
+            h               Toggle this help screen
+            q / Esc         Quit (prompts to save if modified)
+            """;
+
     /**
      * Handle help overlay slide-up rendering in standalone mode.
      * If help is active, animates it upward from the bottom of the content area,

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -56,13 +56,6 @@ public abstract class ToolPanel {
     /** Help overlay for standalone mode (shell has its own for panel mode). */
     protected final HelpOverlay helpOverlay = new HelpOverlay();
 
-    protected static final String NAVIGATION_HELP = """
-            ## Navigation
-            ↑ / ↓           Move selection up / down
-            PgUp / PgDn     Move selection up / down by one page
-            Home / End       Jump to first / last row
-            """;
-
     protected static final String SEARCH_HELP = """
             ## Search
             /               Enter search mode — type to search
@@ -74,12 +67,6 @@ public abstract class ToolPanel {
             ## General
             h               Toggle this help screen
             q / Esc         Quit
-            """;
-
-    protected static final String GENERAL_STANDALONE_SAVE_HELP = """
-            ## General
-            h               Toggle this help screen
-            q / Esc         Quit (prompts to save if modified)
             """;
 
     /**

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -236,18 +236,17 @@ public class TreeTui extends ToolPanel {
 
     @Override
     public List<HelpOverlay.Section> helpSections() {
-        return List.of(new HelpOverlay.Section(
-                "Dependency Tree",
-                List.of(
-                        new HelpOverlay.Entry("", "Shows the resolved dependency tree."),
-                        new HelpOverlay.Entry("", ""),
-                        new HelpOverlay.Entry("↑ / ↓", "Move selection up / down"),
-                        new HelpOverlay.Entry("← / →", "Collapse / expand tree node"),
-                        new HelpOverlay.Entry("e / w", "Expand all / collapse all"),
-                        new HelpOverlay.Entry("/", "Search by groupId or artifactId"),
-                        new HelpOverlay.Entry("c", "Jump to next conflict"),
-                        new HelpOverlay.Entry("r", "Reverse path (why was this pulled in?)"),
-                        new HelpOverlay.Entry("s", "Cycle scope: compile → runtime → test"))));
+        return HelpOverlay.parse("""
+                ## Dependency Tree
+                Shows the resolved dependency tree.
+                ↑ / ↓           Move selection up / down
+                ← / →           Collapse / expand tree node
+                e / w           Expand all / collapse all
+                /               Search by groupId or artifactId
+                c               Jump to next conflict
+                r               Reverse path (why was this pulled in?)
+                s               Cycle scope: compile → runtime → test
+                """);
     }
 
     @Override
@@ -725,23 +724,17 @@ public class TreeTui extends ToolPanel {
     }
 
     private List<HelpOverlay.Section> buildHelpStandalone() {
-        List<HelpOverlay.Section> sections = new ArrayList<>();
-        sections.addAll(helpSections());
-        sections.add(new HelpOverlay.Section(
-                "Colors (by scope)",
-                List.of(
-                        new HelpOverlay.Entry("default", "compile scope"),
-                        new HelpOverlay.Entry("blue", "runtime scope"),
-                        new HelpOverlay.Entry("magenta", "provided scope"),
-                        new HelpOverlay.Entry("dark gray", "test scope"),
-                        new HelpOverlay.Entry("red", "system scope"),
-                        new HelpOverlay.Entry("yellow", "Version conflict"),
-                        new HelpOverlay.Entry("dim", "Scope label, optional marker"))));
-        sections.add(new HelpOverlay.Section(
-                "General",
-                List.of(
-                        new HelpOverlay.Entry("h", "Toggle this help screen"),
-                        new HelpOverlay.Entry("q / Esc", "Quit"))));
+        List<HelpOverlay.Section> sections = new ArrayList<>(helpSections());
+        sections.addAll(HelpOverlay.parse("""
+                ## Colors (by scope)
+                default         compile scope
+                blue            runtime scope
+                magenta         provided scope
+                dark gray       test scope
+                red             system scope
+                yellow          Version conflict
+                dim             Scope label, optional marker
+                """ + GENERAL_STANDALONE_HELP));
         return sections;
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -541,8 +541,6 @@ public class UpdatesTui extends ToolPanel {
                 Enter           Apply selected updates to POM
                 d               Preview POM changes as unified diff
                 s / S           Sort by column / reverse sort
-                /               Search dependencies by name
-                n / N           Next / previous search match
                 """);
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -921,9 +921,7 @@ public class UpdatesTui extends ToolPanel {
         List<HelpOverlay.Section> sections = new ArrayList<>(helpSections());
         sections.addAll(HelpOverlay.parse("""
                 ## General
-                ↑ / ↓           Move selection up / down
-                PgUp / PgDn     Move selection up / down by one page
-                Home / End      Jump to first / last row
+                """ + NAV_KEYS + """
                 d               Preview POM changes as a unified diff
                 h               Toggle this help screen
                 q / Esc         Quit (prompts to save if modified)

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -512,43 +512,38 @@ public class UpdatesTui extends ToolPanel {
 
     @Override
     public List<HelpOverlay.Section> helpSections() {
-        return List.of(
-                new HelpOverlay.Section(
-                        "Dependency Updates",
-                        List.of(
-                                new HelpOverlay.Entry("", "Checks Maven Central for newer versions of each"),
-                                new HelpOverlay.Entry("", "declared dependency. Versions are resolved in"),
-                                new HelpOverlay.Entry("", "the background — status bar shows progress."),
-                                new HelpOverlay.Entry("", ""),
-                                new HelpOverlay.Entry("", "Select updates with Space, then press Enter to"),
-                                new HelpOverlay.Entry("", "apply them to the POM. Use 'd' to preview the"),
-                                new HelpOverlay.Entry("", "changes as a unified diff before committing."))),
-                new HelpOverlay.Section(
-                        "Filters",
-                        List.of(
-                                new HelpOverlay.Entry("f / F", "Cycle filter: All > Patch > Minor > Major"),
-                                new HelpOverlay.Entry("", "All — show all dependencies (default)"),
-                                new HelpOverlay.Entry("", "Patch — only patch updates (bug fixes)"),
-                                new HelpOverlay.Entry("", "Minor — only minor updates (new features)"),
-                                new HelpOverlay.Entry("", "Major — only major updates (breaking changes)"))),
-                new HelpOverlay.Section(
-                        "Colors",
-                        List.of(
-                                new HelpOverlay.Entry("green", "Patch update — safe to apply"),
-                                new HelpOverlay.Entry("yellow", "Minor update — usually compatible"),
-                                new HelpOverlay.Entry("red", "Major update — breaking changes possible"),
-                                new HelpOverlay.Entry("dim", "No update available or up-to-date"))),
-                new HelpOverlay.Section(
-                        "Actions",
-                        List.of(
-                                new HelpOverlay.Entry("↑ / ↓", "Move selection up / down"),
-                                new HelpOverlay.Entry("Space", "Toggle selection of current dependency"),
-                                new HelpOverlay.Entry("a / n", "Select all / deselect all"),
-                                new HelpOverlay.Entry("Enter", "Apply selected updates to POM"),
-                                new HelpOverlay.Entry("d", "Preview POM changes as unified diff"),
-                                new HelpOverlay.Entry("s / S", "Sort by column / reverse sort"),
-                                new HelpOverlay.Entry("/", "Search dependencies by name"),
-                                new HelpOverlay.Entry("n / N", "Next / previous search match"))));
+        return HelpOverlay.parse("""
+                ## Dependency Updates
+                Checks Maven Central for newer versions of each
+                declared dependency. Versions are resolved in
+                the background — status bar shows progress.
+                Select updates with Space, then press Enter to
+                apply them to the POM. Use 'd' to preview the
+                changes as a unified diff before committing.
+
+                ## Filters
+                f / F           Cycle filter: All > Patch > Minor > Major
+                All — show all dependencies (default)
+                Patch — only patch updates (bug fixes)
+                Minor — only minor updates (new features)
+                Major — only major updates (breaking changes)
+
+                ## Colors
+                green           Patch update — safe to apply
+                yellow          Minor update — usually compatible
+                red             Major update — breaking changes possible
+                dim             No update available or up-to-date
+
+                ## Actions
+                ↑ / ↓           Move selection up / down
+                Space           Toggle selection of current dependency
+                a / n           Select all / deselect all
+                Enter           Apply selected updates to POM
+                d               Preview POM changes as unified diff
+                s / S           Sort by column / reverse sort
+                /               Search dependencies by name
+                n / N           Next / previous search match
+                """);
     }
 
     @Override
@@ -924,15 +919,15 @@ public class UpdatesTui extends ToolPanel {
 
     private List<HelpOverlay.Section> buildHelpStandalone() {
         List<HelpOverlay.Section> sections = new ArrayList<>(helpSections());
-        sections.add(new HelpOverlay.Section(
-                "General",
-                List.of(
-                        new HelpOverlay.Entry("↑ / ↓", "Move selection up / down"),
-                        new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
-                        new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
-                        new HelpOverlay.Entry("d", "Preview POM changes as a unified diff"),
-                        new HelpOverlay.Entry("h", "Toggle this help screen"),
-                        new HelpOverlay.Entry("q / Esc", "Quit (prompts to save if modified)"))));
+        sections.addAll(HelpOverlay.parse("""
+                ## General
+                ↑ / ↓           Move selection up / down
+                PgUp / PgDn     Move selection up / down by one page
+                Home / End      Jump to first / last row
+                d               Preview POM changes as a unified diff
+                h               Toggle this help screen
+                q / Esc         Quit (prompts to save if modified)
+                """));
         return sections;
     }
 

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/HelpOverlayTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/HelpOverlayTest.java
@@ -63,6 +63,8 @@ class HelpOverlayTest {
         assertThat(sections.get(0).entries().get(0).key()).isEmpty();
         assertThat(sections.get(0).entries().get(0).description())
                 .isEqualTo("This is a description line without a key.");
+        assertThat(sections.get(0).entries().get(1).key()).isEmpty();
+        assertThat(sections.get(0).entries().get(1).description()).isEqualTo("Another description line.");
     }
 
     @Test

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/HelpOverlayTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/HelpOverlayTest.java
@@ -130,5 +130,6 @@ class HelpOverlayTest {
         assertThat(sections.get(0).entries().get(0).key()).isEqualTo("a / b");
         assertThat(sections.get(0).entries().get(0).description()).isEqualTo("Description with  internal  spaces");
         assertThat(sections.get(0).entries().get(1).key()).isEqualTo("single-word-key");
+        assertThat(sections.get(0).entries().get(1).description()).isEqualTo("value");
     }
 }

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/HelpOverlayTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/HelpOverlayTest.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class HelpOverlayTest {
+
+    @Test
+    void parseMultipleSections() {
+        List<HelpOverlay.Section> sections = HelpOverlay.parse("""
+                ## Navigation
+                ↑ / ↓           Move up / down
+                PgUp / PgDn     Page up / down
+
+                ## Actions
+                Enter           Confirm
+                q / Esc         Quit
+                """);
+
+        assertThat(sections).hasSize(2);
+        assertThat(sections.get(0).title()).isEqualTo("Navigation");
+        assertThat(sections.get(0).entries()).hasSize(2);
+        assertThat(sections.get(0).entries().get(0).key()).isEqualTo("↑ / ↓");
+        assertThat(sections.get(0).entries().get(0).description()).isEqualTo("Move up / down");
+        assertThat(sections.get(0).entries().get(1).key()).isEqualTo("PgUp / PgDn");
+
+        assertThat(sections.get(1).title()).isEqualTo("Actions");
+        assertThat(sections.get(1).entries()).hasSize(2);
+        assertThat(sections.get(1).entries().get(0).key()).isEqualTo("Enter");
+        assertThat(sections.get(1).entries().get(1).key()).isEqualTo("q / Esc");
+    }
+
+    @Test
+    void parseDescriptionOnlyEntries() {
+        List<HelpOverlay.Section> sections = HelpOverlay.parse("""
+                ## About
+                This is a description line without a key.
+                Another description line.
+                """);
+
+        assertThat(sections).hasSize(1);
+        assertThat(sections.get(0).entries()).hasSize(2);
+        assertThat(sections.get(0).entries().get(0).key()).isEmpty();
+        assertThat(sections.get(0).entries().get(0).description())
+                .isEqualTo("This is a description line without a key.");
+    }
+
+    @Test
+    void parseBlankLinesIgnored() {
+        List<HelpOverlay.Section> sections = HelpOverlay.parse("""
+                ## Section
+
+
+                key1            value1
+
+
+                key2            value2
+
+                """);
+
+        assertThat(sections).hasSize(1);
+        assertThat(sections.get(0).entries()).hasSize(2);
+    }
+
+    @Test
+    void parseEmptyInput() {
+        assertThat(HelpOverlay.parse("")).isEmpty();
+        assertThat(HelpOverlay.parse("   \n  \n  ")).isEmpty();
+    }
+
+    @Test
+    void parseLinesBeforeFirstSection() {
+        List<HelpOverlay.Section> sections = HelpOverlay.parse("""
+                stray line without a section
+                ## First
+                a               b
+                """);
+
+        assertThat(sections).hasSize(1);
+        assertThat(sections.get(0).title()).isEqualTo("First");
+    }
+
+    @Test
+    void parseConcatenatedTextBlocks() {
+        String text = """
+                ## Nav
+                ↑ / ↓           Move
+                """ + """
+                ## General
+                h               Help
+                """;
+        List<HelpOverlay.Section> sections = HelpOverlay.parse(text);
+
+        assertThat(sections).hasSize(2);
+        assertThat(sections.get(0).title()).isEqualTo("Nav");
+        assertThat(sections.get(1).title()).isEqualTo("General");
+    }
+
+    @Test
+    void parseSplitsOnTwoOrMoreSpaces() {
+        List<HelpOverlay.Section> sections = HelpOverlay.parse("""
+                ## Keys
+                a / b           Description with  internal  spaces
+                single-word-key  value
+                """);
+
+        assertThat(sections).hasSize(1);
+        assertThat(sections.get(0).entries().get(0).key()).isEqualTo("a / b");
+        assertThat(sections.get(0).entries().get(0).description()).isEqualTo("Description with  internal  spaces");
+        assertThat(sections.get(0).entries().get(1).key()).isEqualTo("single-word-key");
+    }
+}


### PR DESCRIPTION
## Summary
- Add `HelpOverlay.parse(String)` method that converts a simple markdown-like text format (`## Section` headers, 2+ space key/description delimiter) into `List<Section>`
- Add shared help text constants (`NAVIGATION_HELP`, `SEARCH_HELP`, `GENERAL_STANDALONE_HELP`, `GENERAL_STANDALONE_SAVE_HELP`) to `ToolPanel`
- Convert all 9 TUI files (`PomTui`, `TreeTui`, `ConflictsTui`, `DependenciesTui`, `UpdatesTui`, `SearchTui`, `AuditTui`, `AlignTui`, `ReactorUpdatesTui`) from verbose `new Section(..., List.of(new Entry(...)))` to `HelpOverlay.parse("""...""")` text blocks

## Test plan
- [x] `./mvnw compile -B` passes
- [x] `./mvnw test -B` passes
- [ ] Manual verification: press `h` in each tool to confirm help renders correctly
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Help overlays throughout the UI are now created by parsing multi-line help text instead of manual object assembly, preserving content, order, and behavior.
* **New Tests**
  * Added unit tests validating multi-section help parsing, key/description extraction, and edge-case handling.
* **Chore**
  * Introduced shared multi-line help text constants for navigation, search, and general/standalone help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->