### PR TITLE
feat: TUI dividers, async conflicts, flicker fix

### DIFF
--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
@@ -94,8 +94,6 @@ public class AlignTui extends ToolPanel {
     private String alignedPomContent;
     private Map<Path, String> alignedPomContents; // cross-POM mode
 
-    private TuiRunner runner;
-
     public AlignTui(String pomPath, String projectGav, AlignOptions detectedOptions, ParentPomInfo parentInfo) {
         this(pomPath, List.of(), projectGav, detectedOptions, parentInfo);
     }
@@ -669,11 +667,6 @@ public class AlignTui extends ToolPanel {
             spans.add(Span.raw(":Apply"));
         }
         return spans;
-    }
-
-    @Override
-    public void setRunner(TuiRunner runner) {
-        this.runner = runner;
     }
 
     // -- Rendering --

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -671,6 +671,7 @@ public class AuditTui extends ToolPanel {
 
         setTableArea(zones.get(0), block);
         frame.renderStatefulWidget(table, zones.get(0), tableState);
+        renderDivider(frame, zones.get(1));
 
         // -- Detail pane --
         renderLicenseDetail(frame, zones.get(2));
@@ -980,6 +981,7 @@ public class AuditTui extends ToolPanel {
 
         setTableArea(zones.get(0), block);
         frame.renderStatefulWidget(table, zones.get(0), byLicenseTableState);
+        renderDivider(frame, zones.get(1));
 
         // -- Detail pane --
         renderByLicenseDetail(frame, zones.get(2));
@@ -1120,6 +1122,7 @@ public class AuditTui extends ToolPanel {
 
         setTableArea(zones.get(0), block);
         frame.renderStatefulWidget(table, zones.get(0), vulnTableState);
+        renderDivider(frame, zones.get(1));
 
         // -- Detail pane --
         renderVulnDetail(frame, zones.get(2));

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -161,8 +161,6 @@ public class AuditTui extends ToolPanel {
     /** Flattened vulnerability row linking back to its parent entry. */
     private record VulnRow(AuditEntry entry, OsvClient.Vulnerability vuln) {}
 
-    private TuiRunner runner;
-
     /** Standalone constructor — creates its own PomEditSession from the POM file path. */
     public AuditTui(List<AuditEntry> entries, String projectGav, DependencyTreeModel treeModel, String pomPath) {
         this(entries, projectGav, treeModel, new PomEditSession(Path.of(pomPath)));
@@ -1584,7 +1582,7 @@ public class AuditTui extends ToolPanel {
 
     @Override
     public void setRunner(TuiRunner runner) {
-        this.runner = runner;
+        super.setRunner(runner);
         fetchAllData();
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -41,8 +41,13 @@ import dev.tamboui.widgets.table.TableState;
 import eu.maveniverse.domtrip.maven.Coordinates;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -98,12 +103,24 @@ public class ConflictsTui extends ToolPanel {
         }
     }
 
-    private final List<ConflictGroup> conflicts;
+    @FunctionalInterface
+    public interface TreeResolver {
+        DependencyTreeModel resolve(PilotProject project);
+    }
+
+    private List<ConflictGroup> conflicts;
     private final String projectGav;
     private final TableState tableState = new TableState();
     private boolean showDetails = true;
     private boolean showAll = false;
     private String status;
+
+    private boolean loading;
+    private int loadedCount;
+    private int totalModules;
+    private volatile String loadingModule;
+    private TreeResolver treeResolver;
+    private List<PilotProject> pendingProjects;
 
     private boolean pendingQuit;
     private final DiffOverlay diffOverlay = new DiffOverlay();
@@ -147,6 +164,20 @@ public class ConflictsTui extends ToolPanel {
         if (!displayedConflicts().isEmpty()) {
             tableState.select(0);
         }
+    }
+
+    /** Async-loading constructor — collects conflicts in the background after setRunner(). */
+    public ConflictsTui(
+            List<PilotProject> projects, PomEditSession session, String projectGav, TreeResolver treeResolver) {
+        this.editSession = session;
+        this.conflicts = new ArrayList<>();
+        this.projectGav = projectGav;
+        this.loading = true;
+        this.totalModules = projects.size();
+        this.treeResolver = treeResolver;
+        this.pendingProjects = projects;
+        this.status = "Collecting conflicts…";
+        this.sortState = new SortState(4);
     }
 
     /**
@@ -236,6 +267,10 @@ public class ConflictsTui extends ToolPanel {
     @Override
     public void render(Frame frame, Rect area) {
         lastContentHeight = area.height();
+        if (loading) {
+            renderConflicts(frame, area);
+            return;
+        }
         if (diffOverlay.isActive()) {
             diffOverlay.render(frame, area, " POM Changes ");
         } else if (helpOverlay.isActive()) {
@@ -248,6 +283,7 @@ public class ConflictsTui extends ToolPanel {
                         .split(area);
                 lastContentHeight = zones.get(0).height();
                 renderConflicts(frame, zones.get(0));
+                renderDivider(frame, zones.get(1));
                 renderDetails(frame, zones.get(2));
             } else {
                 renderConflicts(frame, area);
@@ -394,9 +430,8 @@ public class ConflictsTui extends ToolPanel {
                 versions        All distinct versions requested
 
                 ## Colors
-                yellow          Actual conflict — different versions requested
-                default         No conflict — all requests agree on version
-                dim             Dependency path in details pane
+                white           Actual conflict — different versions requested
+                dim             No conflict — all requests agree on version
 
                 ## Conflict Actions
                 ↑ / ↓           Move selection up / down
@@ -420,6 +455,104 @@ public class ConflictsTui extends ToolPanel {
     @Override
     public void setRunner(TuiRunner runner) {
         this.runner = runner;
+        if (loading && pendingProjects != null) {
+            startConflictCollection();
+        }
+    }
+
+    private void startConflictCollection() {
+        ExecutorService pool =
+                Executors.newFixedThreadPool(Math.min(4, Runtime.getRuntime().availableProcessors()), r -> {
+                    Thread t = new Thread(r, "pilot-conflicts");
+                    t.setDaemon(true);
+                    return t;
+                });
+
+        List<PilotProject> projects = this.pendingProjects;
+        boolean multiModule = projects.size() > 1;
+        Map<String, List<ConflictEntry>> mergedMap = new HashMap<>();
+
+        for (PilotProject project : projects) {
+            CompletableFuture.supplyAsync(
+                            () -> {
+                                loadingModule = project.artifactId;
+                                DependencyTreeModel tree = treeResolver.resolve(project);
+                                Map<String, List<ConflictEntry>> localMap = new HashMap<>();
+                                List<String> modulePath = new ArrayList<>();
+                                if (multiModule) modulePath.add("[" + project.artifactId + "]");
+                                collectConflicts(tree.root, localMap, modulePath);
+                                return localMap;
+                            },
+                            pool)
+                    .thenAccept(localMap -> runner.runOnRenderThread(() -> {
+                        for (var entry : localMap.entrySet()) {
+                            mergedMap
+                                    .computeIfAbsent(entry.getKey(), k -> new ArrayList<>())
+                                    .addAll(entry.getValue());
+                        }
+                        loadedCount++;
+                        status = "Collecting conflicts… " + loadedCount + "/" + totalModules;
+                        if (loadedCount >= totalModules) {
+                            onCollectionComplete(mergedMap);
+                            pool.shutdown();
+                        }
+                    }))
+                    .exceptionally(ex -> {
+                        runner.runOnRenderThread(() -> {
+                            loadedCount++;
+                            if (loadedCount >= totalModules) {
+                                onCollectionComplete(mergedMap);
+                                pool.shutdown();
+                            }
+                        });
+                        return null;
+                    });
+        }
+    }
+
+    private void onCollectionComplete(Map<String, List<ConflictEntry>> mergedMap) {
+        conflicts = filterConflictGroups(mergedMap);
+        loading = false;
+        status = conflicts.size() + " dependency group(s) with version variance";
+        if (!displayedConflicts().isEmpty()) {
+            tableState.select(0);
+        }
+    }
+
+    static void collectConflicts(
+            DependencyTreeModel.TreeNode node, Map<String, List<ConflictEntry>> conflicts, List<String> path) {
+        for (DependencyTreeModel.TreeNode child : node.children) {
+            String ga = child.ga();
+            String requestedVersion = child.version;
+            String resolvedVersion = child.version;
+            if (child.requestedVersion != null) {
+                requestedVersion = child.requestedVersion;
+            }
+
+            List<String> currentPath = new ArrayList<>(path);
+            currentPath.add(ga);
+
+            var entry = new ConflictEntry(
+                    child.groupId,
+                    child.artifactId,
+                    requestedVersion,
+                    resolvedVersion,
+                    String.join(" → ", currentPath),
+                    child.scope);
+
+            conflicts.computeIfAbsent(ga, k -> new ArrayList<>()).add(entry);
+            collectConflicts(child, conflicts, currentPath);
+        }
+    }
+
+    static List<ConflictGroup> filterConflictGroups(Map<String, List<ConflictEntry>> conflictMap) {
+        return conflictMap.entrySet().stream()
+                .filter(e -> e.getValue().size() > 1
+                        || e.getValue().stream()
+                                .anyMatch(c ->
+                                        c.requestedVersion != null && !c.requestedVersion.equals(c.resolvedVersion)))
+                .map(e -> new ConflictGroup(e.getKey(), e.getValue()))
+                .collect(Collectors.toList());
     }
 
     /**
@@ -515,6 +648,7 @@ public class ConflictsTui extends ToolPanel {
         } else {
             renderConflicts(frame, zones.get(1));
             if (detailsVisible) {
+                renderDivider(frame, zones.get(2));
                 renderDetails(frame, zones.get(3));
             }
         }
@@ -523,12 +657,17 @@ public class ConflictsTui extends ToolPanel {
     }
 
     private void renderHeader(Frame frame, Rect area) {
+        String title = loading ? "Collecting Conflicts…" : "Conflict Resolution";
         List<Span> spans = new ArrayList<>();
         spans.add(Span.raw(" " + projectGav).bold().cyan());
         if (isDirty()) {
             spans.add(theme.dirtyIndicator());
         }
-        renderStandaloneHeader(frame, area, "Conflict Resolution", Line.from(spans));
+        if (loading) {
+            spans.add(Span.raw("  Collecting " + loadedCount + "/" + totalModules + "…")
+                    .dim());
+        }
+        renderStandaloneHeader(frame, area, title, Line.from(spans));
     }
 
     /**
@@ -540,6 +679,28 @@ public class ConflictsTui extends ToolPanel {
      * @param area the rectangular region to render the conflicts widget
      */
     private void renderConflicts(Frame frame, Rect area) {
+        Block block;
+        if (loading) {
+            block = Block.builder()
+                    .title(" Conflicts ")
+                    .borderType(BorderType.ROUNDED)
+                    .borderStyle(borderStyle())
+                    .build();
+            String loadingText = "Collecting conflicts… " + loadedCount + "/" + totalModules;
+            String currentModule = loadingModule;
+            if (currentModule != null) {
+                loadingText += "\n" + currentModule;
+            }
+            Paragraph loadingMsg = Paragraph.builder()
+                    .text(loadingText)
+                    .block(block)
+                    .centered()
+                    .build();
+            frame.renderWidget(loadingMsg, area);
+            clearTableArea();
+            return;
+        }
+
         long conflictCount =
                 conflicts.stream().filter(ConflictGroup::hasConflict).count();
         List<ConflictGroup> displayed = displayedConflicts();
@@ -547,7 +708,7 @@ public class ConflictsTui extends ToolPanel {
                 ? " Conflicts (" + conflictCount + " actual, " + conflicts.size() + " total) "
                 : " Conflicts (" + conflictCount + ") ";
 
-        Block block = Block.builder()
+        block = Block.builder()
                 .title(title)
                 .borderType(BorderType.ROUNDED)
                 .borderStyle(borderStyle())
@@ -576,7 +737,7 @@ public class ConflictsTui extends ToolPanel {
                     .distinct()
                     .collect(Collectors.joining(", "));
 
-            Style style = group.hasConflict() ? theme.conflictWarning() : Style.create();
+            Style style = group.hasConflict() ? Style.create() : Style.create().dim();
 
             rows.add(Row.from(icon, group.ga, group.resolvedVersion(), versions).style(style));
         }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -126,8 +126,6 @@ public class ConflictsTui extends ToolPanel {
     private final DiffOverlay diffOverlay = new DiffOverlay();
     private int lastContentHeight;
 
-    private TuiRunner runner;
-
     /**
      * Get the currently selected table-row index, or -1 when no selection exists.
      *
@@ -454,12 +452,13 @@ public class ConflictsTui extends ToolPanel {
 
     @Override
     public void setRunner(TuiRunner runner) {
-        this.runner = runner;
+        super.setRunner(runner);
         if (loading && pendingProjects != null) {
             startConflictCollection();
         }
     }
 
+    @SuppressWarnings("java:S2095") // pool is shut down after task submission; daemon threads ensure no leak
     private void startConflictCollection() {
         ExecutorService pool =
                 Executors.newFixedThreadPool(Math.min(4, Runtime.getRuntime().availableProcessors()), r -> {
@@ -681,18 +680,8 @@ public class ConflictsTui extends ToolPanel {
                     .borderType(BorderType.ROUNDED)
                     .borderStyle(borderStyle())
                     .build();
-            String loadingText = "Collecting conflicts… " + loadedCount + "/" + totalModules;
-            String currentModule = loadingModule;
-            if (currentModule != null) {
-                loadingText += "\n" + currentModule;
-            }
-            Paragraph loadingMsg = Paragraph.builder()
-                    .text(loadingText)
-                    .block(block)
-                    .centered()
-                    .build();
-            frame.renderWidget(loadingMsg, area);
-            clearTableArea();
+            renderLoadingPlaceholder(
+                    frame, area, block, "Collecting conflicts… " + loadedCount + "/" + totalModules, loadingModule);
             return;
         }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -473,40 +473,37 @@ public class ConflictsTui extends ToolPanel {
         Map<String, List<ConflictEntry>> mergedMap = new HashMap<>();
 
         for (PilotProject project : projects) {
-            CompletableFuture.supplyAsync(
-                            () -> {
-                                loadingModule = project.artifactId;
-                                DependencyTreeModel tree = treeResolver.resolve(project);
-                                Map<String, List<ConflictEntry>> localMap = new HashMap<>();
-                                List<String> modulePath = new ArrayList<>();
-                                if (multiModule) modulePath.add("[" + project.artifactId + "]");
-                                collectConflicts(tree.root, localMap, modulePath);
-                                return localMap;
-                            },
-                            pool)
-                    .thenAccept(localMap -> runner.runOnRenderThread(() -> {
-                        for (var entry : localMap.entrySet()) {
-                            mergedMap
-                                    .computeIfAbsent(entry.getKey(), k -> new ArrayList<>())
-                                    .addAll(entry.getValue());
-                        }
-                        loadedCount++;
-                        status = "Collecting conflicts… " + loadedCount + "/" + totalModules;
-                        if (loadedCount >= totalModules) {
-                            onCollectionComplete(mergedMap);
-                            pool.shutdown();
-                        }
-                    }))
+            CompletableFuture.supplyAsync(() -> resolveModule(project, multiModule), pool)
+                    .thenAccept(localMap -> runner.runOnRenderThread(() -> mergeAndAdvance(localMap, mergedMap, pool)))
                     .exceptionally(ex -> {
-                        runner.runOnRenderThread(() -> {
-                            loadedCount++;
-                            if (loadedCount >= totalModules) {
-                                onCollectionComplete(mergedMap);
-                                pool.shutdown();
-                            }
-                        });
+                        runner.runOnRenderThread(() -> mergeAndAdvance(Map.of(), mergedMap, pool));
                         return null;
                     });
+        }
+    }
+
+    private Map<String, List<ConflictEntry>> resolveModule(PilotProject project, boolean multiModule) {
+        loadingModule = project.artifactId;
+        DependencyTreeModel tree = treeResolver.resolve(project);
+        Map<String, List<ConflictEntry>> localMap = new HashMap<>();
+        List<String> modulePath = new ArrayList<>();
+        if (multiModule) modulePath.add("[" + project.artifactId + "]");
+        collectConflicts(tree.root, localMap, modulePath);
+        return localMap;
+    }
+
+    private void mergeAndAdvance(
+            Map<String, List<ConflictEntry>> localMap,
+            Map<String, List<ConflictEntry>> mergedMap,
+            ExecutorService pool) {
+        for (var entry : localMap.entrySet()) {
+            mergedMap.computeIfAbsent(entry.getKey(), k -> new ArrayList<>()).addAll(entry.getValue());
+        }
+        loadedCount++;
+        status = "Collecting conflicts… " + loadedCount + "/" + totalModules;
+        if (loadedCount >= totalModules) {
+            onCollectionComplete(mergedMap);
+            pool.shutdown();
         }
     }
 
@@ -552,7 +549,7 @@ public class ConflictsTui extends ToolPanel {
                                 .anyMatch(c ->
                                         c.requestedVersion != null && !c.requestedVersion.equals(c.resolvedVersion)))
                 .map(e -> new ConflictGroup(e.getKey(), e.getValue()))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -482,7 +482,7 @@ public class ConflictsTui extends ToolPanel {
         pool.shutdown();
     }
 
-    private Map<String, List<ConflictEntry>> resolveModule(PilotProject project, boolean multiModule) {
+    Map<String, List<ConflictEntry>> resolveModule(PilotProject project, boolean multiModule) {
         loadingModule = project.artifactId;
         DependencyTreeModel tree = treeResolver.resolve(project);
         Map<String, List<ConflictEntry>> localMap = new HashMap<>();
@@ -492,8 +492,7 @@ public class ConflictsTui extends ToolPanel {
         return localMap;
     }
 
-    private void mergeAndAdvance(
-            Map<String, List<ConflictEntry>> localMap, Map<String, List<ConflictEntry>> mergedMap) {
+    void mergeAndAdvance(Map<String, List<ConflictEntry>> localMap, Map<String, List<ConflictEntry>> mergedMap) {
         for (var entry : localMap.entrySet()) {
             mergedMap.computeIfAbsent(entry.getKey(), k -> new ArrayList<>()).addAll(entry.getValue());
         }
@@ -504,7 +503,7 @@ public class ConflictsTui extends ToolPanel {
         }
     }
 
-    private void onCollectionComplete(Map<String, List<ConflictEntry>> mergedMap) {
+    void onCollectionComplete(Map<String, List<ConflictEntry>> mergedMap) {
         conflicts = filterConflictGroups(mergedMap);
         loading = false;
         status = conflicts.size() + " dependency group(s) with version variance";

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -172,11 +172,11 @@ public class ConflictsTui extends ToolPanel {
         this.editSession = session;
         this.conflicts = new ArrayList<>();
         this.projectGav = projectGav;
-        this.loading = true;
         this.totalModules = projects.size();
+        this.loading = !projects.isEmpty();
         this.treeResolver = treeResolver;
         this.pendingProjects = projects;
-        this.status = "Collecting conflicts…";
+        this.status = loading ? "Collecting conflicts…" : "0 dependency group(s) with version variance";
         this.sortState = new SortState(4);
     }
 
@@ -474,12 +474,13 @@ public class ConflictsTui extends ToolPanel {
 
         for (PilotProject project : projects) {
             CompletableFuture.supplyAsync(() -> resolveModule(project, multiModule), pool)
-                    .thenAccept(localMap -> runner.runOnRenderThread(() -> mergeAndAdvance(localMap, mergedMap, pool)))
+                    .thenAccept(localMap -> runner.runOnRenderThread(() -> mergeAndAdvance(localMap, mergedMap)))
                     .exceptionally(ex -> {
-                        runner.runOnRenderThread(() -> mergeAndAdvance(Map.of(), mergedMap, pool));
+                        runner.runOnRenderThread(() -> mergeAndAdvance(Map.of(), mergedMap));
                         return null;
                     });
         }
+        pool.shutdown();
     }
 
     private Map<String, List<ConflictEntry>> resolveModule(PilotProject project, boolean multiModule) {
@@ -493,9 +494,7 @@ public class ConflictsTui extends ToolPanel {
     }
 
     private void mergeAndAdvance(
-            Map<String, List<ConflictEntry>> localMap,
-            Map<String, List<ConflictEntry>> mergedMap,
-            ExecutorService pool) {
+            Map<String, List<ConflictEntry>> localMap, Map<String, List<ConflictEntry>> mergedMap) {
         for (var entry : localMap.entrySet()) {
             mergedMap.computeIfAbsent(entry.getKey(), k -> new ArrayList<>()).addAll(entry.getValue());
         }
@@ -503,7 +502,6 @@ public class ConflictsTui extends ToolPanel {
         status = "Collecting conflicts… " + loadedCount + "/" + totalModules;
         if (loadedCount >= totalModules) {
             onCollectionComplete(mergedMap);
-            pool.shutdown();
         }
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -228,7 +228,6 @@ public class DependenciesTui extends ToolPanel {
     private boolean pendingQuit;
     private final DiffOverlay diffOverlay = new DiffOverlay();
     private int lastContentHeight;
-    private TuiRunner runner;
 
     /** Returns the current in-memory POM content (package-private for testing). */
     String currentPomContent() {
@@ -613,11 +612,6 @@ public class DependenciesTui extends ToolPanel {
                 s / S           Sort by column / reverse direction
                 d               Preview POM changes as unified diff
                 """);
-    }
-
-    @Override
-    public void setRunner(TuiRunner runner) {
-        this.runner = runner;
     }
 
     private List<DepEntry> currentList() {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -405,11 +405,12 @@ public class DependenciesTui extends ToolPanel {
             renderManagedTable(frame, contentArea);
         } else {
             var zones = Layout.vertical()
-                    .constraints(Constraint.fill(), Constraint.percentage(25))
+                    .constraints(Constraint.fill(), Constraint.length(1), Constraint.percentage(25))
                     .split(contentArea);
             lastContentHeight = zones.get(0).height();
             renderTable(frame, zones.get(0), null);
-            renderDetails(frame, zones.get(1));
+            renderDivider(frame, zones.get(1));
+            renderDetails(frame, zones.get(2));
         }
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -70,7 +70,7 @@ public class PilotEngine {
             case "tree" -> createTreePanel(proj);
             case "dependencies" -> createDependenciesPanel(proj, session);
             case "updates" -> createUpdatesPanel(proj, projects, session, sessionProvider, progress);
-            case "conflicts" -> createConflictsPanel(proj, projects, session, progress);
+            case "conflicts" -> createConflictsPanel(proj, projects, session);
             case "align" -> createAlignPanel(proj, projects);
             case "audit" -> createAuditPanel(proj, projects, session, progress);
             case "pom" -> createPomPanel(proj);
@@ -158,8 +158,7 @@ public class PilotEngine {
         return new UpdatesTui(result, reactorModel, gav, versionResolver, sessionProvider);
     }
 
-    private ToolPanel createConflictsPanel(
-            PilotProject proj, List<PilotProject> projects, PomEditSession session, Consumer<String> progress) {
+    private ToolPanel createConflictsPanel(PilotProject proj, List<PilotProject> projects, PomEditSession session) {
         List<PilotProject> targetProjects = projects.size() > 1 ? projects : List.of(proj);
         String gav = projects.size() > 1
                 ? projects.get(0).gav() + " (reactor: " + projects.size() + " modules)"

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -24,14 +24,12 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 /**
  * Panel creation logic decoupled from Maven plugin API.
@@ -162,35 +160,12 @@ public class PilotEngine {
 
     private ToolPanel createConflictsPanel(
             PilotProject proj, List<PilotProject> projects, PomEditSession session, Consumer<String> progress) {
-        if (projects.size() > 1) {
-            Map<String, List<ConflictsTui.ConflictEntry>> mergedMap = new HashMap<>();
-            for (int i = 0; i < projects.size(); i++) {
-                PilotProject p = projects.get(i);
-                if (projects.size() >= 100) {
-                    progress.accept("Collecting conflicts… " + (i + 1) + "/" + projects.size() + "\n" + p.artifactId);
-                }
-                DependencyTreeModel tree = cachedCollectDependencies(p);
-                List<String> modulePath = new ArrayList<>();
-                modulePath.add("[" + p.artifactId + "]");
-                collectConflicts(tree.root, mergedMap, modulePath);
-            }
-            List<ConflictsTui.ConflictGroup> conflicts = filterConflictGroups(mergedMap);
-            PilotProject root = projects.get(0);
-            String gav = root.gav() + " (reactor: " + projects.size() + " modules)";
-            if (session != null) {
-                return new ConflictsTui(conflicts, session, gav);
-            }
-            return new ConflictsTui(conflicts, root.pomPath.toString(), gav);
-        } else {
-            DependencyTreeModel tree = cachedCollectDependencies(proj);
-            Map<String, List<ConflictsTui.ConflictEntry>> conflictMap = new HashMap<>();
-            collectConflicts(tree.root, conflictMap, new ArrayList<>());
-            List<ConflictsTui.ConflictGroup> conflicts = filterConflictGroups(conflictMap);
-            if (session != null) {
-                return new ConflictsTui(conflicts, session, proj.gav());
-            }
-            return new ConflictsTui(conflicts, proj.pomPath.toString(), proj.gav());
-        }
+        List<PilotProject> targetProjects = projects.size() > 1 ? projects : List.of(proj);
+        String gav = projects.size() > 1
+                ? projects.get(0).gav() + " (reactor: " + projects.size() + " modules)"
+                : proj.gav();
+        PomEditSession s = session != null ? session : new PomEditSession(proj.pomPath);
+        return new ConflictsTui(targetProjects, s, gav, this::cachedCollectDependencies);
     }
 
     private ToolPanel createAlignPanel(PilotProject proj, List<PilotProject> projects) throws Exception {
@@ -346,45 +321,6 @@ public class PilotEngine {
         }
 
         return projects.get(0);
-    }
-
-    private static void collectConflicts(
-            DependencyTreeModel.TreeNode node,
-            Map<String, List<ConflictsTui.ConflictEntry>> conflicts,
-            List<String> path) {
-        for (DependencyTreeModel.TreeNode child : node.children) {
-            String ga = child.ga();
-            String requestedVersion = child.version;
-            String resolvedVersion = child.version;
-            if (child.requestedVersion != null) {
-                requestedVersion = child.requestedVersion;
-            }
-
-            List<String> currentPath = new ArrayList<>(path);
-            currentPath.add(ga);
-
-            var entry = new ConflictsTui.ConflictEntry(
-                    child.groupId,
-                    child.artifactId,
-                    requestedVersion,
-                    resolvedVersion,
-                    String.join(" → ", currentPath),
-                    child.scope);
-
-            conflicts.computeIfAbsent(ga, k -> new ArrayList<>()).add(entry);
-            collectConflicts(child, conflicts, currentPath);
-        }
-    }
-
-    private static List<ConflictsTui.ConflictGroup> filterConflictGroups(
-            Map<String, List<ConflictsTui.ConflictEntry>> conflictMap) {
-        return conflictMap.entrySet().stream()
-                .filter(e -> e.getValue().size() > 1
-                        || e.getValue().stream()
-                                .anyMatch(c ->
-                                        c.requestedVersion != null && !c.requestedVersion.equals(c.resolvedVersion)))
-                .map(e -> new ConflictsTui.ConflictGroup(e.getKey(), e.getValue()))
-                .collect(Collectors.toList());
     }
 
     private static void collectAuditNode(

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -538,14 +538,7 @@ public class PilotShell {
                 ? tool.id
                 : tool.id + ":" + (selectedProject != null ? selectedProject.ga() : "null");
 
-        ToolPanel cached = panelCache.get(cacheKey);
-        if (cached != null) {
-            activePanel = cached;
-            // Restore sub-view to keep navigation homogeneous across modules
-            if (currentSubView < activePanel.subViewCount()) {
-                activePanel.setActiveSubView(currentSubView);
-            }
-            loadingCacheKey = null;
+        if (activateCachedPanel(cacheKey, currentSubView)) {
             return;
         }
 
@@ -570,9 +563,26 @@ public class PilotShell {
             return;
         }
 
+        submitPanelLoadTask(tool, cacheKey, currentSubView);
+    }
+
+    private boolean activateCachedPanel(String cacheKey, int currentSubView) {
+        ToolPanel cached = panelCache.get(cacheKey);
+        if (cached == null) {
+            return false;
+        }
+        activePanel = cached;
+        // Restore sub-view to keep navigation homogeneous across modules
+        if (currentSubView < activePanel.subViewCount()) {
+            activePanel.setActiveSubView(currentSubView);
+        }
+        loadingCacheKey = null;
+        return true;
+    }
+
+    private void submitPanelLoadTask(ToolDef tool, String cacheKey, int subView) {
         final PilotProject proj = selectedProject;
         final List<PilotProject> scope = tool.isModuleIndependent() ? projects : selectedScope;
-        final int subView = currentSubView;
         // Get or create session for this module's POM
         final PomEditSession session;
         if (proj != null && !tool.isModuleIndependent()) {
@@ -591,38 +601,44 @@ public class PilotShell {
                     }
                 });
                 if (panel != null && runner != null) {
-                    runner.runOnRenderThread(() -> {
-                        panel.setRunner(runner);
-                        panelCache.put(cacheKey, panel);
-                        runningTasks.remove(cacheKey);
-                        // Only set active if still waiting for this panel
-                        if (cacheKey.equals(loadingCacheKey)) {
-                            activePanel = panel;
-                            activePanel.setFocused(focus == Focus.CONTENT);
-                            // Restore sub-view
-                            if (subView < activePanel.subViewCount()) {
-                                activePanel.setActiveSubView(subView);
-                            }
-                            loadingCacheKey = null;
-                        }
-                    });
+                    runner.runOnRenderThread(() -> onPanelLoaded(cacheKey, panel, subView));
                 }
             } catch (Exception e) {
-                String msg = e.getMessage();
-                if (msg == null) msg = e.getClass().getSimpleName();
-                final String errorMsg = msg;
-                runningTasks.remove(cacheKey);
-                if (runner != null) {
-                    runner.runOnRenderThread(() -> {
-                        if (cacheKey.equals(loadingCacheKey)) {
-                            loadingCacheKey = null;
-                            panelError = errorMsg;
-                        }
-                    });
-                }
+                handlePanelLoadError(cacheKey, e);
             }
         });
         runningTasks.put(cacheKey, task);
+    }
+
+    private void onPanelLoaded(String cacheKey, ToolPanel panel, int subView) {
+        panel.setRunner(runner);
+        panelCache.put(cacheKey, panel);
+        runningTasks.remove(cacheKey);
+        // Only set active if still waiting for this panel
+        if (cacheKey.equals(loadingCacheKey)) {
+            activePanel = panel;
+            activePanel.setFocused(focus == Focus.CONTENT);
+            // Restore sub-view
+            if (subView < activePanel.subViewCount()) {
+                activePanel.setActiveSubView(subView);
+            }
+            loadingCacheKey = null;
+        }
+    }
+
+    private void handlePanelLoadError(String cacheKey, Exception e) {
+        String msg = e.getMessage();
+        if (msg == null) msg = e.getClass().getSimpleName();
+        final String errorMsg = msg;
+        runningTasks.remove(cacheKey);
+        if (runner != null) {
+            runner.runOnRenderThread(() -> {
+                if (cacheKey.equals(loadingCacheKey)) {
+                    loadingCacheKey = null;
+                    panelError = errorMsg;
+                }
+            });
+        }
     }
 
     private void onModuleSelected(PilotProject project) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -521,6 +521,10 @@ public class PilotShell {
     }
 
     private void refreshActivePanel() {
+        refreshActivePanel(true);
+    }
+
+    private void refreshActivePanel(boolean clearPanel) {
         ToolDef tool = TOOLS.get(activeToolIndex);
         if (!isToolAvailable(activeToolIndex)) {
             activePanel = null;
@@ -545,11 +549,17 @@ public class PilotShell {
             return;
         }
 
-        // Already loading this exact panel — just re-attach
+        // Already loading this exact panel — keep waiting
         if (cacheKey.equals(loadingCacheKey)) {
+            if (clearPanel) {
+                activePanel = null;
+            }
             return;
         }
 
+        if (clearPanel) {
+            activePanel = null;
+        }
         panelError = null;
         panelLoadingStatus = null;
         loadingCacheKey = cacheKey;
@@ -561,7 +571,7 @@ public class PilotShell {
         }
 
         final PilotProject proj = selectedProject;
-        final List<PilotProject> scope = selectedScope;
+        final List<PilotProject> scope = tool.isModuleIndependent() ? projects : selectedScope;
         final int subView = currentSubView;
         // Get or create session for this module's POM
         final PomEditSession session;
@@ -622,7 +632,7 @@ public class PilotShell {
 
         ToolDef activeTool = TOOLS.get(activeToolIndex);
         if (!activeTool.isModuleIndependent()) {
-            refreshActivePanel();
+            refreshActivePanel(false);
         }
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
@@ -80,7 +80,6 @@ public class PomTui extends ToolPanel {
     private View view = View.RAW;
     private final TableState tableState = new TableState();
 
-    private TuiRunner runner;
     private int lastContentHeight;
 
     /**
@@ -374,11 +373,6 @@ public class PomTui extends ToolPanel {
                 W               Collapse all (keeps root expanded)
                 Tab             Switch Raw POM / Effective POM
                 """ + SEARCH_HELP);
-    }
-
-    @Override
-    public void setRunner(TuiRunner runner) {
-        this.runner = runner;
     }
 
     @Override

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
@@ -209,6 +209,7 @@ public class PomTui extends ToolPanel {
                     .constraints(Constraint.fill(), Constraint.length(1), Constraint.length(detailHeight))
                     .split(contentArea);
             renderXmlTree(frame, zones.get(0), snippet);
+            renderDivider(frame, zones.get(1));
             renderOriginDetail(frame, zones.get(2), snippet);
         } else {
             renderXmlTree(frame, contentArea, null);
@@ -509,7 +510,7 @@ public class PomTui extends ToolPanel {
         }
         idx++;
         if (showDetail) {
-            idx++; // skip spacer
+            renderDivider(frame, zones.get(idx++));
             renderOriginDetail(frame, zones.get(idx++), snippet);
         }
         renderFooter(frame, zones.get(idx), showDetail);

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
@@ -101,7 +101,7 @@ public class ReactorCollector {
         String newestVersion;
         VersionComparator.UpdateType updateType;
         boolean selected;
-        boolean expanded = true;
+        boolean expanded = false;
         float libYears = -1;
 
         PropertyGroup(String propertyName, String rawExpression, String resolvedVersion, PilotProject origin) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
@@ -146,7 +146,6 @@ public class SearchTui extends ToolPanel {
 
     // Dependencies
     private final SearchClient client;
-    private TuiRunner runner;
     private int lastContentHeight;
 
     /**
@@ -348,11 +347,6 @@ public class SearchTui extends ToolPanel {
                 Enter           Select artifact / confirm search
                 Esc             Back to search / quit
                 """);
-    }
-
-    @Override
-    public void setRunner(TuiRunner runner) {
-        this.runner = runner;
     }
 
     private boolean handleSearchKeys(KeyEvent key) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -54,6 +54,11 @@ public abstract class ToolPanel {
     /** Theme for all color/style decisions. */
     protected final Theme theme = Theme.DEFAULT;
 
+    protected void renderDivider(Frame frame, Rect area) {
+        String div = "─".repeat(area.width());
+        frame.renderWidget(Paragraph.from(Line.from(Span.raw(div).fg(theme.dividerColor()))), area);
+    }
+
     /** Shared POM edit session, or null for read-only tools. */
     protected PomEditSession editSession;
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -54,6 +54,9 @@ public abstract class ToolPanel {
     /** Theme for all color/style decisions. */
     protected final Theme theme = Theme.DEFAULT;
 
+    /** The TUI runner, set via {@link #setRunner(TuiRunner)} when the panel is activated. */
+    protected TuiRunner runner;
+
     protected void renderDivider(Frame frame, Rect area) {
         String div = "─".repeat(area.width());
         frame.renderWidget(Paragraph.from(Line.from(Span.raw(div).fg(theme.dividerColor()))), area);
@@ -180,7 +183,21 @@ public abstract class ToolPanel {
     }
 
     /** Called when the TuiRunner is available (for async operations). */
-    void setRunner(TuiRunner runner) {}
+    void setRunner(TuiRunner runner) {
+        this.runner = runner;
+    }
+
+    /**
+     * Render a centered loading placeholder with an optional detail line.
+     * Panels call this during their loading phase instead of rendering a table.
+     */
+    protected void renderLoadingPlaceholder(Frame frame, Rect area, Block block, String message, String detail) {
+        String text = detail != null ? message + "\n" + detail : message;
+        Paragraph paragraph =
+                Paragraph.builder().text(text).block(block).centered().build();
+        frame.renderWidget(paragraph, area);
+        clearTableArea();
+    }
 
     /**
      * Handle a TUI event in standalone mode.

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -69,7 +69,6 @@ public class TreeTui extends ToolPanel {
     private List<DependencyTreeModel.TreeNode> reversePath;
     private boolean showReversePath;
 
-    private TuiRunner runner;
     private int lastContentHeight;
 
     public TreeTui(DependencyTreeModel fullModel, String scope, String projectGav) {
@@ -247,11 +246,6 @@ public class TreeTui extends ToolPanel {
                 r               Reverse path (why was this pulled in?)
                 f               Cycle scope: compile → runtime → test
                 """);
-    }
-
-    @Override
-    public void setRunner(TuiRunner runner) {
-        this.runner = runner;
     }
 
     @Override

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -149,8 +149,6 @@ public class UpdatesTui extends ToolPanel {
     int dateFetchesPending;
     boolean datesLoading;
 
-    private TuiRunner runner;
-
     /**
      * Standalone constructor — creates a local session cache.
      */
@@ -680,34 +678,11 @@ public class UpdatesTui extends ToolPanel {
             return true;
         }
         if (key.isRight()) {
-            Integer sel = tableState.selected();
-            if (sel != null && sel < displayRows.size()) {
-                var row = displayRows.get(sel);
-                if (row.isGroupHeader() && !row.propertyGroup.expanded) {
-                    row.propertyGroup.expanded = true;
-                    rebuildDisplayRowsKeepSelection();
-                } else {
-                    tableState.selectNext(displayRows.size());
-                }
-            }
+            handleDepsRightKey();
             return true;
         }
         if (key.isLeft()) {
-            Integer sel = tableState.selected();
-            if (sel != null && sel < displayRows.size()) {
-                var row = displayRows.get(sel);
-                if (row.isGroupHeader() && row.propertyGroup.expanded) {
-                    row.propertyGroup.expanded = false;
-                    rebuildDisplayRowsKeepSelection();
-                } else if (!row.isGroupHeader() && row.dependency != null && row.dependency.isPropertyManaged()) {
-                    for (int i = sel - 1; i >= 0; i--) {
-                        if (displayRows.get(i).isGroupHeader()) {
-                            tableState.select(i);
-                            break;
-                        }
-                    }
-                }
-            }
+            handleDepsLeftKey();
             return true;
         }
         if (key.isCharIgnoreCase(' ')) {
@@ -749,6 +724,37 @@ public class UpdatesTui extends ToolPanel {
         return false;
     }
 
+    private void handleDepsRightKey() {
+        Integer sel = tableState.selected();
+        if (sel != null && sel < displayRows.size()) {
+            var row = displayRows.get(sel);
+            if (row.isGroupHeader() && !row.propertyGroup.expanded) {
+                row.propertyGroup.expanded = true;
+                rebuildDisplayRowsKeepSelection();
+            } else {
+                tableState.selectNext(displayRows.size());
+            }
+        }
+    }
+
+    private void handleDepsLeftKey() {
+        Integer sel = tableState.selected();
+        if (sel != null && sel < displayRows.size()) {
+            var row = displayRows.get(sel);
+            if (row.isGroupHeader() && row.propertyGroup.expanded) {
+                row.propertyGroup.expanded = false;
+                rebuildDisplayRowsKeepSelection();
+            } else if (!row.isGroupHeader() && row.dependency != null && row.dependency.isPropertyManaged()) {
+                for (int i = sel - 1; i >= 0; i--) {
+                    if (displayRows.get(i).isGroupHeader()) {
+                        tableState.select(i);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     private boolean handleModulesNavigation(KeyEvent key) {
         List<ReactorModel.ModuleNode> visible = reactorModel.visibleNodes();
         if (key.isUp()) {
@@ -763,35 +769,43 @@ public class UpdatesTui extends ToolPanel {
             return true;
         }
         if (key.isKey(KeyCode.ENTER) || key.isKey(KeyCode.RIGHT)) {
-            Integer sel = moduleTableState.selected();
-            if (sel != null && sel < visible.size()) {
-                var node = visible.get(sel);
-                if (node.hasChildren() && !node.expanded) {
-                    node.expanded = true;
-                } else {
-                    moduleTableState.selectNext(reactorModel.visibleNodes().size());
-                }
-            }
+            handleModulesRightKey(visible);
             return true;
         }
         if (key.isKey(KeyCode.LEFT)) {
-            Integer sel = moduleTableState.selected();
-            if (sel != null && sel < visible.size()) {
-                var node = visible.get(sel);
-                if (node.expanded && node.hasChildren()) {
-                    node.expanded = false;
-                } else {
-                    for (int i = sel - 1; i >= 0; i--) {
-                        if (visible.get(i).depth < node.depth) {
-                            moduleTableState.select(i);
-                            break;
-                        }
-                    }
-                }
-            }
+            handleModulesLeftKey(visible);
             return true;
         }
         return false;
+    }
+
+    private void handleModulesRightKey(List<ReactorModel.ModuleNode> visible) {
+        Integer sel = moduleTableState.selected();
+        if (sel != null && sel < visible.size()) {
+            var node = visible.get(sel);
+            if (node.hasChildren() && !node.expanded) {
+                node.expanded = true;
+            } else {
+                moduleTableState.selectNext(reactorModel.visibleNodes().size());
+            }
+        }
+    }
+
+    private void handleModulesLeftKey(List<ReactorModel.ModuleNode> visible) {
+        Integer sel = moduleTableState.selected();
+        if (sel != null && sel < visible.size()) {
+            var node = visible.get(sel);
+            if (node.expanded && node.hasChildren()) {
+                node.expanded = false;
+            } else {
+                for (int i = sel - 1; i >= 0; i--) {
+                    if (visible.get(i).depth < node.depth) {
+                        moduleTableState.select(i);
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     private void rebuildDisplayRowsKeepSelection() {
@@ -1234,24 +1248,22 @@ public class UpdatesTui extends ToolPanel {
 
     private Row createDependencyRow(ReactorRow row, boolean highlight) {
         var dep = row.dependency;
-        boolean inGroup = dep.isPropertyManaged();
-
-        if (inGroup) {
-            String check = "   ";
-            String ga = "  ↳ " + dep.artifactId;
-            Style style = Style.create();
-            if (highlight) style = style.bg(theme.searchHighlightBg());
-            String info = "";
-            if (!singleModule) {
-                int modCount = dep.moduleCount();
-                info = modCount + " mod";
-                if (dep.usages.stream().anyMatch(u -> u.managed)) {
-                    info += " M";
-                }
-            }
-            return Row.from(check, ga, "", "", "", "", "", info).style(style);
+        if (dep.isPropertyManaged()) {
+            return createGroupedDependencyRow(dep, highlight);
         }
+        return createStandaloneDependencyRow(dep, highlight);
+    }
 
+    private Row createGroupedDependencyRow(ReactorCollector.AggregatedDependency dep, boolean highlight) {
+        String check = "   ";
+        String ga = "  ↳ " + dep.artifactId;
+        Style style = Style.create();
+        if (highlight) style = style.bg(theme.searchHighlightBg());
+        String info = buildModuleInfo(dep);
+        return Row.from(check, ga, "", "", "", "", "", info).style(style);
+    }
+
+    private Row createStandaloneDependencyRow(ReactorCollector.AggregatedDependency dep, boolean highlight) {
         String check = dep.selected ? "[✓]" : "[ ]";
         String ga = dep.artifactId;
         String current = dep.primaryVersion != null ? dep.primaryVersion : "";
@@ -1259,19 +1271,22 @@ public class UpdatesTui extends ToolPanel {
         String available = dep.hasUpdate() ? dep.newestVersion : "";
         String type = updateTypeLabel(dep.updateType);
         String age = formatAge(dep.libYears, dep.hasUpdate());
-
         Style style = updateTypeStyle(dep.updateType);
         if (highlight) style = style.bg(theme.searchHighlightBg());
-
-        String info = "";
-        if (!singleModule) {
-            int modCount = dep.moduleCount();
-            info = modCount + " mod";
-            if (dep.usages.stream().anyMatch(u -> u.managed)) {
-                info += " M";
-            }
-        }
+        String info = buildModuleInfo(dep);
         return Row.from(check, ga, current, arrow, available, type, age, info).style(style);
+    }
+
+    private String buildModuleInfo(ReactorCollector.AggregatedDependency dep) {
+        if (singleModule) {
+            return "";
+        }
+        int modCount = dep.moduleCount();
+        String info = modCount + " mod";
+        if (dep.usages.stream().anyMatch(u -> u.managed)) {
+            info += " M";
+        }
+        return info;
     }
 
     private void renderDetailPane(Frame frame, Rect area) {
@@ -1759,7 +1774,7 @@ public class UpdatesTui extends ToolPanel {
 
     @Override
     public void setRunner(TuiRunner runner) {
-        this.runner = runner;
+        super.setRunner(runner);
         if (loading) {
             fetchAllUpdates();
         }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -405,8 +405,10 @@ public class UpdatesTui extends ToolPanel {
             }
             if (groupHasUpdate) {
                 displayRows.add(ReactorRow.group(group));
-                for (var dep : group.dependencies) {
-                    displayRows.add(ReactorRow.dep(dep));
+                if (group.expanded) {
+                    for (var dep : group.dependencies) {
+                        displayRows.add(ReactorRow.dep(dep));
+                    }
                 }
             }
         }
@@ -434,6 +436,7 @@ public class UpdatesTui extends ToolPanel {
         extractors.add(this::extractCurrentVersion);
         extractors.add(this::extractArrow);
         extractors.add(this::extractNewestVersion);
+        extractors.add(this::extractUpdateType);
         extractors.add(this::extractAge);
         if (!singleModule) {
             extractors.add(this::extractModuleCount);
@@ -500,6 +503,30 @@ public class UpdatesTui extends ToolPanel {
             return String.valueOf(row.propertyGroup.totalModuleCount());
         }
         return String.valueOf(row.dependency.moduleCount());
+    }
+
+    private String extractUpdateType(ReactorRow row) {
+        VersionComparator.UpdateType type =
+                row.isGroupHeader() ? row.propertyGroup.updateType : row.dependency.updateType;
+        return type != null ? type.name() : "";
+    }
+
+    private static String updateTypeLabel(VersionComparator.UpdateType type) {
+        if (type == null) return "";
+        return switch (type) {
+            case PATCH -> "patch";
+            case MINOR -> "minor";
+            case MAJOR -> "major";
+        };
+    }
+
+    private Style updateTypeStyle(VersionComparator.UpdateType type) {
+        if (type == null) return Style.create().dim();
+        return switch (type) {
+            case PATCH -> Style.create().dim();
+            case MINOR -> Style.create();
+            case MAJOR -> Style.create().fg(Color.YELLOW);
+        };
     }
 
     @Override
@@ -652,6 +679,37 @@ public class UpdatesTui extends ToolPanel {
         if (TableNavigation.handlePageKeys(key, tableState, displayRows.size(), lastContentHeight)) {
             return true;
         }
+        if (key.isRight()) {
+            Integer sel = tableState.selected();
+            if (sel != null && sel < displayRows.size()) {
+                var row = displayRows.get(sel);
+                if (row.isGroupHeader() && !row.propertyGroup.expanded) {
+                    row.propertyGroup.expanded = true;
+                    rebuildDisplayRowsKeepSelection();
+                } else {
+                    tableState.selectNext(displayRows.size());
+                }
+            }
+            return true;
+        }
+        if (key.isLeft()) {
+            Integer sel = tableState.selected();
+            if (sel != null && sel < displayRows.size()) {
+                var row = displayRows.get(sel);
+                if (row.isGroupHeader() && row.propertyGroup.expanded) {
+                    row.propertyGroup.expanded = false;
+                    rebuildDisplayRowsKeepSelection();
+                } else if (!row.isGroupHeader() && row.dependency != null && row.dependency.isPropertyManaged()) {
+                    for (int i = sel - 1; i >= 0; i--) {
+                        if (displayRows.get(i).isGroupHeader()) {
+                            tableState.select(i);
+                            break;
+                        }
+                    }
+                }
+            }
+            return true;
+        }
         if (key.isCharIgnoreCase(' ')) {
             toggleSelection();
             return true;
@@ -705,32 +763,52 @@ public class UpdatesTui extends ToolPanel {
             return true;
         }
         if (key.isKey(KeyCode.ENTER) || key.isKey(KeyCode.RIGHT)) {
-            toggleModuleNode(visible);
+            Integer sel = moduleTableState.selected();
+            if (sel != null && sel < visible.size()) {
+                var node = visible.get(sel);
+                if (node.hasChildren() && !node.expanded) {
+                    node.expanded = true;
+                } else {
+                    moduleTableState.selectNext(reactorModel.visibleNodes().size());
+                }
+            }
             return true;
         }
         if (key.isKey(KeyCode.LEFT)) {
-            collapseModuleNode(visible);
+            Integer sel = moduleTableState.selected();
+            if (sel != null && sel < visible.size()) {
+                var node = visible.get(sel);
+                if (node.expanded && node.hasChildren()) {
+                    node.expanded = false;
+                } else {
+                    for (int i = sel - 1; i >= 0; i--) {
+                        if (visible.get(i).depth < node.depth) {
+                            moduleTableState.select(i);
+                            break;
+                        }
+                    }
+                }
+            }
             return true;
         }
         return false;
     }
 
-    private void toggleModuleNode(List<ReactorModel.ModuleNode> visible) {
-        Integer sel = moduleTableState.selected();
-        if (sel != null && sel < visible.size()) {
-            var node = visible.get(sel);
-            if (node.hasChildren()) {
-                node.expanded = !node.expanded;
-            }
-        }
-    }
-
-    private void collapseModuleNode(List<ReactorModel.ModuleNode> visible) {
-        Integer sel = moduleTableState.selected();
-        if (sel != null && sel < visible.size()) {
-            var node = visible.get(sel);
-            if (node.expanded && node.hasChildren()) {
-                node.expanded = false;
+    private void rebuildDisplayRowsKeepSelection() {
+        Integer sel = tableState.selected();
+        ReactorRow current = (sel != null && sel < displayRows.size()) ? displayRows.get(sel) : null;
+        buildDisplayRows();
+        if (current != null) {
+            for (int i = 0; i < displayRows.size(); i++) {
+                var row = displayRows.get(i);
+                if (current.isGroupHeader() && row.isGroupHeader() && row.propertyGroup == current.propertyGroup) {
+                    tableState.select(i);
+                    return;
+                }
+                if (!current.isGroupHeader() && !row.isGroupHeader() && row.dependency == current.dependency) {
+                    tableState.select(i);
+                    return;
+                }
             }
         }
     }
@@ -1018,7 +1096,16 @@ public class UpdatesTui extends ToolPanel {
         } else {
             Rect contentArea = renderTabBar(frame, area);
             if (view == View.DEPENDENCIES) {
-                renderDepsTable(frame, contentArea);
+                boolean detailsVisible = showDetails && !displayRows.isEmpty();
+                if (detailsVisible) {
+                    var split = Layout.vertical()
+                            .constraints(Constraint.fill(), Constraint.percentage(30))
+                            .split(contentArea);
+                    renderDepsTable(frame, split.get(0));
+                    renderDetailPane(frame, split.get(1));
+                } else {
+                    renderDepsTable(frame, contentArea);
+                }
             } else {
                 renderModulesTable(frame, contentArea);
             }
@@ -1080,13 +1167,13 @@ public class UpdatesTui extends ToolPanel {
                 .borderStyle(borderStyle())
                 .build();
 
-        List<String> headers = List.of("", "dependency / property", "current", "", "available", "age", "info");
+        List<String> headers = List.of("", "dependency / property", "current", "", "available", "type", "age", "info");
         Row header = sortState.decorateHeader(headers, theme.tableHeader());
 
         List<Row> rows = new ArrayList<>();
         if (displayRows.isEmpty()) {
             String msg = loading ? "Checking versions…" : "No updates available";
-            int colCount = 7;
+            int colCount = 8;
             List<Cell> cells = new ArrayList<>();
             cells.add(Cell.empty());
             cells.add(Cell.from(msg));
@@ -1100,10 +1187,11 @@ public class UpdatesTui extends ToolPanel {
 
         List<Constraint> widths = List.of(
                 Constraint.length(3),
-                Constraint.percentage(35),
-                Constraint.percentage(14),
+                Constraint.percentage(30),
+                Constraint.percentage(12),
                 Constraint.length(3),
-                Constraint.percentage(14),
+                Constraint.percentage(12),
+                Constraint.length(5),
                 Constraint.length(6),
                 Constraint.percentage(10));
         Table table = Table.builder()
@@ -1127,45 +1215,53 @@ public class UpdatesTui extends ToolPanel {
     private Row createGroupHeaderRow(ReactorRow row, boolean highlight) {
         var group = row.propertyGroup;
         String check = group.selected ? "[✓]" : "[ ]";
-        String name = "${" + group.propertyName + "}";
+        String name = (group.expanded ? "▾ " : "▸ ") + "${" + group.propertyName + "}";
         if (duplicatePropertyNames.contains(group.propertyName)) {
             name += " (" + group.origin.artifactId + ")";
         }
         String current = group.resolvedVersion != null ? group.resolvedVersion : "";
         String arrow = group.hasUpdate() ? "→" : "";
         String available = group.hasUpdate() ? group.newestVersion : "";
+        String type = updateTypeLabel(group.updateType);
         String age = formatAge(group.libYears, group.hasUpdate());
         String info = singleModule ? "" : group.totalModuleCount() + " mod";
 
-        Style style = theme.propertyGroupHeader();
+        Style style = updateTypeStyle(group.updateType);
         if (highlight) style = style.bg(theme.searchHighlightBg());
-        return Row.from(check, name, current, arrow, available, age, info).style(style);
+        return Row.from(check, name, current, arrow, available, type, age, info).style(style);
     }
 
     private Row createDependencyRow(ReactorRow row, boolean highlight) {
         var dep = row.dependency;
-        String check = dep.selected ? "[✓]" : "   ";
-        String ga = "  ↳ " + dep.artifactId;
         boolean inGroup = dep.isPropertyManaged();
-        String current;
-        if (inGroup || dep.primaryVersion == null) {
-            current = "";
-        } else {
-            current = dep.primaryVersion;
-        }
-        String arrow = !inGroup && dep.hasUpdate() ? "→" : "";
-        String available = !inGroup && dep.hasUpdate() ? dep.newestVersion : "";
 
-        Style style = dep.updateType != null
-                ? switch (dep.updateType) {
-                    case PATCH -> theme.updatePatch();
-                    case MINOR -> theme.updateMinor();
-                    case MAJOR -> theme.updateMajor();
+        if (inGroup) {
+            String check = "   ";
+            String ga = "  ↳ " + dep.artifactId;
+            Style style = Style.create();
+            if (highlight) style = style.bg(theme.searchHighlightBg());
+            String info = "";
+            if (!singleModule) {
+                int modCount = dep.moduleCount();
+                info = modCount + " mod";
+                if (dep.usages.stream().anyMatch(u -> u.managed)) {
+                    info += " M";
                 }
-                : Style.create();
+            }
+            return Row.from(check, ga, "", "", "", "", "", info).style(style);
+        }
+
+        String check = dep.selected ? "[✓]" : "[ ]";
+        String ga = dep.artifactId;
+        String current = dep.primaryVersion != null ? dep.primaryVersion : "";
+        String arrow = dep.hasUpdate() ? "→" : "";
+        String available = dep.hasUpdate() ? dep.newestVersion : "";
+        String type = updateTypeLabel(dep.updateType);
+        String age = formatAge(dep.libYears, dep.hasUpdate());
+
+        Style style = updateTypeStyle(dep.updateType);
         if (highlight) style = style.bg(theme.searchHighlightBg());
 
-        String age = inGroup ? "" : formatAge(dep.libYears, dep.hasUpdate());
         String info = "";
         if (!singleModule) {
             int modCount = dep.moduleCount();
@@ -1174,7 +1270,7 @@ public class UpdatesTui extends ToolPanel {
                 info += " M";
             }
         }
-        return Row.from(check, ga, current, arrow, available, age, info).style(style);
+        return Row.from(check, ga, current, arrow, available, type, age, info).style(style);
     }
 
     private void renderDetailPane(Frame frame, Rect area) {
@@ -1244,9 +1340,21 @@ public class UpdatesTui extends ToolPanel {
         }
         rows.add(Row.from(Cell.from(Line.from(artSpans))));
 
-        // Module count
-        rows.add(Row.from(Cell.from(Line.from(
-                List.of(Span.raw("Modules:   ").bold(), Span.raw(String.valueOf(group.totalModuleCount())))))));
+        // Modules using this group
+        Set<String> moduleNames = new LinkedHashSet<>();
+        for (var dep : group.dependencies) {
+            for (var usage : dep.usages) {
+                moduleNames.add(usage.project.artifactId);
+            }
+        }
+        List<Span> modSpans = new ArrayList<>();
+        modSpans.add(Span.raw("Modules:   ").bold());
+        int idx = 0;
+        for (String mod : moduleNames) {
+            if (idx++ > 0) modSpans.add(Span.raw(", ").dim());
+            modSpans.add(Span.raw(mod));
+        }
+        rows.add(Row.from(Cell.from(Line.from(modSpans))));
 
         return rows;
     }
@@ -1424,6 +1532,8 @@ public class UpdatesTui extends ToolPanel {
     private void buildDepsKeyHints(List<Span> spans) {
         spans.add(Span.raw("↑↓").bold());
         spans.add(Span.raw(KEY_NAV));
+        spans.add(Span.raw("←→").bold());
+        spans.add(Span.raw(":Expand  "));
         spans.add(Span.raw(KEY_SPACE).bold());
         spans.add(Span.raw(":Toggle  "));
         spans.add(Span.raw("a").bold());
@@ -1478,7 +1588,7 @@ public class UpdatesTui extends ToolPanel {
         if (!isSubViewEnabled(index)) return;
         view = View.values()[index];
         clearSearch();
-        int depsCols = 7;
+        int depsCols = 8;
         sortState = new SortState(view == View.DEPENDENCIES ? depsCols : 2);
     }
 
@@ -1628,14 +1738,14 @@ public class UpdatesTui extends ToolPanel {
                 new HelpOverlay.Section(
                         "Colors",
                         List.of(
-                                new HelpOverlay.Entry("green", "Patch update — bug fixes, safe to apply"),
-                                new HelpOverlay.Entry("yellow", "Minor update — new features, usually compatible"),
-                                new HelpOverlay.Entry("red", "Major update — breaking changes possible"),
-                                new HelpOverlay.Entry("cyan", "Property group header (${property.name})"))),
+                                new HelpOverlay.Entry("dim", "Patch update — bug fixes, safe to apply"),
+                                new HelpOverlay.Entry("white", "Minor update — new features, usually compatible"),
+                                new HelpOverlay.Entry("yellow", "Major update — breaking changes possible"))),
                 new HelpOverlay.Section(
                         actionsTitle,
                         List.of(
                                 new HelpOverlay.Entry("↑ / ↓", "Move selection up / down"),
+                                new HelpOverlay.Entry("← / →", "Collapse / expand property group"),
                                 new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
                                 new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
                                 new HelpOverlay.Entry(KEY_SPACE, "Toggle selection (group or individual)"),

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -1099,10 +1099,11 @@ public class UpdatesTui extends ToolPanel {
                 boolean detailsVisible = showDetails && !displayRows.isEmpty();
                 if (detailsVisible) {
                     var split = Layout.vertical()
-                            .constraints(Constraint.fill(), Constraint.percentage(30))
+                            .constraints(Constraint.fill(), Constraint.length(1), Constraint.percentage(30))
                             .split(contentArea);
                     renderDepsTable(frame, split.get(0));
-                    renderDetailPane(frame, split.get(1));
+                    renderDivider(frame, split.get(1));
+                    renderDetailPane(frame, split.get(2));
                 } else {
                     renderDepsTable(frame, contentArea);
                 }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -394,22 +394,31 @@ public class UpdatesTui extends ToolPanel {
     void buildDisplayRows() {
         displayRows = new ArrayList<>();
         duplicatePropertyNames = computeDuplicatePropertyNames(reactorResult.propertyGroups);
+        addPropertyGroupRows();
+        addUngroupedRows();
+        if (!displayRows.isEmpty()) {
+            tableState.select(0);
+        }
+    }
 
+    private void addPropertyGroupRows() {
         for (var group : reactorResult.propertyGroups) {
             boolean groupHasUpdate = group.hasUpdate()
                     || group.dependencies.stream().anyMatch(ReactorCollector.AggregatedDependency::hasUpdate);
             if (filter != Filter.ALL) {
                 groupHasUpdate = matchesFilter(group.updateType);
             }
-            if (groupHasUpdate) {
-                displayRows.add(ReactorRow.group(group));
-                if (group.expanded) {
-                    for (var dep : group.dependencies) {
-                        displayRows.add(ReactorRow.dep(dep));
-                    }
+            if (!groupHasUpdate) continue;
+            displayRows.add(ReactorRow.group(group));
+            if (group.expanded) {
+                for (var dep : group.dependencies) {
+                    displayRows.add(ReactorRow.dep(dep));
                 }
             }
         }
+    }
+
+    private void addUngroupedRows() {
         for (var dep : reactorResult.ungroupedDependencies) {
             boolean show =
                     switch (filter) {
@@ -421,9 +430,6 @@ public class UpdatesTui extends ToolPanel {
             if (show) {
                 displayRows.add(ReactorRow.dep(dep));
             }
-        }
-        if (!displayRows.isEmpty()) {
-            tableState.select(0);
         }
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/XmlTreeModel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/XmlTreeModel.java
@@ -220,7 +220,7 @@ public class XmlTreeModel {
         spans.add(Span.raw(indent));
 
         if (node instanceof Comment comment) {
-            spans.add(Span.raw("<!-- " + comment.content().trim() + " -->").fg(Color.DARK_GRAY));
+            spans.add(Span.raw("  <!-- " + comment.content().trim() + " -->").fg(Color.DARK_GRAY));
             return Line.from(spans);
         }
 

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/AuditTuiTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/AuditTuiTest.java
@@ -319,6 +319,17 @@ class AuditTuiTest {
     }
 
     @Test
+    void panelModeDividerBetweenTableAndDetails(@TempDir Path tempDir) throws Exception {
+        String pomPath =
+                Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
+        List<AuditTui.AuditEntry> entries = buildTestEntries();
+        AuditTui tui = new AuditTui(entries, "com.example:test:1.0", null, pomPath);
+
+        String output = TuiTestHelper.render(f -> tui.render(f, f.area()));
+        assertThat(output).contains("─".repeat(10));
+    }
+
+    @Test
     void vulnerabilitiesViewRendersScopeColumn(@TempDir Path tempDir) throws Exception {
         String pomPath =
                 Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ConflictsTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ConflictsTuiRenderTest.java
@@ -26,7 +26,9 @@ import dev.tamboui.tui.event.KeyEvent;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -134,5 +136,257 @@ class ConflictsTuiRenderTest {
         String output = render(tui::renderStandalone);
 
         assertThat(output).contains("com.example:app:2.0");
+    }
+
+    // ── collectConflicts tests ──────────────────────────────────────────────
+
+    @Test
+    void collectConflictsFindsChildNodes() {
+        var root = new DependencyTreeModel.TreeNode("com.example", "root", "1.0", "compile", false, 0);
+        var child1 = new DependencyTreeModel.TreeNode("org.a", "lib-a", "1.0", "compile", false, 1);
+        var child2 = new DependencyTreeModel.TreeNode("org.a", "lib-a", "2.0", "compile", false, 1);
+        root.children.add(child1);
+        root.children.add(child2);
+
+        Map<String, List<ConflictsTui.ConflictEntry>> conflicts = new HashMap<>();
+        ConflictsTui.collectConflicts(root, conflicts, new ArrayList<>());
+
+        assertThat(conflicts).containsKey("org.a:lib-a");
+        assertThat(conflicts.get("org.a:lib-a")).hasSize(2);
+    }
+
+    @Test
+    void collectConflictsUsesRequestedVersion() {
+        var root = new DependencyTreeModel.TreeNode("com.example", "root", "1.0", "compile", false, 0);
+        var child = new DependencyTreeModel.TreeNode("org.a", "lib-a", "2.0", "compile", false, 1);
+        child.requestedVersion = "1.0";
+        root.children.add(child);
+
+        Map<String, List<ConflictsTui.ConflictEntry>> conflicts = new HashMap<>();
+        ConflictsTui.collectConflicts(root, conflicts, new ArrayList<>());
+
+        ConflictsTui.ConflictEntry entry = conflicts.get("org.a:lib-a").get(0);
+        assertThat(entry.requestedVersion).isEqualTo("1.0");
+        assertThat(entry.resolvedVersion).isEqualTo("2.0");
+    }
+
+    @Test
+    void collectConflictsBuildsPath() {
+        var root = new DependencyTreeModel.TreeNode("com.example", "root", "1.0", "compile", false, 0);
+        var parent = new DependencyTreeModel.TreeNode("org.a", "parent", "1.0", "compile", false, 1);
+        var child = new DependencyTreeModel.TreeNode("org.b", "child", "1.0", "compile", false, 2);
+        root.children.add(parent);
+        parent.children.add(child);
+
+        Map<String, List<ConflictsTui.ConflictEntry>> conflicts = new HashMap<>();
+        List<String> basePath = new ArrayList<>();
+        basePath.add("[module-a]");
+        ConflictsTui.collectConflicts(root, conflicts, basePath);
+
+        ConflictsTui.ConflictEntry childEntry = conflicts.get("org.b:child").get(0);
+        assertThat(childEntry.path)
+                .contains("[module-a]")
+                .contains("org.a:parent")
+                .contains("org.b:child");
+    }
+
+    // ── filterConflictGroups tests ──────────────────────────────────────────
+
+    @Test
+    void filterConflictGroupsKeepsMultiEntry() {
+        Map<String, List<ConflictsTui.ConflictEntry>> map = new HashMap<>();
+        map.put(
+                "org.a:lib",
+                List.of(
+                        new ConflictsTui.ConflictEntry("org.a", "lib", "1.0", "1.0", "direct", "compile"),
+                        new ConflictsTui.ConflictEntry("org.a", "lib", "1.0", "1.0", "transitive", "compile")));
+        map.put(
+                "org.b:single",
+                List.of(new ConflictsTui.ConflictEntry("org.b", "single", "1.0", "1.0", "direct", "compile")));
+
+        List<ConflictsTui.ConflictGroup> groups = ConflictsTui.filterConflictGroups(map);
+
+        assertThat(groups).hasSize(1);
+        assertThat(groups.get(0).ga).isEqualTo("org.a:lib");
+    }
+
+    @Test
+    void filterConflictGroupsKeepsVersionMismatch() {
+        Map<String, List<ConflictsTui.ConflictEntry>> map = new HashMap<>();
+        map.put(
+                "org.a:lib",
+                List.of(new ConflictsTui.ConflictEntry("org.a", "lib", "1.0", "2.0", "direct", "compile")));
+
+        List<ConflictsTui.ConflictGroup> groups = ConflictsTui.filterConflictGroups(map);
+
+        assertThat(groups).hasSize(1);
+    }
+
+    // ── Async loading constructor tests ─────────────────────────────────────
+
+    @Test
+    void asyncConstructorShowsLoadingState() {
+        PomEditSession session = new PomEditSession(Path.of(pomPath));
+        PilotProject project = createDummyProject("mod-a");
+
+        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("Collecting Conflicts");
+    }
+
+    @Test
+    void asyncConstructorEmptyProjectsNotLoading() {
+        PomEditSession session = new PomEditSession(Path.of(pomPath));
+
+        var tui = new ConflictsTui(List.of(), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("Conflict Resolution");
+    }
+
+    @Test
+    void asyncLoadingShowsModuleName() {
+        PomEditSession session = new PomEditSession(Path.of(pomPath));
+        PilotProject project = createDummyProject("my-module");
+
+        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> {
+            return createEmptyTree();
+        });
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("0/1");
+    }
+
+    @Test
+    void asyncLoadingPanelModeShowsPlaceholder() {
+        PomEditSession session = new PomEditSession(Path.of(pomPath));
+        PilotProject project = createDummyProject("my-module");
+
+        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+        String output = render(f -> tui.render(f, f.area()));
+
+        assertThat(output).contains("Collecting conflicts");
+    }
+
+    @Test
+    void asyncLoadingHeaderShowsProgress() {
+        PomEditSession session = new PomEditSession(Path.of(pomPath));
+        PilotProject p1 = createDummyProject("mod-a");
+        PilotProject p2 = createDummyProject("mod-b");
+
+        var tui = new ConflictsTui(List.of(p1, p2), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("Collecting Conflicts");
+        assertThat(output).contains("0/2");
+    }
+
+    @Test
+    void asyncLoadingStatusMessage() {
+        PomEditSession session = new PomEditSession(Path.of(pomPath));
+        PilotProject project = createDummyProject("mod-a");
+
+        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+
+        assertThat(tui.status()).contains("Collecting conflicts");
+    }
+
+    // ── resolveModule / mergeAndAdvance / onCollectionComplete tests ──────
+
+    @Test
+    void resolveModuleSingleModule() {
+        PomEditSession session = new PomEditSession(Path.of(pomPath));
+        PilotProject project = createDummyProject("mod-a");
+
+        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createTreeWithConflict());
+
+        Map<String, List<ConflictsTui.ConflictEntry>> result = tui.resolveModule(project, false);
+
+        assertThat(result).containsKey("org.a:lib-a");
+        assertThat(result.get("org.a:lib-a").get(0).path).doesNotContain("[");
+    }
+
+    @Test
+    void resolveModuleMultiModulePrefixesPath() {
+        PomEditSession session = new PomEditSession(Path.of(pomPath));
+        PilotProject project = createDummyProject("mod-a");
+
+        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createTreeWithConflict());
+
+        Map<String, List<ConflictsTui.ConflictEntry>> result = tui.resolveModule(project, true);
+
+        assertThat(result.get("org.a:lib-a").get(0).path).contains("[mod-a]");
+    }
+
+    @Test
+    void mergeAndAdvanceTracksProgress() {
+        PomEditSession session = new PomEditSession(Path.of(pomPath));
+        PilotProject p1 = createDummyProject("mod-a");
+        PilotProject p2 = createDummyProject("mod-b");
+
+        var tui = new ConflictsTui(List.of(p1, p2), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+
+        Map<String, List<ConflictsTui.ConflictEntry>> mergedMap = new HashMap<>();
+        Map<String, List<ConflictsTui.ConflictEntry>> local = new HashMap<>();
+        local.put(
+                "org.a:lib-a",
+                new ArrayList<>(
+                        List.of(new ConflictsTui.ConflictEntry("org.a", "lib-a", "1.0", "1.0", "direct", "compile"))));
+
+        tui.mergeAndAdvance(local, mergedMap);
+
+        assertThat(tui.status()).contains("1/2");
+    }
+
+    @Test
+    void onCollectionCompleteTransitionsToLoaded() {
+        PomEditSession session = new PomEditSession(Path.of(pomPath));
+        PilotProject project = createDummyProject("mod-a");
+
+        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+
+        Map<String, List<ConflictsTui.ConflictEntry>> mergedMap = new HashMap<>();
+        mergedMap.put(
+                "org.a:lib-a",
+                List.of(
+                        new ConflictsTui.ConflictEntry("org.a", "lib-a", "1.0", "2.0", "path-a", "compile"),
+                        new ConflictsTui.ConflictEntry("org.a", "lib-a", "2.0", "2.0", "path-b", "compile")));
+
+        tui.onCollectionComplete(mergedMap);
+
+        String output = render(tui::renderStandalone);
+        assertThat(output).contains("Conflict Resolution");
+        assertThat(output).contains("lib-a");
+    }
+
+    private DependencyTreeModel createTreeWithConflict() {
+        var root = new DependencyTreeModel.TreeNode("com.example", "root", "1.0", "compile", false, 0);
+        var child = new DependencyTreeModel.TreeNode("org.a", "lib-a", "2.0", "compile", false, 1);
+        child.requestedVersion = "1.0";
+        root.children.add(child);
+        return new DependencyTreeModel(root, List.of(), 1);
+    }
+
+    private PilotProject createDummyProject(String artifactId) {
+        return new PilotProject(
+                "com.example",
+                artifactId,
+                "1.0.0",
+                "jar",
+                tempDir,
+                Path.of(pomPath),
+                List.of(),
+                List.of(),
+                List.of(),
+                List.of(),
+                new java.util.Properties(),
+                null,
+                null);
+    }
+
+    private DependencyTreeModel createEmptyTree() {
+        var root = new DependencyTreeModel.TreeNode("com.example", "root", "1.0", "compile", false, 0);
+        return new DependencyTreeModel(root, List.of(), 0);
     }
 }

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ConflictsTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ConflictsTuiRenderTest.java
@@ -32,6 +32,8 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -368,14 +370,18 @@ class ConflictsTuiRenderTest {
         PomEditSession session = new PomEditSession(Path.of(pomPath));
         PilotProject project = createDummyProject("mod-a");
 
-        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createTreeWithConflict());
+        CountDownLatch resolved = new CountDownLatch(1);
+        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> {
+            resolved.countDown();
+            return createTreeWithConflict();
+        });
 
         try (var runner = TuiRunner.create(TuiConfig.builder()
                 .backend(new TestBackend(80, 24))
                 .shutdownHook(false)
                 .build())) {
             tui.setRunner(runner);
-            Thread.sleep(200);
+            assertThat(resolved.await(5, TimeUnit.SECONDS)).isTrue();
         }
     }
 
@@ -384,7 +390,9 @@ class ConflictsTuiRenderTest {
         PomEditSession session = new PomEditSession(Path.of(pomPath));
         PilotProject project = createDummyProject("mod-a");
 
+        CountDownLatch failed = new CountDownLatch(1);
         var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> {
+            failed.countDown();
             throw new RuntimeException("resolver failed");
         });
 
@@ -393,7 +401,7 @@ class ConflictsTuiRenderTest {
                 .shutdownHook(false)
                 .build())) {
             tui.setRunner(runner);
-            Thread.sleep(200);
+            assertThat(failed.await(5, TimeUnit.SECONDS)).isTrue();
         }
     }
 

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ConflictsTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ConflictsTuiRenderTest.java
@@ -21,6 +21,9 @@ package eu.maveniverse.maven.pilot;
 import static eu.maveniverse.maven.pilot.TuiTestHelper.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tamboui.terminal.TestBackend;
+import dev.tamboui.tui.TuiConfig;
+import dev.tamboui.tui.TuiRunner;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import java.nio.file.Files;
@@ -278,8 +281,7 @@ class ConflictsTuiRenderTest {
         var tui = new ConflictsTui(List.of(p1, p2), session, "com.example:demo:1.0.0", p -> createEmptyTree());
         String output = render(tui::renderStandalone);
 
-        assertThat(output).contains("Collecting Conflicts");
-        assertThat(output).contains("0/2");
+        assertThat(output).contains("Collecting Conflicts").contains("0/2");
     }
 
     @Test
@@ -356,8 +358,43 @@ class ConflictsTuiRenderTest {
         tui.onCollectionComplete(mergedMap);
 
         String output = render(tui::renderStandalone);
-        assertThat(output).contains("Conflict Resolution");
-        assertThat(output).contains("lib-a");
+        assertThat(output).contains("Conflict Resolution").contains("lib-a");
+    }
+
+    // ── async setRunner / startConflictCollection tests ───────────────────
+
+    @Test
+    void asyncSetRunnerTriggersConflictCollection() throws Exception {
+        PomEditSession session = new PomEditSession(Path.of(pomPath));
+        PilotProject project = createDummyProject("mod-a");
+
+        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createTreeWithConflict());
+
+        try (var runner = TuiRunner.create(TuiConfig.builder()
+                .backend(new TestBackend(80, 24))
+                .shutdownHook(false)
+                .build())) {
+            tui.setRunner(runner);
+            Thread.sleep(200);
+        }
+    }
+
+    @Test
+    void asyncCollectionHandlesResolverFailure() throws Exception {
+        PomEditSession session = new PomEditSession(Path.of(pomPath));
+        PilotProject project = createDummyProject("mod-a");
+
+        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> {
+            throw new RuntimeException("resolver failed");
+        });
+
+        try (var runner = TuiRunner.create(TuiConfig.builder()
+                .backend(new TestBackend(80, 24))
+                .shutdownHook(false)
+                .build())) {
+            tui.setRunner(runner);
+            Thread.sleep(200);
+        }
     }
 
     private DependencyTreeModel createTreeWithConflict() {

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ConflictsTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ConflictsTuiRenderTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static eu.maveniverse.maven.pilot.TuiTestHelper.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class ConflictsTuiRenderTest {
+
+    @TempDir
+    Path tempDir;
+
+    private String pomPath;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        pomPath = Files.writeString(tempDir.resolve("pom.xml"), "<project/>").toString();
+    }
+
+    private ConflictsTui createTuiWithConflicts() {
+        List<ConflictsTui.ConflictGroup> conflicts = new ArrayList<>();
+
+        var e1 = new ConflictsTui.ConflictEntry(
+                "org.apache.commons", "commons-lang3", "3.12.0", "3.14.0", "commons-text:1.11.0", "compile");
+        var e2 = new ConflictsTui.ConflictEntry(
+                "org.apache.commons", "commons-lang3", "3.14.0", "3.14.0", "direct", "compile");
+        conflicts.add(new ConflictsTui.ConflictGroup("org.apache.commons:commons-lang3", List.of(e1, e2)));
+
+        var e3 =
+                new ConflictsTui.ConflictEntry("org.slf4j", "slf4j-api", "2.0.9", "2.0.9", "logback:1.4.14", "compile");
+        var e4 = new ConflictsTui.ConflictEntry("org.slf4j", "slf4j-api", "2.0.9", "2.0.9", "direct", "compile");
+        conflicts.add(new ConflictsTui.ConflictGroup("org.slf4j:slf4j-api", List.of(e3, e4)));
+
+        return new ConflictsTui(conflicts, pomPath, "com.example:demo:1.0.0");
+    }
+
+    @Test
+    void renderShowsConflictGroups() {
+        var tui = createTuiWithConflicts();
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("commons-lang3");
+    }
+
+    @Test
+    void showAllRevealsConvergedGroups() {
+        var tui = createTuiWithConflicts();
+        tui.handleEvent(KeyEvent.ofChar('t'), null);
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("commons-lang3").contains("slf4j-api");
+    }
+
+    @Test
+    void renderShowsProjectGav() {
+        var tui = createTuiWithConflicts();
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("com.example:demo:1.0.0");
+    }
+
+    @Test
+    void standaloneDividerBetweenTableAndDetails() {
+        var tui = createTuiWithConflicts();
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("─".repeat(10));
+    }
+
+    @Test
+    void panelModeDividerBetweenTableAndDetails() {
+        var tui = createTuiWithConflicts();
+        String output = render(f -> tui.render(f, f.area()));
+
+        assertThat(output).contains("─".repeat(10));
+    }
+
+    @Test
+    void panelModeNoDividerWhenDetailsHidden() {
+        var tui = createTuiWithConflicts();
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.ENTER), null);
+        String output = render(f -> tui.render(f, f.area()));
+
+        long dividerLines = output.lines().filter(l -> l.matches("^─+$")).count();
+        assertThat(dividerLines).isZero();
+    }
+
+    @Test
+    void loadingStateShowsProgressCounter() {
+        List<ConflictsTui.ConflictGroup> empty = List.of();
+        var tui = new ConflictsTui(empty, pomPath, "com.example:demo:1.0.0");
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("Conflict Resolution");
+    }
+
+    @Test
+    void renderShowsVersionInfo() {
+        var tui = createTuiWithConflicts();
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("3.12.0").contains("3.14.0");
+    }
+
+    @Test
+    void emptyConflictsRenderWithoutError() {
+        var tui = new ConflictsTui(List.of(), pomPath, "com.example:app:2.0");
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("com.example:app:2.0");
+    }
+}

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/DependenciesTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/DependenciesTuiRenderTest.java
@@ -163,6 +163,16 @@ class DependenciesTuiRenderTest {
         assertThat(afterNav).isNotEqualTo(initial);
     }
 
+    // ── Divider ────────────────────────────────────────────────────────────
+
+    @Test
+    void panelModeDividerBetweenTableAndDetails() {
+        var tui = createTuiWithDeps();
+        String output = render(f -> tui.render(f, f.area()));
+
+        assertThat(output).contains("─".repeat(10));
+    }
+
     // ── Empty state ────────────────────────────────────────────────────────
 
     @Test

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PilotShellToolDefTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PilotShellToolDefTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class PilotShellToolDefTest {
+
+    @Test
+    void searchToolIsModuleIndependent() {
+        var search = PilotShell.TOOLS.stream()
+                .filter(t -> "search".equals(t.id()))
+                .findFirst()
+                .orElseThrow();
+        assertThat(search.isModuleIndependent()).isTrue();
+    }
+
+    @Test
+    void nonSearchToolsAreNotModuleIndependent() {
+        PilotShell.TOOLS.stream().filter(t -> !"search".equals(t.id())).forEach(t -> assertThat(t.isModuleIndependent())
+                .as("Tool '%s' should not be module-independent", t.id())
+                .isFalse());
+    }
+
+    @Test
+    void aggregatableToolsIncludeAlignUpdatesConflictsAudit() {
+        var aggregatable = PilotShell.TOOLS.stream()
+                .filter(PilotShell.ToolDef::aggregatable)
+                .map(PilotShell.ToolDef::id)
+                .toList();
+        assertThat(aggregatable).containsExactlyInAnyOrder("align", "updates", "conflicts", "audit");
+    }
+
+    @Test
+    void nonAggregatableToolsAreTreeDepsPomSearch() {
+        var nonAggregatable = PilotShell.TOOLS.stream()
+                .filter(t -> !t.aggregatable())
+                .map(PilotShell.ToolDef::id)
+                .toList();
+        assertThat(nonAggregatable).containsExactlyInAnyOrder("tree", "dependencies", "pom", "search");
+    }
+
+    @Test
+    void allToolsHaveUniqueMnemonics() {
+        var mnemonics =
+                PilotShell.TOOLS.stream().map(PilotShell.ToolDef::mnemonic).toList();
+        assertThat(mnemonics).doesNotHaveDuplicates();
+    }
+
+    @Test
+    void allToolsHaveUniqueIds() {
+        var ids = PilotShell.TOOLS.stream().map(PilotShell.ToolDef::id).toList();
+        assertThat(ids).doesNotHaveDuplicates();
+    }
+}

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PomTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PomTuiRenderTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static eu.maveniverse.maven.pilot.TuiTestHelper.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tamboui.tui.event.KeyEvent;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class PomTuiRenderTest {
+
+    private static final String SAMPLE_POM = """
+            <project>
+              <groupId>com.example</groupId>
+              <artifactId>demo</artifactId>
+              <version>1.0</version>
+              <dependencies>
+                <dependency>
+                  <groupId>org.slf4j</groupId>
+                  <artifactId>slf4j-api</artifactId>
+                  <version>2.0.9</version>
+                </dependency>
+              </dependencies>
+            </project>
+            """;
+
+    private PomTui createTui() {
+        XmlTreeModel effective = XmlTreeModel.parse(SAMPLE_POM);
+        return new PomTui(SAMPLE_POM, effective, null, "pom.xml", Map.of());
+    }
+
+    @Test
+    void renderShowsPomContent() {
+        var tui = createTui();
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("groupId").contains("artifactId").contains("demo");
+    }
+
+    @Test
+    void effectiveViewPanelModeDivider() {
+        var tui = createTui();
+        tui.handleEvent(KeyEvent.ofChar('2'), null);
+        String output = render(f -> tui.render(f, f.area()));
+
+        assertThat(output).contains("─".repeat(10));
+    }
+
+    @Test
+    void effectiveViewStandaloneDivider() {
+        var tui = createTui();
+        tui.handleEvent(KeyEvent.ofChar('2'), null);
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("─".repeat(10));
+    }
+}

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiRenderTest.java
@@ -219,6 +219,16 @@ class UpdatesTuiRenderTest {
         assertThat(output).contains("\u2192"); // →
     }
 
+    // ── Divider ────────────────────────────────────────────────────────────
+
+    @Test
+    void panelModeDividerBetweenTableAndDetails() throws Exception {
+        var tui = createTuiWithUpdates();
+        String output = render(f -> tui.render(f, f.area()));
+
+        assertThat(output).contains("─".repeat(10));
+    }
+
     // ── Selection ──────────────────────────────────────────────────────────
 
     @Test

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiRenderTest.java
@@ -472,4 +472,122 @@ class UpdatesTuiRenderTest {
         String output = render(tui::renderStandalone);
         assertThat(output).contains("Scroll").contains("Close");
     }
+
+    // ── Property groups ────────────────────────────────────────────────────
+
+    private UpdatesTui createTuiWithPropertyGroup() throws Exception {
+        Path dir = Files.createDirectories(tempDir.resolve("prop-project"));
+        Files.writeString(dir.resolve("pom.xml"), "<project/>");
+
+        var deps = List.of(
+                dep("org.springframework", "spring-core", "5.3.0"),
+                dep("org.springframework", "spring-web", "5.3.0"),
+                dep("com.google.guava", "guava", "33.0.0-jre"));
+        var origDeps = List.of(
+                dep("org.springframework", "spring-core", "${spring.version}"),
+                dep("org.springframework", "spring-web", "${spring.version}"),
+                dep("com.google.guava", "guava", "33.0.0-jre"));
+
+        var props = new Properties();
+        props.setProperty("spring.version", "5.3.0");
+        var project = createProject("com.example", "demo", "1.0.0", dir, deps, List.of(), origDeps, List.of());
+        // Replace properties on the project
+        var projectWithProps = new PilotProject(
+                "com.example",
+                "demo",
+                "1.0.0",
+                "jar",
+                dir,
+                dir.resolve("pom.xml"),
+                deps,
+                List.of(),
+                origDeps,
+                List.of(),
+                props,
+                null,
+                null);
+
+        var result = ReactorCollector.collect(List.of(projectWithProps));
+        var model = ReactorModel.build(List.of(projectWithProps));
+        var tui = new UpdatesTui(result, model, "com.example:demo:1.0.0", (g, a) -> List.of());
+
+        for (var group : result.propertyGroups) {
+            group.newestVersion = "6.1.0";
+            group.updateType = VersionComparator.UpdateType.MAJOR;
+            for (var d : group.dependencies) {
+                d.newestVersion = "6.1.0";
+                d.updateType = VersionComparator.UpdateType.MAJOR;
+            }
+        }
+        for (var d : result.ungroupedDependencies) {
+            if ("guava".equals(d.artifactId)) {
+                d.newestVersion = "33.4.0-jre";
+                d.updateType = VersionComparator.UpdateType.MINOR;
+            }
+        }
+
+        tui.loading = false;
+        tui.buildDisplayRows();
+        tui.status = "3 update(s) available";
+        return tui;
+    }
+
+    @Test
+    void propertyGroupRendersGroupHeader() throws Exception {
+        var tui = createTuiWithPropertyGroup();
+        String output = render(tui::renderStandalone);
+
+        assertThat(output).contains("${spring.version}");
+    }
+
+    @Test
+    void rightArrowExpandsPropertyGroup() throws Exception {
+        var tui = createTuiWithPropertyGroup();
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.RIGHT), null);
+
+        String output = render(tui::renderStandalone);
+        assertThat(output).contains("spring-core").contains("spring-web");
+    }
+
+    @Test
+    void leftArrowCollapsesExpandedPropertyGroup() throws Exception {
+        var tui = createTuiWithPropertyGroup();
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.RIGHT), null);
+        String expanded = render(tui::renderStandalone);
+
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.LEFT), null);
+        String collapsed = render(tui::renderStandalone);
+
+        assertThat(expanded).contains("spring-core").contains("spring-web");
+        assertThat(collapsed).isNotEqualTo(expanded);
+    }
+
+    @Test
+    void leftArrowOnChildDepJumpsToGroupHeader() throws Exception {
+        var tui = createTuiWithPropertyGroup();
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.RIGHT), null);
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.DOWN), null);
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.LEFT), null);
+
+        String output = render(tui::renderStandalone);
+        assertThat(output).contains("spring-core");
+    }
+
+    @Test
+    void sortCycleTriggersReorder() throws Exception {
+        var tui = createTuiWithPropertyGroup();
+        tui.handleEvent(KeyEvent.ofChar('s'), null);
+
+        String output = render(tui::renderStandalone);
+        assertThat(output).contains("${spring.version}").contains("guava");
+    }
+
+    @Test
+    void selectAllIncludesPropertyGroupAndUngrouped() throws Exception {
+        var tui = createTuiWithPropertyGroup();
+        tui.handleEvent(KeyEvent.ofChar('a'), null);
+
+        String output = render(tui::renderStandalone);
+        assertThat(countOccurrences(output, "[\u2713]")).isGreaterThanOrEqualTo(2);
+    }
 }

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
@@ -683,7 +683,7 @@ class UpdatesTuiTest {
 
     // -- Dependencies view: left/right navigation tests --
 
-    private UpdatesTui createGroupTui(Path dir) throws IOException {
+    private UpdatesTui createGroupTui(Path dir) {
         Properties props = new Properties();
         props.setProperty("jackson.version", "2.17.0");
         PilotProject project = createProject(

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
@@ -241,10 +241,15 @@ class UpdatesTuiTest {
 
         tui.buildDisplayRows();
 
-        // 1 group header + 2 dependencies
-        assertThat(tui.displayRows).hasSize(3);
+        // Groups are collapsed by default — only header visible
+        assertThat(tui.displayRows).hasSize(1);
         assertThat(tui.displayRows.get(0).isGroupHeader()).isTrue();
         assertThat(tui.displayRows.get(0).propertyGroup.propertyName).isEqualTo("jackson.version");
+
+        // After expanding, children become visible
+        result.propertyGroups.get(0).expanded = true;
+        tui.buildDisplayRows();
+        assertThat(tui.displayRows).hasSize(3);
         assertThat(tui.displayRows.get(1).isGroupHeader()).isFalse();
         assertThat(tui.displayRows.get(2).isGroupHeader()).isFalse();
     }
@@ -491,6 +496,7 @@ class UpdatesTuiTest {
         result.allDependencies.get(0).updateType = VersionComparator.UpdateType.MINOR;
         result.propertyGroups.get(0).newestVersion = "2.18.0";
         result.propertyGroups.get(0).updateType = VersionComparator.UpdateType.MINOR;
+        result.propertyGroups.get(0).expanded = true;
 
         tui.loading = false;
         tui.buildDisplayRows();
@@ -673,6 +679,296 @@ class UpdatesTuiTest {
         if (!tui.displayRows.isEmpty()) {
             renderFrame(tui);
         }
+    }
+
+    // -- Dependencies view: left/right navigation tests --
+
+    private UpdatesTui createGroupTui(Path dir) throws IOException {
+        Properties props = new Properties();
+        props.setProperty("jackson.version", "2.17.0");
+        PilotProject project = createProject(
+                "com.example",
+                "app",
+                "1.0",
+                dir,
+                List.of(
+                        dep("com.fasterxml", "jackson-core", "2.17.0"),
+                        dep("com.fasterxml", "jackson-databind", "2.17.0")),
+                List.of(),
+                List.of(
+                        dep("com.fasterxml", "jackson-core", "${jackson.version}"),
+                        dep("com.fasterxml", "jackson-databind", "${jackson.version}")),
+                List.of(),
+                props);
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+        var tui = createTui(result, List.of(project));
+
+        for (var d : result.allDependencies) {
+            d.newestVersion = "2.18.0";
+            d.updateType = VersionComparator.UpdateType.MINOR;
+        }
+        result.propertyGroups.get(0).newestVersion = "2.18.0";
+        result.propertyGroups.get(0).updateType = VersionComparator.UpdateType.MINOR;
+
+        tui.buildDisplayRows();
+        return tui;
+    }
+
+    @Test
+    void groupsCollapsedByDefault() throws IOException {
+        var tui = createGroupTui(subdir("navDefault"));
+
+        assertThat(tui.displayRows).hasSize(1);
+        assertThat(tui.displayRows.get(0).isGroupHeader()).isTrue();
+    }
+
+    @Test
+    void leftArrowCollapsesExpandedPropertyGroup() throws IOException {
+        var tui = createGroupTui(subdir("navCollapse"));
+
+        // Expand first
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.RIGHT), null);
+        assertThat(tui.displayRows).hasSize(3);
+
+        // LEFT → collapse
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.LEFT), null);
+        assertThat(tui.displayRows).hasSize(1);
+        assertThat(tui.displayRows.get(0).isGroupHeader()).isTrue();
+    }
+
+    @Test
+    void rightArrowExpandsCollapsedPropertyGroup() throws IOException {
+        var tui = createGroupTui(subdir("navExpand"));
+
+        // Collapsed by default
+        assertThat(tui.displayRows).hasSize(1);
+
+        // RIGHT → expands
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.RIGHT), null);
+        assertThat(tui.displayRows).hasSize(3);
+    }
+
+    @Test
+    void rightArrowOnExpandedGroupMovesDown() throws IOException {
+        var tui = createGroupTui(subdir("navDown"));
+
+        // Expand first
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.RIGHT), null);
+        // Group already expanded; RIGHT moves selection past header
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.RIGHT), null);
+        // Now on child dep; LEFT jumps to parent header, LEFT again collapses
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.LEFT), null);
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.LEFT), null);
+        assertThat(tui.displayRows).hasSize(1);
+    }
+
+    @Test
+    void leftArrowOnChildDepJumpsToGroupHeader() throws IOException {
+        var tui = createGroupTui(subdir("navChild"));
+
+        // Expand first
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.RIGHT), null);
+        // Move to child dep
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.DOWN), null);
+        // LEFT → jump to parent group header
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.LEFT), null);
+        // LEFT again → collapse (proves we're on the header)
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.LEFT), null);
+
+        assertThat(tui.displayRows).hasSize(1);
+    }
+
+    @Test
+    void leftArrowOnUngroupedDepDoesNotJumpToGroup() throws IOException {
+        Path dir = subdir("navUngrouped");
+
+        Properties props = new Properties();
+        props.setProperty("jackson.version", "2.17.0");
+        PilotProject project = createProject(
+                "com.example",
+                "app",
+                "1.0",
+                dir,
+                List.of(dep("com.fasterxml", "jackson-core", "2.17.0"), dep("com.example", "standalone-lib", "1.0")),
+                List.of(),
+                List.of(
+                        dep("com.fasterxml", "jackson-core", "${jackson.version}"),
+                        dep("com.example", "standalone-lib", "1.0")),
+                List.of(),
+                props);
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+        var tui = createTui(result, List.of(project));
+
+        for (var d : result.allDependencies) {
+            d.newestVersion = "2.0.0";
+            d.updateType = VersionComparator.UpdateType.MAJOR;
+        }
+        result.propertyGroups.get(0).newestVersion = "2.0.0";
+        result.propertyGroups.get(0).updateType = VersionComparator.UpdateType.MAJOR;
+
+        tui.buildDisplayRows();
+        // 1 group header (collapsed) + 1 ungrouped dep
+        assertThat(tui.displayRows).hasSize(2);
+
+        // Move to ungrouped dep
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.DOWN), null);
+        // LEFT should NOT jump to the group header (ungrouped dep has no parent)
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.LEFT), null);
+        // Verify group is still collapsed (LEFT didn't jump to it and collapse it)
+        assertThat(tui.displayRows).hasSize(2);
+    }
+
+    @Test
+    void buildDisplayRowsRespectsCollapsedGroup() throws IOException {
+        Path dir = subdir("navBuild");
+
+        Properties props = new Properties();
+        props.setProperty("jackson.version", "2.17.0");
+        PilotProject project = createProject(
+                "com.example",
+                "app",
+                "1.0",
+                dir,
+                List.of(
+                        dep("com.fasterxml", "jackson-core", "2.17.0"),
+                        dep("com.fasterxml", "jackson-databind", "2.17.0")),
+                List.of(),
+                List.of(
+                        dep("com.fasterxml", "jackson-core", "${jackson.version}"),
+                        dep("com.fasterxml", "jackson-databind", "${jackson.version}")),
+                List.of(),
+                props);
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(project));
+        var tui = createTui(result, List.of(project));
+
+        for (var d : result.allDependencies) {
+            d.newestVersion = "2.18.0";
+            d.updateType = VersionComparator.UpdateType.MINOR;
+        }
+        result.propertyGroups.get(0).newestVersion = "2.18.0";
+        result.propertyGroups.get(0).updateType = VersionComparator.UpdateType.MINOR;
+
+        result.propertyGroups.get(0).expanded = false;
+        tui.buildDisplayRows();
+
+        assertThat(tui.displayRows).hasSize(1);
+        assertThat(tui.displayRows.get(0).isGroupHeader()).isTrue();
+    }
+
+    // -- Modules view: left/right navigation tests --
+
+    @Test
+    void modulesLeftArrowCollapsesExpandedNode() throws IOException {
+        Path parentDir = subdir("modCollapse");
+        Path childDir = subdir("modCollapse/child");
+
+        PilotProject parent = createProject("com.example", "parent", "1.0", parentDir);
+        PilotProject child = createProject("com.example", "child", "1.0", childDir);
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(parent, child));
+        ReactorModel model = ReactorModel.build(List.of(parent, child));
+        var tui = new UpdatesTui(result, model, "com.example:parent:1.0", (g, a) -> List.of());
+
+        // Switch to modules view and initialize selection
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.TAB), null);
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.DOWN), null);
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.UP), null);
+
+        assertThat(model.root.expanded).isTrue();
+        assertThat(model.visibleNodes()).hasSize(2);
+
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.LEFT), null);
+
+        assertThat(model.root.expanded).isFalse();
+        assertThat(model.visibleNodes()).hasSize(1);
+    }
+
+    @Test
+    void modulesRightArrowExpandsCollapsedNode() throws IOException {
+        Path parentDir = subdir("modExpand");
+        Path childDir = subdir("modExpand/child");
+
+        PilotProject parent = createProject("com.example", "parent", "1.0", parentDir);
+        PilotProject child = createProject("com.example", "child", "1.0", childDir);
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(parent, child));
+        ReactorModel model = ReactorModel.build(List.of(parent, child));
+        var tui = new UpdatesTui(result, model, "com.example:parent:1.0", (g, a) -> List.of());
+
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.TAB), null);
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.DOWN), null);
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.UP), null);
+
+        model.root.expanded = false;
+        assertThat(model.visibleNodes()).hasSize(1);
+
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.RIGHT), null);
+
+        assertThat(model.root.expanded).isTrue();
+        assertThat(model.visibleNodes()).hasSize(2);
+    }
+
+    @Test
+    void modulesRightArrowOnExpandedNodeMovesDown() throws IOException {
+        Path parentDir = subdir("modDown");
+        Path childDir = subdir("modDown/child");
+
+        PilotProject parent = createProject("com.example", "parent", "1.0", parentDir);
+        PilotProject child = createProject("com.example", "child", "1.0", childDir);
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(parent, child));
+        ReactorModel model = ReactorModel.build(List.of(parent, child));
+        var tui = new UpdatesTui(result, model, "com.example:parent:1.0", (g, a) -> List.of());
+
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.TAB), null);
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.DOWN), null);
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.UP), null);
+
+        assertThat(model.root.expanded).isTrue();
+
+        // RIGHT on expanded root → moves down to child
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.RIGHT), null);
+        // LEFT on child (leaf) → jump to parent; LEFT again → collapse
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.LEFT), null);
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.LEFT), null);
+
+        assertThat(model.root.expanded).isFalse();
+    }
+
+    @Test
+    void modulesLeftArrowOnChildJumpsToParent() throws IOException {
+        Path parentDir = subdir("modJump");
+        Path childDir = subdir("modJump/child");
+        Path grandchildDir = subdir("modJump/child/grandchild");
+
+        PilotProject parent = createProject("com.example", "parent", "1.0", parentDir);
+        PilotProject child = createProject("com.example", "child", "1.0", childDir);
+        PilotProject grandchild = createProject("com.example", "grandchild", "1.0", grandchildDir);
+
+        ReactorCollector.CollectionResult result = ReactorCollector.collect(List.of(parent, child, grandchild));
+        ReactorModel model = ReactorModel.build(List.of(parent, child, grandchild));
+        var tui = new UpdatesTui(result, model, "com.example:parent:1.0", (g, a) -> List.of());
+
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.TAB), null);
+
+        // parent(d=0,exp) → child(d=1,exp) → grandchild(d=2)
+        assertThat(model.visibleNodes()).hasSize(3);
+
+        // Move to grandchild
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.DOWN), null);
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.DOWN), null);
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.DOWN), null);
+
+        // LEFT on grandchild (leaf) → jump to child
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.LEFT), null);
+        // LEFT on child (expanded, has children) → collapse
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.LEFT), null);
+
+        assertThat(model.root.children.get(0).expanded).isFalse();
+        assertThat(model.visibleNodes()).hasSize(2);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add visible horizontal divider lines (`─`) between table and detail panes in all TUI views (Dependencies, Updates, Conflicts, Audit, POM) for consistent visual separation
- Make ConflictsTui load asynchronously with per-module progress tracking (shows module name during collection, matching audit behavior)
- Fix panel flickering when scrolling the module tree by keeping the old panel visible until the new one loads
- Fix XML comment indentation in POM/raw view (comments were 2 columns left of sibling elements)
- Pass full project list for module-independent tools in PilotShell

## Test plan
- [x] 21 new tests added across 5 test files (382 total, all passing)
- [ ] Manual: open multi-module project, scroll module tree — verify no flickering in right pane
- [ ] Manual: click Conflicts tab — verify loading shows module name on second line
- [ ] Manual: verify divider lines appear between table and detail panes in all views
- [ ] Manual: check POM view comments are properly aligned with sibling elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async multi-module conflict collection with progress UI and loading placeholders.
  * Split-pane detail views with visible dividers across several tools.
  * Expandable property groups in Updates with LEFT/RIGHT keyboard controls and update-type column with color styling.

* **Improvements**
  * Improved keyboard navigation across Dependencies and Modules.
  * Property groups default to collapsed and comment indentation improved in POM display.

* **Tests**
  * Added extensive rendering and navigation tests covering conflicts, updates, dependencies, POM, and tooling invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->