### PR TITLE
feat: add LibYear computation and display to updates TUI

### DIFF
--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
@@ -18,6 +18,7 @@
  */
 package eu.maveniverse.maven.pilot;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -64,6 +65,9 @@ public class ReactorCollector {
         String newestVersion;
         VersionComparator.UpdateType updateType;
         boolean selected;
+        LocalDate currentReleaseDate;
+        LocalDate newestReleaseDate;
+        float libYears = -1;
 
         AggregatedDependency(String groupId, String artifactId) {
             this.groupId = groupId;
@@ -98,6 +102,7 @@ public class ReactorCollector {
         VersionComparator.UpdateType updateType;
         boolean selected;
         boolean expanded = true;
+        float libYears = -1;
 
         PropertyGroup(String propertyName, String rawExpression, String resolvedVersion, PilotProject origin) {
             this.propertyName = propertyName;

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReleaseDateFetcher.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReleaseDateFetcher.java
@@ -20,7 +20,6 @@ package eu.maveniverse.maven.pilot;
 
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.nio.file.Path;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -28,9 +27,6 @@ import java.time.ZoneId;
 class ReleaseDateFetcher {
 
     static LocalDate fetchReleaseDate(String groupId, String artifactId, String version) {
-        LocalDate local = fetchFromLocal(groupId, artifactId, version);
-        if (local != null) return local;
-
         try {
             String path = groupId.replace('.', '/') + "/" + artifactId + "/" + version + "/" + artifactId + "-"
                     + version + ".pom";
@@ -56,28 +52,6 @@ class ReleaseDateFetcher {
             } finally {
                 conn.disconnect();
             }
-        } catch (Exception e) {
-            return null;
-        }
-    }
-
-    private static LocalDate fetchFromLocal(String groupId, String artifactId, String version) {
-        try {
-            String localRepo = System.getProperty("maven.repo.local");
-            if (localRepo == null) {
-                localRepo = System.getProperty("user.home") + "/.m2/repository";
-            }
-            Path pomFile = Path.of(
-                    localRepo, groupId.replace('.', '/'), artifactId, version, artifactId + "-" + version + ".pom");
-            if (!pomFile.toFile().isFile()) return null;
-
-            long lastModified = pomFile.toFile().lastModified();
-            if (lastModified > 0) {
-                return Instant.ofEpochMilli(lastModified)
-                        .atZone(ZoneId.systemDefault())
-                        .toLocalDate();
-            }
-            return null;
         } catch (Exception e) {
             return null;
         }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReleaseDateFetcher.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReleaseDateFetcher.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+class ReleaseDateFetcher {
+
+    static LocalDate fetchReleaseDate(String groupId, String artifactId, String version) {
+        LocalDate local = fetchFromLocal(groupId, artifactId, version);
+        if (local != null) return local;
+
+        try {
+            String path = groupId.replace('.', '/') + "/" + artifactId + "/" + version + "/" + artifactId + "-"
+                    + version + ".pom";
+            String url = "https://repo1.maven.org/maven2/" + path;
+
+            HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
+            try {
+                conn.setRequestMethod("HEAD");
+                conn.setConnectTimeout(5_000);
+                conn.setReadTimeout(5_000);
+
+                if (conn.getResponseCode() != 200) {
+                    return null;
+                }
+
+                long lastModified = conn.getLastModified();
+                if (lastModified > 0) {
+                    return Instant.ofEpochMilli(lastModified)
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalDate();
+                }
+                return null;
+            } finally {
+                conn.disconnect();
+            }
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static LocalDate fetchFromLocal(String groupId, String artifactId, String version) {
+        try {
+            String localRepo = System.getProperty("maven.repo.local");
+            if (localRepo == null) {
+                localRepo = System.getProperty("user.home") + "/.m2/repository";
+            }
+            Path pomFile = Path.of(
+                    localRepo, groupId.replace('.', '/'), artifactId, version, artifactId + "-" + version + ".pom");
+            if (!pomFile.toFile().isFile()) return null;
+
+            long lastModified = pomFile.toFile().lastModified();
+            if (lastModified > 0) {
+                return Instant.ofEpochMilli(lastModified)
+                        .atZone(ZoneId.systemDefault())
+                        .toLocalDate();
+            }
+            return null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -308,6 +308,7 @@ public class UpdatesTui extends ToolPanel {
         datesLoading = false;
         propagateLibYearsToGroups();
         status = buildStatusMessage();
+        onSortChanged();
     }
 
     private String buildStatusMessage() {
@@ -490,7 +491,8 @@ public class UpdatesTui extends ToolPanel {
         } else {
             ly = row.dependency.libYears;
         }
-        return ly < 0 ? "" : String.valueOf(ly);
+        if (ly < 0) return "";
+        return String.format(java.util.Locale.US, "%010.3f", ly);
     }
 
     private String extractModuleCount(ReactorRow row) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -43,6 +43,7 @@ import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.maven.Coordinates;
 import eu.maveniverse.domtrip.maven.PomEditor;
 import java.nio.file.Path;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -145,6 +146,8 @@ public class UpdatesTui extends ToolPanel {
     boolean loading = true;
     int loadedCount = 0;
     int failedCount = 0;
+    int dateFetchesPending;
+    boolean datesLoading;
 
     private TuiRunner runner;
 
@@ -174,7 +177,7 @@ public class UpdatesTui extends ToolPanel {
         this.singleModule = reactorModel.allModules.size() <= 1;
         this.versionResolver = versionResolver;
         this.sessionProvider = sessionProvider != null ? sessionProvider : defaultSessionProvider();
-        this.sortState = new SortState(6);
+        this.sortState = new SortState(7);
         if (!reactorModel.allModules.isEmpty()) {
             moduleTableState.select(0);
         }
@@ -235,15 +238,114 @@ public class UpdatesTui extends ToolPanel {
         computePropertyGroupVersions();
         updateReactorCounts();
         buildDisplayRows();
+        status = buildStatusMessage();
+        fetchReleaseDates();
+    }
+
+    private void fetchReleaseDates() {
+        int count = 0;
+        for (var dep : reactorResult.allDependencies) {
+            if (dep.hasUpdate()) count += 2;
+        }
+        dateFetchesPending = count;
+        if (dateFetchesPending == 0) return;
+        datesLoading = true;
+        for (var dep : reactorResult.allDependencies) {
+            if (!dep.hasUpdate()) continue;
+            CompletableFuture.supplyAsync(
+                            () -> ReleaseDateFetcher.fetchReleaseDate(dep.groupId, dep.artifactId, dep.primaryVersion),
+                            httpPool)
+                    .thenAccept(date -> runner.runOnRenderThread(() -> {
+                        dep.currentReleaseDate = date;
+                        computeLibYear(dep);
+                        propagateLibYearsToGroups();
+                        if (--dateFetchesPending <= 0) onDatesComplete();
+                    }))
+                    .exceptionally(ex -> {
+                        runner.runOnRenderThread(() -> {
+                            if (--dateFetchesPending <= 0) onDatesComplete();
+                        });
+                        return null;
+                    });
+            CompletableFuture.supplyAsync(
+                            () -> ReleaseDateFetcher.fetchReleaseDate(dep.groupId, dep.artifactId, dep.newestVersion),
+                            httpPool)
+                    .thenAccept(date -> runner.runOnRenderThread(() -> {
+                        dep.newestReleaseDate = date;
+                        computeLibYear(dep);
+                        propagateLibYearsToGroups();
+                        if (--dateFetchesPending <= 0) onDatesComplete();
+                    }))
+                    .exceptionally(ex -> {
+                        runner.runOnRenderThread(() -> {
+                            if (--dateFetchesPending <= 0) onDatesComplete();
+                        });
+                        return null;
+                    });
+        }
+    }
+
+    private void computeLibYear(ReactorCollector.AggregatedDependency dep) {
+        if (dep.currentReleaseDate != null && dep.newestReleaseDate != null) {
+            long weeks = ChronoUnit.WEEKS.between(dep.currentReleaseDate, dep.newestReleaseDate);
+            dep.libYears = Math.max(0, weeks / 52.0f);
+        }
+    }
+
+    private void propagateLibYearsToGroups() {
+        for (var group : reactorResult.propertyGroups) {
+            float maxLy = -1;
+            for (var dep : group.dependencies) {
+                if (dep.libYears > maxLy) {
+                    maxLy = dep.libYears;
+                }
+            }
+            group.libYears = maxLy;
+        }
+    }
+
+    private void onDatesComplete() {
+        datesLoading = false;
+        propagateLibYearsToGroups();
+        status = buildStatusMessage();
+    }
+
+    private String buildStatusMessage() {
         long updates = reactorResult.allDependencies.stream()
                 .filter(ReactorCollector.AggregatedDependency::hasUpdate)
                 .count();
-        status = singleModule
+        String msg = singleModule
                 ? updates + " update(s) available"
                 : updates + " update(s) available across " + reactorModel.allModules.size() + " modules";
         if (failedCount > 0) {
-            status += "; " + failedCount + " lookup(s) failed";
+            msg += "; " + failedCount + " lookup(s) failed";
         }
+        if (!datesLoading) {
+            float total = totalLibYears();
+            if (total > 0) {
+                int tenths = Math.round(total * 10);
+                msg += " \u2014 " + (tenths / 10) + "." + (tenths % 10) + " libyear(s) behind";
+            }
+        }
+        return msg;
+    }
+
+    private float totalLibYears() {
+        float total = 0;
+        Set<String> seen = new LinkedHashSet<>();
+        for (var dep : reactorResult.allDependencies) {
+            if (dep.hasUpdate() && dep.libYears >= 0 && seen.add(dep.ga())) {
+                total += dep.libYears;
+            }
+        }
+        return total;
+    }
+
+    private String formatAge(float libYears, boolean hasUpdate) {
+        if (!hasUpdate) return "";
+        if (libYears < 0) return datesLoading ? "\u2026" : "";
+        int tenths = Math.round(libYears * 10);
+        return (tenths / 10) + "." + (tenths % 10) + "y";
     }
 
     private void computePropertyGroupVersions() {
@@ -331,6 +433,7 @@ public class UpdatesTui extends ToolPanel {
         extractors.add(this::extractCurrentVersion);
         extractors.add(this::extractArrow);
         extractors.add(this::extractNewestVersion);
+        extractors.add(this::extractAge);
         if (!singleModule) {
             extractors.add(this::extractModuleCount);
         }
@@ -376,6 +479,18 @@ public class UpdatesTui extends ToolPanel {
             return row.dependency.newestVersion;
         }
         return "";
+    }
+
+    private String extractAge(ReactorRow row) {
+        float ly;
+        if (row.isGroupHeader()) {
+            ly = row.propertyGroup.libYears;
+        } else if (row.dependency.isPropertyManaged()) {
+            return "";
+        } else {
+            ly = row.dependency.libYears;
+        }
+        return ly < 0 ? "" : String.valueOf(ly);
     }
 
     private String extractModuleCount(ReactorRow row) {
@@ -963,13 +1078,13 @@ public class UpdatesTui extends ToolPanel {
                 .borderStyle(borderStyle())
                 .build();
 
-        List<String> headers = List.of("", "dependency / property", "current", "", "available", "info");
+        List<String> headers = List.of("", "dependency / property", "current", "", "available", "age", "info");
         Row header = sortState.decorateHeader(headers, theme.tableHeader());
 
         List<Row> rows = new ArrayList<>();
         if (displayRows.isEmpty()) {
             String msg = loading ? "Checking versions…" : "No updates available";
-            int colCount = 6;
+            int colCount = 7;
             List<Cell> cells = new ArrayList<>();
             cells.add(Cell.empty());
             cells.add(Cell.from(msg));
@@ -983,10 +1098,11 @@ public class UpdatesTui extends ToolPanel {
 
         List<Constraint> widths = List.of(
                 Constraint.length(3),
-                Constraint.percentage(40),
-                Constraint.percentage(15),
+                Constraint.percentage(35),
+                Constraint.percentage(14),
                 Constraint.length(3),
-                Constraint.percentage(15),
+                Constraint.percentage(14),
+                Constraint.length(6),
                 Constraint.percentage(10));
         Table table = Table.builder()
                 .header(header)
@@ -1016,11 +1132,12 @@ public class UpdatesTui extends ToolPanel {
         String current = group.resolvedVersion != null ? group.resolvedVersion : "";
         String arrow = group.hasUpdate() ? "→" : "";
         String available = group.hasUpdate() ? group.newestVersion : "";
+        String age = formatAge(group.libYears, group.hasUpdate());
         String info = singleModule ? "" : group.totalModuleCount() + " mod";
 
         Style style = theme.propertyGroupHeader();
         if (highlight) style = style.bg(theme.searchHighlightBg());
-        return Row.from(check, name, current, arrow, available, info).style(style);
+        return Row.from(check, name, current, arrow, available, age, info).style(style);
     }
 
     private Row createDependencyRow(ReactorRow row, boolean highlight) {
@@ -1046,6 +1163,7 @@ public class UpdatesTui extends ToolPanel {
                 : Style.create();
         if (highlight) style = style.bg(theme.searchHighlightBg());
 
+        String age = inGroup ? "" : formatAge(dep.libYears, dep.hasUpdate());
         String info = "";
         if (!singleModule) {
             int modCount = dep.moduleCount();
@@ -1054,7 +1172,7 @@ public class UpdatesTui extends ToolPanel {
                 info += " M";
             }
         }
-        return Row.from(check, ga, current, arrow, available, info).style(style);
+        return Row.from(check, ga, current, arrow, available, age, info).style(style);
     }
 
     private void renderDetailPane(Frame frame, Rect area) {
@@ -1358,7 +1476,7 @@ public class UpdatesTui extends ToolPanel {
         if (!isSubViewEnabled(index)) return;
         view = View.values()[index];
         clearSearch();
-        int depsCols = 6;
+        int depsCols = 7;
         sortState = new SortState(view == View.DEPENDENCIES ? depsCols : 2);
     }
 
@@ -1380,9 +1498,13 @@ public class UpdatesTui extends ToolPanel {
         List<Constraint> widths;
         if (view == View.DEPENDENCIES) {
             widths = List.of(
-                    Constraint.length(3), Constraint.percentage(40),
-                    Constraint.percentage(15), Constraint.length(3),
-                    Constraint.percentage(15), Constraint.percentage(10));
+                    Constraint.length(3),
+                    Constraint.percentage(35),
+                    Constraint.percentage(14),
+                    Constraint.length(3),
+                    Constraint.percentage(14),
+                    Constraint.length(6),
+                    Constraint.percentage(10));
         } else {
             widths = List.of(Constraint.percentage(75), Constraint.percentage(25));
         }


### PR DESCRIPTION
## Summary

- **ReleaseDateFetcher**: new utility that fetches release dates via HTTP HEAD requests to Maven Central (local repo first, 5s timeouts)
- **LibYear computation**: after version resolution completes, fires two async HEAD requests per dependency (current + newest version) to compute `weeks_between / 52.0`
- **Age column**: new "age" column in the updates table showing values like `1.3y`, `0.2y`, or `…` while loading
- **Status bar total**: appends total libyear sum after all dates resolve, e.g. `"12 update(s) available — 8.3 libyear(s) behind"`
- **Sort support**: age column is sortable via column header click or `s` key

Depends on #63.

## Test plan

- [x] `./mvnw compile -B` passes
- [x] `./mvnw test -B` passes
- [ ] Manual: run `pilot:updates` on a multi-module project, verify age column shows `…` initially then fills in
- [ ] Manual: verify total libyear appears in status bar after loading completes
- [ ] Manual: verify sorting by age column works
- [ ] Manual: single-module project also shows libyear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Dependencies view now displays release date and age information for each dependency
  * Introduced "libyear" metric showing how many years behind each dependency is from its latest release
  * Added age column to the Dependencies view table
  * Status messages now include total libyears-behind information once release dates are retrieved

<!-- end of auto-generated comment: release notes by coderabbit.ai -->