### PR TITLE
perf: parallel dependency resolution, shared model cache, idle CPU fix

### DIFF
--- a/pilot-cli/src/main/java/eu/maveniverse/maven/pilot/mvn4/PilotMain.java
+++ b/pilot-cli/src/main/java/eu/maveniverse/maven/pilot/mvn4/PilotMain.java
@@ -279,13 +279,13 @@ public class PilotMain {
         List<Path> pomPaths = new ArrayList<>();
         collectPomPaths(discoveryResult, pomPaths);
 
-        // Build effective models for each module
+        // Build effective models for each module (reuse one session for shared cache)
         status.set("Building effective models (0/" + pomPaths.size() + ")…");
+        ModelBuilder.ModelBuilderSession effectiveSession = modelBuilder.newSession();
         List<PilotProject> projects = new ArrayList<>();
         Map<String, Model> effectiveModels = new LinkedHashMap<>();
         Map<String, PilotProject> projectsByGa = new LinkedHashMap<>();
         for (Path modulePom : pomPaths) {
-            ModelBuilder.ModelBuilderSession effectiveSession = modelBuilder.newSession();
             ModelBuilderRequest.ModelBuilderRequestBuilder effectiveBuilder = ModelBuilderRequest.builder()
                     .session(session)
                     .requestType(ModelBuilderRequest.RequestType.BUILD_EFFECTIVE)
@@ -314,7 +314,7 @@ public class PilotMain {
 
         // Extend parent chains beyond reactor for external parents
         status.set("Resolving parent chains…");
-        extendExternalParents(session, modelBuilder, projects, projectsByGa, extensionProperties);
+        extendExternalParents(session, effectiveSession, projects, projectsByGa, extensionProperties);
 
         status.set("Ready");
         PilotResolver resolver = new Maven4PilotResolver(session, effectiveModels);
@@ -331,7 +331,7 @@ public class PilotMain {
 
     private static void extendExternalParents(
             Session session,
-            ModelBuilder modelBuilder,
+            ModelBuilder.ModelBuilderSession mbs,
             List<PilotProject> projects,
             Map<String, PilotProject> projectsByGa,
             Map<String, String> extensionProperties) {
@@ -343,14 +343,14 @@ public class PilotMain {
             }
             if (projectsByGa.containsKey(top.ga())) {
                 // Already processed or is a reactor project — check if it needs extension
-                resolveExternalParentChain(session, modelBuilder, top, projectsByGa, extensionProperties);
+                resolveExternalParentChain(session, mbs, top, projectsByGa, extensionProperties);
             }
         }
     }
 
     private static void resolveExternalParentChain(
             Session session,
-            ModelBuilder modelBuilder,
+            ModelBuilder.ModelBuilderSession mbs,
             PilotProject project,
             Map<String, PilotProject> projectsByGa,
             Map<String, String> extensionProperties) {
@@ -359,7 +359,6 @@ public class PilotMain {
         // Resolve this project's parent POM to find properties defined in external parents
         try {
             // Build the file model for this project to get its declared parent
-            ModelBuilder.ModelBuilderSession mbs = modelBuilder.newSession();
             ModelBuilderRequest.ModelBuilderRequestBuilder builder = ModelBuilderRequest.builder()
                     .session(session)
                     .requestType(ModelBuilderRequest.RequestType.BUILD_EFFECTIVE)
@@ -383,7 +382,6 @@ public class PilotMain {
             if (parentPom == null) return;
 
             // Build the parent's model
-            ModelBuilder.ModelBuilderSession parentMbs = modelBuilder.newSession();
             ModelBuilderRequest.ModelBuilderRequestBuilder parentBuilder = ModelBuilderRequest.builder()
                     .session(session)
                     .requestType(ModelBuilderRequest.RequestType.BUILD_EFFECTIVE)
@@ -391,7 +389,7 @@ public class PilotMain {
             if (!extensionProperties.isEmpty()) {
                 parentBuilder.userProperties(extensionProperties);
             }
-            ModelBuilderResult parentResult = parentMbs.build(parentBuilder.build());
+            ModelBuilderResult parentResult = mbs.build(parentBuilder.build());
 
             PilotProject parentProject =
                     toPilotProject(parentResult.getEffectiveModel(), parentResult.getFileModel(), parentPom);
@@ -399,7 +397,7 @@ public class PilotMain {
             project.parent = parentProject;
 
             // Recursively extend the parent's parent chain
-            resolveExternalParentChain(session, modelBuilder, parentProject, projectsByGa, extensionProperties);
+            resolveExternalParentChain(session, mbs, parentProject, projectsByGa, extensionProperties);
         } catch (Exception e) {
             // External parent resolution is best-effort
         }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -569,6 +569,18 @@ public class AuditTui extends ToolPanel {
         status = changes == 0 ? "No changes to show" : changes + " line(s) changed";
     }
 
+    @Override
+    protected Line buildSubViewTabLine() {
+        Line base = super.buildSubViewTabLine();
+        if (vulnsLoaded < entries.size()) {
+            List<Span> spans = new ArrayList<>(base.spans());
+            spans.add(Span.raw("  checking vulnerabilities\u2026 " + vulnsLoaded + "/" + entries.size())
+                    .fg(Color.DARK_GRAY));
+            return Line.from(spans);
+        }
+        return base;
+    }
+
     // -- Rendering --
 
     @Override
@@ -1050,14 +1062,14 @@ public class AuditTui extends ToolPanel {
 
     private void renderVulnerabilities(Frame frame, Rect area) {
         if (vulnRows.isEmpty()) {
-            String filterLabel = scopeFilter != null ? " [" + scopeFilter + "]" : "";
             Block block = Block.builder()
                     .borderType(BorderType.ROUNDED)
                     .borderStyle(borderStyle())
                     .build();
             String msg;
             if (vulnsLoaded < entries.size()) {
-                msg = "Checking vulnerabilities\u2026 " + vulnsLoaded + "/" + entries.size();
+                // Loading progress is shown on the tab bar line
+                msg = "";
             } else if (scopeFilter != null) {
                 msg = "No known vulnerabilities in " + scopeFilter + " scope";
             } else {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -29,6 +29,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 /**
@@ -54,6 +55,18 @@ public class PilotEngine {
         return treeCache.computeIfAbsent(project.ga(), k -> resolver.collectDependencies(project));
     }
 
+    private void resolveAllDependencies(List<PilotProject> projects, Consumer<String> progress) {
+        AtomicInteger loaded = new AtomicInteger();
+        int total = projects.size();
+        projects.parallelStream().forEach(p -> {
+            cachedCollectDependencies(p);
+            synchronized (loaded) {
+                int count = loaded.incrementAndGet();
+                progress.accept("Resolving dependencies… " + count + "/" + total + "\n" + p.artifactId);
+            }
+        });
+    }
+
     public ToolPanel createPanel(String toolId, PilotProject proj, List<PilotProject> projects) throws Exception {
         return createPanel(toolId, proj, projects, null, null, s -> {});
     }
@@ -70,7 +83,7 @@ public class PilotEngine {
             case "tree" -> createTreePanel(proj);
             case "dependencies" -> createDependenciesPanel(proj, session);
             case "updates" -> createUpdatesPanel(proj, projects, session, sessionProvider, progress);
-            case "conflicts" -> createConflictsPanel(proj, projects, session);
+            case "conflicts" -> createConflictsPanel(proj, projects, session, progress);
             case "align" -> createAlignPanel(proj, projects);
             case "audit" -> createAuditPanel(proj, projects, session, progress);
             case "pom" -> createPomPanel(proj);
@@ -158,8 +171,10 @@ public class PilotEngine {
         return new UpdatesTui(result, reactorModel, gav, versionResolver, sessionProvider);
     }
 
-    private ToolPanel createConflictsPanel(PilotProject proj, List<PilotProject> projects, PomEditSession session) {
+    private ToolPanel createConflictsPanel(
+            PilotProject proj, List<PilotProject> projects, PomEditSession session, Consumer<String> progress) {
         List<PilotProject> targetProjects = projects.size() > 1 ? projects : List.of(proj);
+        resolveAllDependencies(targetProjects, progress);
         String gav = projects.size() > 1
                 ? projects.get(0).gav() + " (reactor: " + projects.size() + " modules)"
                 : proj.gav();
@@ -192,15 +207,12 @@ public class PilotEngine {
     private ToolPanel createAuditPanel(
             PilotProject proj, List<PilotProject> projects, PomEditSession session, Consumer<String> progress) {
         if (projects.size() > 1) {
+            resolveAllDependencies(projects, progress);
             PilotProject root = projects.get(0);
             DependencyTreeModel treeModel = cachedCollectDependencies(root);
             Map<String, AuditTui.AuditEntry> entryMap = new LinkedHashMap<>();
             int emptyTrees = 0;
-            for (int i = 0; i < projects.size(); i++) {
-                PilotProject p = projects.get(i);
-                if (projects.size() >= 100) {
-                    progress.accept("Collecting audit data… " + (i + 1) + "/" + projects.size() + "\n" + p.artifactId);
-                }
+            for (PilotProject p : projects) {
                 DependencyTreeModel tree = cachedCollectDependencies(p);
                 if (tree.root.children.isEmpty()) {
                     emptyTrees++;

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -23,6 +23,7 @@ import dev.tamboui.layout.Constraint;
 import dev.tamboui.layout.Layout;
 import dev.tamboui.layout.Rect;
 import dev.tamboui.style.Color;
+import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
@@ -32,6 +33,7 @@ import dev.tamboui.tui.event.Event;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.MouseEvent;
+import dev.tamboui.tui.event.TickEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.paragraph.Paragraph;
@@ -233,7 +235,33 @@ public class PilotShell {
             return handleMouseEvent(mouse);
         }
 
+        // Only redraw on tick if there's an active animation or loading
+        if (event instanceof TickEvent) {
+            return needsTickRedraw();
+        }
+
         return true;
+    }
+
+    private boolean needsTickRedraw() {
+        // Tree width animation in progress
+        if (currentTreeCols >= 0) {
+            int fullWidth = 120;
+            int narrowWidth = 30;
+            int target =
+                    switch (targetTreeWidth) {
+                        case FULL -> fullWidth;
+                        case NARROW -> narrowWidth;
+                        case HIDDEN -> 0;
+                    };
+            if (currentTreeCols != target) return true;
+        }
+        // Help overlay animating
+        if (helpOverlay.isAnimating()) return true;
+        // Panel loading in progress
+        if (panelLoadingStatus != null) return true;
+        if (loadingStatusSupplier != null && loadingStatusSupplier.get() != null) return true;
+        return false;
     }
 
     private boolean handleKeyEvent(KeyEvent key) {
@@ -825,10 +853,11 @@ public class PilotShell {
             title = " No Tool Selected ";
             message = "Select a tool with Alt+letter";
         }
+        Style border = focus == Focus.CONTENT ? theme.focusedBorder() : theme.unfocusedBorder();
         Block block = Block.builder()
                 .title(title)
                 .borderType(BorderType.ROUNDED)
-                .borderStyle(theme.placeholderBorder())
+                .borderStyle(border)
                 .build();
         Paragraph p = Paragraph.builder().text(message).block(block).centered().build();
         frame.renderWidget(p, area);

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -260,8 +260,7 @@ public class PilotShell {
         if (helpOverlay.isAnimating()) return true;
         // Panel loading in progress
         if (panelLoadingStatus != null) return true;
-        if (loadingStatusSupplier != null && loadingStatusSupplier.get() != null) return true;
-        return false;
+        return loadingStatusSupplier != null && loadingStatusSupplier.get() != null;
     }
 
     private boolean handleKeyEvent(KeyEvent key) {


### PR DESCRIPTION
## Summary

- **Parallel dependency resolution**: Use `parallelStream()` to resolve dependency trees for all reactor modules concurrently in conflicts and audit panels
- **Shared ModelBuilderSession cache**: Reuse a single `ModelBuilderSession` across all modules in CLI mode, avoiding redundant POM parsing and parent resolution for shared dependencies
- **Idle CPU optimization**: Skip tick redraws when nothing is animating or loading — prevents constant 50 FPS rendering when the TUI is idle
- **Audit UI fixes**: 
  - Placeholder border uses focused (cyan) style when content pane has focus
  - "checking vulnerabilities…" progress shown greyed on the tab bar line instead of centered in the content area, preventing layout shifts

## Test plan

- [x] Run `./mvnw test -B` — all existing tests pass
- [x] Open a multi-module project → Conflicts/Audit panels resolve dependencies in parallel  
- [x] CLI on large reactor (e.g. Camel) → model building phase benefits from shared cache
- [x] Idle TUI → CPU usage drops to near zero (no constant redraws)
- [x] Audit panel → "checking vulnerabilities" shown greyed after tabs, layout stable
- [x] Loading placeholder → border is cyan when content pane is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)