### PR TITLE
feat: audit view merge, global sub-views, shared caching

### DIFF
--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -326,29 +326,10 @@ public class AuditTui extends ToolPanel {
         Map<String, VulnGroup> groupMap = new LinkedHashMap<>();
         Map<String, String> aliasToId = new HashMap<>();
         for (var vr : vulnRows) {
-            String id = vr.vuln().id;
-            String groupId = aliasToId.getOrDefault(id, id);
-            if (vr.vuln().aliases != null) {
-                for (String alias : vr.vuln().aliases) {
-                    String mapped = aliasToId.get(alias);
-                    if (mapped != null) {
-                        groupId = mapped;
-                        break;
-                    }
-                }
-            }
+            String groupId = resolveGroupId(vr.vuln(), aliasToId);
             VulnGroup group = groupMap.get(groupId);
             if (group == null) {
-                String severity = normalizeSeverity(vr.vuln().severity);
-                group = new VulnGroup(id, vr.vuln().summary, severity, vr.vuln().published);
-                group.expanded = expandedIds.contains(id);
-                groupMap.put(groupId, group);
-                aliasToId.put(id, groupId);
-                if (vr.vuln().aliases != null) {
-                    for (String alias : vr.vuln().aliases) {
-                        aliasToId.put(alias, groupId);
-                    }
-                }
+                group = createVulnGroup(vr, groupId, expandedIds, aliasToId, groupMap);
             }
             boolean alreadyPresent = group.rows.stream()
                     .anyMatch(r -> r.entry().gav().equals(vr.entry().gav()));
@@ -357,6 +338,39 @@ public class AuditTui extends ToolPanel {
             }
         }
         return new ArrayList<>(groupMap.values());
+    }
+
+    private static String resolveGroupId(OsvClient.Vulnerability vuln, Map<String, String> aliasToId) {
+        String groupId = aliasToId.getOrDefault(vuln.id, vuln.id);
+        if (vuln.aliases != null) {
+            for (String alias : vuln.aliases) {
+                String mapped = aliasToId.get(alias);
+                if (mapped != null) {
+                    return mapped;
+                }
+            }
+        }
+        return groupId;
+    }
+
+    private VulnGroup createVulnGroup(
+            VulnRow vr,
+            String groupId,
+            Set<String> expandedIds,
+            Map<String, String> aliasToId,
+            Map<String, VulnGroup> groupMap) {
+        String id = vr.vuln().id;
+        String severity = normalizeSeverity(vr.vuln().severity);
+        VulnGroup group = new VulnGroup(id, vr.vuln().summary, severity, vr.vuln().published);
+        group.expanded = expandedIds.contains(id);
+        groupMap.put(groupId, group);
+        aliasToId.put(id, groupId);
+        if (vr.vuln().aliases != null) {
+            for (String alias : vr.vuln().aliases) {
+                aliasToId.put(alias, groupId);
+            }
+        }
+        return group;
     }
 
     private void rebuildVulnDisplayRows() {
@@ -1382,31 +1396,33 @@ public class AuditTui extends ToolPanel {
     }
 
     private Row buildVulnTableRow(VulnDisplayRow dr, int i) {
-        if (dr.isGroupHeader()) {
-            var group = dr.group();
-            boolean allManaged = editSession != null
-                    && group.rows.stream()
-                            .allMatch(r -> editSession.isChanged(r.entry().ga()));
-            String arrow = group.expanded ? "▾ " : "▸ ";
-            String severity = normalizeSeverity(group.severity);
-            String published = formatPublished(group.published);
-            int affected = group.rows.size();
-            String countLabel = affected > 1 ? " (" + affected + " artifacts)" : "";
-            Style style = allManaged
-                    ? Style.create().dim()
-                    : getSeverityStyle(severity).bold();
-            if (view == View.VULNERABILITIES && isSearchMatch(i)) {
-                style = style.bg(theme.searchHighlightBg());
-            }
-            String statusIcon = allManaged ? "✓ " : "";
-            return Row.from(
-                    Cell.from(statusIcon + arrow + group.id + countLabel).style(style),
-                    Cell.from(severity).style(style),
-                    Cell.from("").style(style),
-                    Cell.from(published).style(style),
-                    Cell.from(truncateSummary(group.summary, 50)).style(style));
+        return dr.isGroupHeader() ? buildVulnGroupHeaderRow(dr.group(), i) : buildVulnArtifactRow(dr.row(), i);
+    }
+
+    private Row buildVulnGroupHeaderRow(VulnGroup group, int i) {
+        boolean allManaged = editSession != null
+                && group.rows.stream()
+                        .allMatch(r -> editSession.isChanged(r.entry().ga()));
+        String arrow = group.expanded ? "▾ " : "▸ ";
+        String severity = normalizeSeverity(group.severity);
+        String published = formatPublished(group.published);
+        int affected = group.rows.size();
+        String countLabel = affected > 1 ? " (" + affected + " artifacts)" : "";
+        Style style =
+                allManaged ? Style.create().dim() : getSeverityStyle(severity).bold();
+        if (view == View.VULNERABILITIES && isSearchMatch(i)) {
+            style = style.bg(theme.searchHighlightBg());
         }
-        var vr = dr.row();
+        String statusIcon = allManaged ? "✓ " : "";
+        return Row.from(
+                Cell.from(statusIcon + arrow + group.id + countLabel).style(style),
+                Cell.from(severity).style(style),
+                Cell.from("").style(style),
+                Cell.from(published).style(style),
+                Cell.from(truncateSummary(group.summary, 50)).style(style));
+    }
+
+    private Row buildVulnArtifactRow(VulnRow vr, int i) {
         boolean managed =
                 editSession != null && editSession.isChanged(vr.entry().ga());
         String severity = normalizeSeverity(vr.vuln().severity);

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -98,8 +98,7 @@ public class AuditTui extends ToolPanel {
 
     private enum View {
         VULNERABILITIES,
-        LICENSES,
-        BY_LICENSE
+        LICENSES
     }
 
     /** Row in the by-license view: either a license group header or a dependency. */
@@ -146,6 +145,7 @@ public class AuditTui extends ToolPanel {
     private final TableState byLicenseTableState = new TableState();
 
     private View view = View.LICENSES;
+    private boolean licensesGrouped = false;
     private int licensesLoaded = 0;
     private int vulnsLoaded = 0;
     private int vulnCount = 0;
@@ -156,10 +156,36 @@ public class AuditTui extends ToolPanel {
     private String scopeFilter; // null = show all
     private List<AuditEntry> filteredEntries;
     List<VulnRow> vulnRows = new ArrayList<>();
+    private List<VulnGroup> vulnGroups = new ArrayList<>();
+    private List<VulnDisplayRow> vulnDisplayRows = new ArrayList<>();
     private List<LicenseRow> byLicenseRows = new ArrayList<>();
 
     /** Flattened vulnerability row linking back to its parent entry. */
     record VulnRow(AuditEntry entry, OsvClient.Vulnerability vuln) {}
+
+    /** Group of vulnerability rows sharing the same CVE ID. */
+    static class VulnGroup {
+        final String id;
+        final String summary;
+        final String severity;
+        final String published;
+        final List<VulnRow> rows = new ArrayList<>();
+        boolean expanded = false;
+
+        VulnGroup(String id, String summary, String severity, String published) {
+            this.id = id;
+            this.summary = summary;
+            this.severity = severity;
+            this.published = published;
+        }
+    }
+
+    /** Display row in the vulnerability table: either a group header or an artifact entry. */
+    record VulnDisplayRow(VulnGroup group, VulnRow row) {
+        boolean isGroupHeader() {
+            return row == null;
+        }
+    }
 
     /** Standalone constructor — creates its own PomEditSession from the POM file path. */
     public AuditTui(List<AuditEntry> entries, String projectGav, DependencyTreeModel treeModel, String pomPath) {
@@ -196,42 +222,58 @@ public class AuditTui extends ToolPanel {
 
     private void fetchAllData() {
         for (var entry : entries) {
-            // Fetch license info
-            CompletableFuture.supplyAsync(
-                            () -> SearchTui.fetchPomFromCentral(entry.groupId, entry.artifactId, entry.version),
-                            httpPool)
-                    .thenAccept(info -> runner.runOnRenderThread(() -> {
-                        if (info != null && info.license != null) {
-                            entry.license = info.license;
-                            entry.licenseUrl = info.licenseUrl;
-                        }
-                        entry.licenseLoaded = true;
-                        licensesLoaded++;
-                        rebuildByLicenseRows();
-                        updateStatus();
-                    }));
+            if (entry.licenseLoaded) {
+                licensesLoaded++;
+            } else {
+                CompletableFuture.supplyAsync(
+                                () -> SearchTui.fetchPomFromCentral(entry.groupId, entry.artifactId, entry.version),
+                                httpPool)
+                        .thenAccept(info -> runner.runOnRenderThread(() -> {
+                            if (info != null && info.license != null) {
+                                entry.license = info.license;
+                                entry.licenseUrl = info.licenseUrl;
+                            }
+                            entry.licenseLoaded = true;
+                            licensesLoaded++;
+                            rebuildByLicenseRows();
+                            updateStatus();
+                        }));
+            }
 
-            // Fetch vulnerability info
-            CompletableFuture.supplyAsync(
-                            () -> {
-                                try {
-                                    return osvClient.query(entry.groupId, entry.artifactId, entry.version);
-                                } catch (Exception e) {
-                                    return List.<OsvClient.Vulnerability>of();
-                                }
-                            },
-                            httpPool)
-                    .thenAccept(vulns -> runner.runOnRenderThread(() -> {
-                        entry.vulnerabilities = vulns;
-                        entry.vulnsLoaded = true;
-                        vulnsLoaded++;
-                        if (!vulns.isEmpty()) {
-                            vulnCount += vulns.size();
-                            rebuildVulnRows();
-                        }
-                        updateStatus();
-                    }));
+            if (entry.vulnsLoaded) {
+                vulnsLoaded++;
+                if (entry.hasVulnerabilities()) {
+                    vulnCount += entry.vulnerabilities.size();
+                }
+            } else {
+                CompletableFuture.supplyAsync(
+                                () -> {
+                                    try {
+                                        return osvClient.query(entry.groupId, entry.artifactId, entry.version);
+                                    } catch (Exception e) {
+                                        return List.<OsvClient.Vulnerability>of();
+                                    }
+                                },
+                                httpPool)
+                        .thenAccept(vulns -> runner.runOnRenderThread(() -> {
+                            entry.vulnerabilities = vulns;
+                            entry.vulnsLoaded = true;
+                            vulnsLoaded++;
+                            if (!vulns.isEmpty()) {
+                                vulnCount += vulns.size();
+                                rebuildVulnRows();
+                            }
+                            updateStatus();
+                        }));
+            }
         }
+        if (licensesLoaded > 0) {
+            rebuildByLicenseRows();
+        }
+        if (vulnCount > 0) {
+            rebuildVulnRows();
+        }
+        updateStatus();
     }
 
     void rebuildVulnRows() {
@@ -244,10 +286,79 @@ public class AuditTui extends ToolPanel {
                 }
             }
         }
-        if (vulnRows.isEmpty()) {
+
+        // Preserve expansion state — save all known IDs and aliases for expanded groups
+        // so that re-ordering due to async loading doesn't lose the state
+        var expandedIds = new HashSet<String>();
+        for (var group : vulnGroups) {
+            if (group.expanded) {
+                expandedIds.add(group.id);
+                for (var vr : group.rows) {
+                    expandedIds.add(vr.vuln().id);
+                    if (vr.vuln().aliases != null) {
+                        expandedIds.addAll(vr.vuln().aliases);
+                    }
+                }
+            }
+        }
+
+        // Group by CVE ID, using aliases to unify GHSA/CVE references
+        Map<String, VulnGroup> groupMap = new LinkedHashMap<>();
+        Map<String, String> aliasToId = new HashMap<>();
+        for (var vr : vulnRows) {
+            String id = vr.vuln().id;
+            // Check if this vuln's ID or any alias matches an existing group
+            String groupId = aliasToId.getOrDefault(id, id);
+            if (vr.vuln().aliases != null) {
+                for (String alias : vr.vuln().aliases) {
+                    String mapped = aliasToId.get(alias);
+                    if (mapped != null) {
+                        groupId = mapped;
+                        break;
+                    }
+                }
+            }
+            VulnGroup group = groupMap.get(groupId);
+            if (group == null) {
+                String severity = normalizeSeverity(vr.vuln().severity);
+                group = new VulnGroup(id, vr.vuln().summary, severity, vr.vuln().published);
+                group.expanded = expandedIds.contains(id);
+                groupMap.put(groupId, group);
+                aliasToId.put(id, groupId);
+                if (vr.vuln().aliases != null) {
+                    for (String alias : vr.vuln().aliases) {
+                        aliasToId.put(alias, groupId);
+                    }
+                }
+            }
+            // Avoid duplicate artifacts in the same group
+            boolean alreadyPresent = group.rows.stream()
+                    .anyMatch(r -> r.entry().gav().equals(vr.entry().gav()));
+            if (!alreadyPresent) {
+                group.rows.add(vr);
+            }
+        }
+        vulnGroups = new ArrayList<>(groupMap.values());
+
+        // Build display rows
+        rebuildVulnDisplayRows();
+
+        if (vulnDisplayRows.isEmpty()) {
             vulnTableState.clearSelection();
-        } else if (vulnTableState.selected() == null || vulnTableState.selected() >= vulnRows.size()) {
+        } else if (vulnTableState.selected() == null || vulnTableState.selected() >= vulnDisplayRows.size()) {
             vulnTableState.select(0);
+        }
+    }
+
+    private void rebuildVulnDisplayRows() {
+        vulnDisplayRows = new ArrayList<>();
+        for (var group : vulnGroups) {
+            vulnDisplayRows.add(new VulnDisplayRow(group, null));
+            if (group.expanded) {
+                for (var vr : group.rows) {
+                    vulnDisplayRows.add(new VulnDisplayRow(group, vr));
+                }
+            }
         }
     }
 
@@ -320,7 +431,7 @@ public class AuditTui extends ToolPanel {
         }
 
         // Re-apply active sort so expand/collapse preserves order
-        if (view == View.BY_LICENSE && sortState.isSorted()) {
+        if (view == View.LICENSES && licensesGrouped && sortState.isSorted()) {
             sortByLicenseTree();
         }
 
@@ -365,8 +476,57 @@ public class AuditTui extends ToolPanel {
             return true;
         }
 
-        // ←/→ for expand/collapse in BY_LICENSE view
-        if (key.isRight() && view == View.BY_LICENSE) {
+        // ←/→ for expand/collapse in VULNERABILITIES view
+        if (key.isRight() && view == View.VULNERABILITIES) {
+            int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
+            if (idx >= 0
+                    && idx < vulnDisplayRows.size()
+                    && vulnDisplayRows.get(idx).isGroupHeader()) {
+                var group = vulnDisplayRows.get(idx).group();
+                if (!group.expanded) {
+                    group.expanded = true;
+                    rebuildVulnDisplayRows();
+                } else {
+                    vulnTableState.selectNext(vulnDisplayRows.size());
+                }
+                return true;
+            }
+        }
+        if (key.isLeft() && view == View.VULNERABILITIES) {
+            int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
+            if (idx >= 0 && idx < vulnDisplayRows.size()) {
+                var dr = vulnDisplayRows.get(idx);
+                if (dr.isGroupHeader() && dr.group().expanded) {
+                    dr.group().expanded = false;
+                    rebuildVulnDisplayRows();
+                    return true;
+                } else if (!dr.isGroupHeader()) {
+                    for (int i = idx - 1; i >= 0; i--) {
+                        if (vulnDisplayRows.get(i).isGroupHeader()) {
+                            vulnTableState.select(i);
+                            break;
+                        }
+                    }
+                    return true;
+                }
+            }
+        }
+
+        // VULNERABILITIES: Enter/Space to expand/collapse groups
+        if (view == View.VULNERABILITIES && (key.isKey(KeyCode.ENTER) || key.isChar(' '))) {
+            int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
+            if (idx >= 0
+                    && idx < vulnDisplayRows.size()
+                    && vulnDisplayRows.get(idx).isGroupHeader()) {
+                var group = vulnDisplayRows.get(idx).group();
+                group.expanded = !group.expanded;
+                rebuildVulnDisplayRows();
+            }
+            return true;
+        }
+
+        // ←/→ for expand/collapse in grouped licenses view
+        if (key.isRight() && view == View.LICENSES && licensesGrouped) {
             int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
             if (idx >= 0 && idx < byLicenseRows.size() && byLicenseRows.get(idx).isGroup()) {
                 if (!byLicenseRows.get(idx).expanded) {
@@ -378,7 +538,7 @@ public class AuditTui extends ToolPanel {
                 return true;
             }
         }
-        if (key.isLeft() && view == View.BY_LICENSE) {
+        if (key.isLeft() && view == View.LICENSES && licensesGrouped) {
             int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
             if (idx >= 0 && idx < byLicenseRows.size()) {
                 LicenseRow row = byLicenseRows.get(idx);
@@ -398,8 +558,8 @@ public class AuditTui extends ToolPanel {
             }
         }
 
-        // BY_LICENSE: Enter/Space to expand/collapse groups
-        if (view == View.BY_LICENSE && (key.isKey(KeyCode.ENTER) || key.isChar(' '))) {
+        // Grouped licenses: Enter/Space to expand/collapse groups
+        if (view == View.LICENSES && licensesGrouped && (key.isKey(KeyCode.ENTER) || key.isChar(' '))) {
             int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
             if (idx >= 0 && idx < byLicenseRows.size() && byLicenseRows.get(idx).isGroup()) {
                 byLicenseRows.get(idx).expanded = !byLicenseRows.get(idx).expanded;
@@ -415,6 +575,18 @@ public class AuditTui extends ToolPanel {
 
         if (key.isCharIgnoreCase('d')) {
             toggleDiffView();
+            return true;
+        }
+
+        if (key.isCharIgnoreCase('g') && view == View.LICENSES) {
+            licensesGrouped = !licensesGrouped;
+            clearSearch();
+            sortState = new SortState(4);
+            if (licensesGrouped) {
+                rebuildByLicenseRows();
+            } else {
+                rebuildFilteredEntries();
+            }
             return true;
         }
 
@@ -505,28 +677,54 @@ public class AuditTui extends ToolPanel {
     private AuditEntry selectedEntry() {
         return switch (view) {
             case LICENSES -> {
-                int idx = tableState.selected() != null ? tableState.selected() : -1;
-                yield (idx >= 0 && idx < filteredEntries.size()) ? filteredEntries.get(idx) : null;
+                if (licensesGrouped) {
+                    int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
+                    yield (idx >= 0
+                                    && idx < byLicenseRows.size()
+                                    && !byLicenseRows.get(idx).isGroup())
+                            ? byLicenseRows.get(idx).entry
+                            : null;
+                } else {
+                    int idx = tableState.selected() != null ? tableState.selected() : -1;
+                    yield (idx >= 0 && idx < filteredEntries.size()) ? filteredEntries.get(idx) : null;
+                }
             }
             case VULNERABILITIES -> {
                 int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
-                yield (idx >= 0 && idx < vulnRows.size()) ? vulnRows.get(idx).entry : null;
-            }
-            case BY_LICENSE -> {
-                int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
-                yield (idx >= 0
-                                && idx < byLicenseRows.size()
-                                && !byLicenseRows.get(idx).isGroup())
-                        ? byLicenseRows.get(idx).entry
-                        : null;
+                if (idx >= 0 && idx < vulnDisplayRows.size()) {
+                    var dr = vulnDisplayRows.get(idx);
+                    yield dr.row() != null
+                            ? dr.row().entry()
+                            : (dr.group().rows.isEmpty()
+                                    ? null
+                                    : dr.group().rows.get(0).entry());
+                }
+                yield null;
             }
         };
     }
 
     private void addManagedDependency() {
+        if (view == View.VULNERABILITIES) {
+            int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
+            if (idx >= 0
+                    && idx < vulnDisplayRows.size()
+                    && vulnDisplayRows.get(idx).isGroupHeader()) {
+                manageGroup(vulnDisplayRows.get(idx).group());
+                return;
+            }
+        }
         AuditEntry entry = selectedEntry();
         if (entry == null) {
             status = "No dependency selected";
+            return;
+        }
+        manageSingleEntry(entry);
+    }
+
+    private void manageSingleEntry(AuditEntry entry) {
+        if (editSession.isChanged(entry.ga())) {
+            status = entry.ga() + " already managed";
             return;
         }
         try {
@@ -542,6 +740,21 @@ public class AuditTui extends ToolPanel {
             status = "Added " + entry.ga() + ":" + entry.version + " to dependencyManagement";
         } catch (Exception e) {
             status = "Failed: " + e.getMessage();
+        }
+    }
+
+    private void manageGroup(VulnGroup group) {
+        int count = 0;
+        for (var vr : group.rows) {
+            if (!editSession.isChanged(vr.entry().ga())) {
+                manageSingleEntry(vr.entry());
+                count++;
+            }
+        }
+        if (count == 0) {
+            status = "All artifacts in " + group.id + " already managed";
+        } else {
+            status = "Added " + count + " artifact(s) from " + group.id + " to dependencyManagement";
         }
     }
 
@@ -591,8 +804,10 @@ public class AuditTui extends ToolPanel {
         } else {
             Rect contentArea = renderTabBar(frame, area);
             switch (view) {
-                case LICENSES -> renderLicenses(frame, contentArea);
-                case BY_LICENSE -> renderByLicense(frame, contentArea);
+                case LICENSES -> {
+                    if (licensesGrouped) renderByLicense(frame, contentArea);
+                    else renderLicenses(frame, contentArea);
+                }
                 case VULNERABILITIES -> renderVulnerabilities(frame, contentArea);
             }
         }
@@ -612,8 +827,10 @@ public class AuditTui extends ToolPanel {
                 diffOverlay.render(frame, contentArea, " POM Changes ");
             } else {
                 switch (view) {
-                    case LICENSES -> renderLicenses(frame, contentArea);
-                    case BY_LICENSE -> renderByLicense(frame, contentArea);
+                    case LICENSES -> {
+                        if (licensesGrouped) renderByLicense(frame, contentArea);
+                        else renderLicenses(frame, contentArea);
+                    }
                     case VULNERABILITIES -> renderVulnerabilities(frame, contentArea);
                 }
             }
@@ -632,11 +849,14 @@ public class AuditTui extends ToolPanel {
                 view,
                 View.values(),
                 v -> switch (v) {
-                    case LICENSES -> "Licenses";
-                    case BY_LICENSE -> "By License";
+                    case LICENSES -> licensesGrouped ? "Licenses (grouped)" : "Licenses";
                     case VULNERABILITIES -> "Vulnerabilities" + (vulnCount > 0 ? " (" + vulnCount + ")" : "");
                 },
                 v -> v == View.VULNERABILITIES && vulnCount > 0 ? Color.RED : Color.YELLOW));
+        if (vulnsLoaded < entries.size()) {
+            spans.add(Span.raw("  Checking vulnerabilities\u2026 " + vulnsLoaded + "/" + entries.size())
+                    .fg(Color.DARK_GRAY));
+        }
         renderStandaloneHeader(frame, area, "License & Security Audit", Line.from(spans));
     }
 
@@ -658,14 +878,17 @@ public class AuditTui extends ToolPanel {
         List<Row> rows = new ArrayList<>();
         for (int i = 0; i < filteredEntries.size(); i++) {
             var entry = filteredEntries.get(i);
+            boolean managed = editSession != null && editSession.isChanged(entry.ga());
             String license = entry.license != null
                     ? normalizeLicense(entry.license, entry.licenseUrl)
                     : (entry.licenseLoaded ? "-" : "…");
-            Style style = getLicenseStyle(entry.license);
+            Style style = managed ? Style.create().dim() : getLicenseStyle(entry.license);
             if (view == View.LICENSES && isSearchMatch(i)) {
                 style = style.bg(theme.searchHighlightBg());
             }
-            rows.add(Row.from(entry.ga(), entry.version, license, entry.scope).style(style));
+            String marker = managed ? "✓ " : "";
+            rows.add(Row.from(marker + entry.ga(), entry.version, license, entry.scope)
+                    .style(style));
         }
 
         Table table = Table.builder()
@@ -778,16 +1001,14 @@ public class AuditTui extends ToolPanel {
     private TableState activeTableState() {
         return switch (view) {
             case VULNERABILITIES -> vulnTableState;
-            case BY_LICENSE -> byLicenseTableState;
-            default -> tableState;
+            case LICENSES -> licensesGrouped ? byLicenseTableState : tableState;
         };
     }
 
     private int activeRowCount() {
         return switch (view) {
-            case VULNERABILITIES -> vulnRows.size();
-            case BY_LICENSE -> byLicenseRows.size();
-            default -> filteredEntries.size();
+            case VULNERABILITIES -> vulnDisplayRows.size();
+            case LICENSES -> licensesGrouped ? byLicenseRows.size() : filteredEntries.size();
         };
     }
 
@@ -802,26 +1023,36 @@ public class AuditTui extends ToolPanel {
         searchMatches = new ArrayList<>();
         switch (view) {
             case LICENSES -> {
-                for (int i = 0; i < entries.size(); i++) {
-                    if (auditEntryMatchesSearch(entries.get(i), query)) {
-                        searchMatches.add(i);
+                if (licensesGrouped) {
+                    for (int i = 0; i < byLicenseRows.size(); i++) {
+                        if (licenseRowMatchesSearch(byLicenseRows.get(i), query)) {
+                            searchMatches.add(i);
+                        }
                     }
-                }
-            }
-            case BY_LICENSE -> {
-                for (int i = 0; i < byLicenseRows.size(); i++) {
-                    if (licenseRowMatchesSearch(byLicenseRows.get(i), query)) {
-                        searchMatches.add(i);
+                } else {
+                    for (int i = 0; i < entries.size(); i++) {
+                        if (auditEntryMatchesSearch(entries.get(i), query)) {
+                            searchMatches.add(i);
+                        }
                     }
                 }
             }
             case VULNERABILITIES -> {
-                for (int i = 0; i < vulnRows.size(); i++) {
-                    var vr = vulnRows.get(i);
-                    if (auditEntryMatchesSearch(vr.entry(), query)
-                            || vr.vuln().id.toLowerCase().contains(query)
-                            || vr.vuln().summary.toLowerCase().contains(query)) {
-                        searchMatches.add(i);
+                for (int i = 0; i < vulnDisplayRows.size(); i++) {
+                    var dr = vulnDisplayRows.get(i);
+                    if (dr.isGroupHeader()) {
+                        var g = dr.group();
+                        if (g.id.toLowerCase().contains(query)
+                                || g.summary.toLowerCase().contains(query)) {
+                            searchMatches.add(i);
+                        }
+                    } else {
+                        var vr = dr.row();
+                        if (auditEntryMatchesSearch(vr.entry(), query)
+                                || vr.vuln().id.toLowerCase().contains(query)
+                                || vr.vuln().summary.toLowerCase().contains(query)) {
+                            searchMatches.add(i);
+                        }
                     }
                 }
             }
@@ -854,8 +1085,20 @@ public class AuditTui extends ToolPanel {
     }
 
     @Override
+    protected Line buildSubViewTabLine() {
+        Line base = super.buildSubViewTabLine();
+        if (vulnsLoaded < entries.size()) {
+            List<Span> spans = new ArrayList<>(base.spans());
+            spans.add(Span.raw("  Checking vulnerabilities\u2026 " + vulnsLoaded + "/" + entries.size())
+                    .fg(Color.DARK_GRAY));
+            return Line.from(spans);
+        }
+        return base;
+    }
+
+    @Override
     int subViewCount() {
-        return 3;
+        return 2;
     }
 
     @Override
@@ -868,13 +1111,13 @@ public class AuditTui extends ToolPanel {
         view = View.values()[index];
         clearSearch();
         sortState = view == View.VULNERABILITIES
-                ? new SortState(6, 4, false) // default sort: published date descending
+                ? new SortState(5, 3, false) // default sort: published date descending
                 : new SortState(4);
     }
 
     @Override
     List<String> subViewNames() {
-        return List.of("Vulns", "Licenses", "By License");
+        return List.of("Vulns", "Licenses");
     }
 
     private List<Function<AuditEntry, String>> licensesExtractors() {
@@ -885,14 +1128,13 @@ public class AuditTui extends ToolPanel {
                 e -> e.scope);
     }
 
-    private List<Function<VulnRow, String>> vulnExtractors() {
+    private List<Function<VulnGroup, String>> vulnGroupExtractors() {
         return List.of(
-                vr -> vr.entry().ga() + ":" + vr.entry().version,
-                vr -> vr.vuln().id,
-                vr -> severitySortKey(vr.vuln().severity),
-                vr -> vr.entry().scope,
-                vr -> vr.vuln().published != null ? vr.vuln().published : "",
-                vr -> vr.vuln().summary);
+                g -> g.id,
+                g -> severitySortKey(g.severity),
+                g -> "",
+                g -> g.published != null ? g.published : "",
+                g -> g.summary);
     }
 
     private List<Function<LicenseRow, String>> byLicenseGroupExtractors() {
@@ -906,9 +1148,14 @@ public class AuditTui extends ToolPanel {
     @Override
     protected void onSortChanged() {
         switch (view) {
-            case LICENSES -> sortState.sort(entries, licensesExtractors());
-            case BY_LICENSE -> sortByLicenseTree();
-            case VULNERABILITIES -> sortState.sort(vulnRows, vulnExtractors());
+            case LICENSES -> {
+                if (licensesGrouped) sortByLicenseTree();
+                else sortState.sort(entries, licensesExtractors());
+            }
+            case VULNERABILITIES -> {
+                sortState.sort(vulnGroups, vulnGroupExtractors());
+                rebuildVulnDisplayRows();
+            }
         }
     }
 
@@ -962,7 +1209,7 @@ public class AuditTui extends ToolPanel {
         List<Row> rows = new ArrayList<>();
         for (int i = 0; i < byLicenseRows.size(); i++) {
             var row = byLicenseRows.get(i);
-            boolean highlight = view == View.BY_LICENSE && isSearchMatch(i);
+            boolean highlight = isSearchMatch(i);
             if (row.isGroup()) {
                 String arrow = row.expanded ? "▾ " : HIGHLIGHT_SYMBOL;
                 String label = arrow + row.licenseName + " (" + row.deps.size() + ")";
@@ -971,9 +1218,11 @@ public class AuditTui extends ToolPanel {
                 if (highlight) style = style.bg(theme.searchHighlightBg());
                 rows.add(Row.from(label, "", "", "").style(style));
             } else {
-                Style style = theme.unfocusedBorder();
+                boolean managed = editSession != null && editSession.isChanged(row.entry.ga());
+                Style style = managed ? Style.create().dim() : theme.unfocusedBorder();
                 if (highlight) style = style.bg(theme.searchHighlightBg());
-                rows.add(Row.from("    " + row.entry.ga(), row.entry.version, row.entry.scope, "")
+                String prefix = managed ? "  ✓ " : "    ";
+                rows.add(Row.from(prefix + row.entry.ga(), row.entry.version, row.entry.scope, "")
                         .style(style));
             }
         }
@@ -1064,20 +1313,14 @@ public class AuditTui extends ToolPanel {
     }
 
     private void renderVulnerabilities(Frame frame, Rect area) {
-        if (vulnRows.isEmpty()) {
+        if (vulnDisplayRows.isEmpty() && vulnsLoaded >= entries.size()) {
             Block block = Block.builder()
                     .borderType(BorderType.ROUNDED)
                     .borderStyle(borderStyle())
                     .build();
-            String msg;
-            if (vulnsLoaded < entries.size()) {
-                // Loading progress is shown on the tab bar line
-                msg = "";
-            } else if (scopeFilter != null) {
-                msg = "No known vulnerabilities in " + scopeFilter + " scope";
-            } else {
-                msg = "No known vulnerabilities found \u2713";
-            }
+            String msg = scopeFilter != null
+                    ? "No known vulnerabilities in " + scopeFilter + " scope"
+                    : "No known vulnerabilities found \u2713";
             Paragraph empty =
                     Paragraph.builder().text(msg).block(block).centered().build();
             frame.renderWidget(empty, area);
@@ -1092,46 +1335,70 @@ public class AuditTui extends ToolPanel {
         lastTableHeight = zones.get(0).height();
 
         // -- Vulnerability table --
-        String vFilterLabel = scopeFilter != null ? " [" + scopeFilter + "]" : "";
-        Block.Builder blockBuilder =
-                Block.builder().borderType(BorderType.ROUNDED).borderStyle(borderStyle());
-        if (vulnsLoaded < entries.size()) {
-            blockBuilder.title(" Checking vulnerabilities\u2026 " + vulnsLoaded + "/" + entries.size() + " ");
-        }
-        Block block = blockBuilder.build();
+        Block block = Block.builder()
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(borderStyle())
+                .build();
 
         List<Row> rows = new ArrayList<>();
-        for (int i = 0; i < vulnRows.size(); i++) {
-            var vr = vulnRows.get(i);
-            String severity = normalizeSeverity(vr.vuln().severity);
-            String published = formatPublished(vr.vuln().published);
-            String summary = truncateSummary(vr.vuln().summary, 50);
-            Style style = getSeverityStyle(severity);
-            if (view == View.VULNERABILITIES && isSearchMatch(i)) {
-                style = style.bg(theme.searchHighlightBg());
+        for (int i = 0; i < vulnDisplayRows.size(); i++) {
+            var dr = vulnDisplayRows.get(i);
+            if (dr.isGroupHeader()) {
+                var group = dr.group();
+                boolean allManaged = editSession != null
+                        && group.rows.stream()
+                                .allMatch(r -> editSession.isChanged(r.entry().ga()));
+                String arrow = group.expanded ? "▾ " : "▸ ";
+                String severity = normalizeSeverity(group.severity);
+                String published = formatPublished(group.published);
+                int affected = group.rows.size();
+                String countLabel = affected > 1 ? " (" + affected + " artifacts)" : "";
+                Style style = allManaged
+                        ? Style.create().dim()
+                        : getSeverityStyle(severity).bold();
+                if (view == View.VULNERABILITIES && isSearchMatch(i)) {
+                    style = style.bg(theme.searchHighlightBg());
+                }
+                String statusIcon = allManaged ? "✓ " : "";
+                rows.add(Row.from(
+                        Cell.from(statusIcon + arrow + group.id + countLabel).style(style),
+                        Cell.from(severity).style(style),
+                        Cell.from("").style(style),
+                        Cell.from(published).style(style),
+                        Cell.from(truncateSummary(group.summary, 50)).style(style)));
+            } else {
+                var vr = dr.row();
+                boolean managed =
+                        editSession != null && editSession.isChanged(vr.entry().ga());
+                String severity = normalizeSeverity(vr.vuln().severity);
+                Style style = managed ? Style.create().dim() : getSeverityStyle(severity);
+                if (view == View.VULNERABILITIES && isSearchMatch(i)) {
+                    style = style.bg(theme.searchHighlightBg());
+                }
+                String marker = managed ? "  ✓ " : "    ";
+                rows.add(Row.from(
+                        Cell.from(marker + vr.entry().ga() + ":" + vr.entry().version)
+                                .style(style),
+                        Cell.from("").style(style),
+                        Cell.from(vr.entry().scope)
+                                .style(managed ? Style.create().dim() : getScopeStyle(vr.entry().scope)),
+                        Cell.from("").style(style),
+                        Cell.from("").style(style)));
             }
-            rows.add(Row.from(
-                    Cell.from(vr.entry().ga() + ":" + vr.entry().version).style(style),
-                    Cell.from(vr.vuln().id).style(style),
-                    Cell.from(severity).style(style),
-                    Cell.from(vr.entry().scope).style(getScopeStyle(vr.entry().scope)),
-                    Cell.from(published).style(style),
-                    Cell.from(summary).style(style)));
         }
 
         Row header = sortState.decorateHeader(
-                List.of("artifact", "CVE/ID", "severity", COL_SCOPE, "published", "summary"), theme.tableHeader());
+                List.of("artifact / CVE", "severity", COL_SCOPE, "published", "summary"), theme.tableHeader());
 
         Table table = Table.builder()
                 .header(header)
                 .rows(rows)
                 .widths(
-                        Constraint.percentage(24),
-                        Constraint.percentage(14),
+                        Constraint.percentage(35),
+                        Constraint.percentage(10),
                         Constraint.percentage(9),
-                        Constraint.percentage(8),
                         Constraint.percentage(11),
-                        Constraint.percentage(34))
+                        Constraint.percentage(35))
                 .highlightStyle(theme.highlightStyle())
                 .highlightSymbol(HIGHLIGHT_SYMBOL)
                 .block(block)
@@ -1153,47 +1420,76 @@ public class AuditTui extends ToolPanel {
                 .build();
 
         int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
-        if (idx < 0 || idx >= vulnRows.size()) {
+        if (idx < 0 || idx >= vulnDisplayRows.size()) {
             frame.renderWidget(Paragraph.builder().text("").block(block).build(), area);
             return;
         }
 
-        VulnRow vr = vulnRows.get(idx);
-        var vuln = vr.vuln;
+        var dr = vulnDisplayRows.get(idx);
         List<Line> lines = new ArrayList<>();
-        String url = vulnUrl(vuln.id);
-        String severity = normalizeSeverity(vuln.severity);
-        String centralUrl = centralUrl(vr.entry.groupId, vr.entry.artifactId);
-        lines.add(Line.from(
-                Span.raw(vuln.id).bold().cyan().hyperlink(url),
-                Span.raw("  "),
-                Span.raw(severity).style(getSeverityStyle(severity).bold()),
-                Span.raw(LABEL_SCOPE).fg(Color.DARK_GRAY),
-                Span.raw(vr.entry.scope).style(getScopeStyle(vr.entry.scope)),
-                Span.raw("  "),
-                Span.raw(vr.entry.ga() + ":" + vr.entry.version)
-                        .fg(theme.detailSeparatorColor())
-                        .hyperlink(centralUrl)));
-        lines.add(Line.from(
-                Span.raw("↗ ").fg(theme.detailSeparatorColor()),
-                Span.raw(url).fg(theme.linkColor()).hyperlink(url)));
-        if (!vuln.aliases.isEmpty()) {
-            List<Span> aliasSpans = new ArrayList<>();
-            aliasSpans.add(Span.raw("Aliases: ").fg(theme.detailSeparatorColor()));
-            for (int i = 0; i < vuln.aliases.size(); i++) {
-                if (i > 0) aliasSpans.add(Span.raw(", "));
-                String alias = vuln.aliases.get(i);
-                aliasSpans.add(Span.raw(alias).hyperlink(vulnUrl(alias)));
+
+        if (dr.isGroupHeader()) {
+            var group = dr.group();
+            String url = vulnUrl(group.id);
+            String severity = normalizeSeverity(group.severity);
+            lines.add(Line.from(
+                    Span.raw(group.id).bold().cyan().hyperlink(url),
+                    Span.raw("  "),
+                    Span.raw(severity).style(getSeverityStyle(severity).bold()),
+                    Span.raw("  " + group.rows.size() + " affected artifact(s)").fg(theme.detailSeparatorColor())));
+            lines.add(Line.from(
+                    Span.raw("↗ ").fg(theme.detailSeparatorColor()),
+                    Span.raw(url).fg(theme.linkColor()).hyperlink(url)));
+            if (group.published != null && !group.published.isEmpty()) {
+                String pub = group.published.length() > 10 ? group.published.substring(0, 10) : group.published;
+                lines.add(Line.from(Span.raw("Published: ").fg(theme.detailSeparatorColor()), Span.raw(pub)));
             }
-            lines.add(Line.from(aliasSpans));
+            lines.add(Line.from(Span.raw(group.summary != null ? group.summary : "")));
+            List<Span> artifacts = new ArrayList<>();
+            artifacts.add(Span.raw("Artifacts: ").fg(theme.detailSeparatorColor()));
+            for (int i = 0; i < group.rows.size(); i++) {
+                if (i > 0) artifacts.add(Span.raw(", ").fg(theme.detailSeparatorColor()));
+                var r = group.rows.get(i);
+                artifacts.add(Span.raw(r.entry().ga() + ":" + r.entry().version));
+            }
+            lines.add(Line.from(artifacts));
+        } else {
+            var vr = dr.row();
+            var vuln = vr.vuln();
+            String url = vulnUrl(vuln.id);
+            String severity = normalizeSeverity(vuln.severity);
+            String centralUrl = centralUrl(vr.entry().groupId, vr.entry().artifactId);
+            lines.add(Line.from(
+                    Span.raw(vuln.id).bold().cyan().hyperlink(url),
+                    Span.raw("  "),
+                    Span.raw(severity).style(getSeverityStyle(severity).bold()),
+                    Span.raw(LABEL_SCOPE).fg(Color.DARK_GRAY),
+                    Span.raw(vr.entry().scope).style(getScopeStyle(vr.entry().scope)),
+                    Span.raw("  "),
+                    Span.raw(vr.entry().ga() + ":" + vr.entry().version)
+                            .fg(theme.detailSeparatorColor())
+                            .hyperlink(centralUrl)));
+            lines.add(Line.from(
+                    Span.raw("↗ ").fg(theme.detailSeparatorColor()),
+                    Span.raw(url).fg(theme.linkColor()).hyperlink(url)));
+            if (!vuln.aliases.isEmpty()) {
+                List<Span> aliasSpans = new ArrayList<>();
+                aliasSpans.add(Span.raw("Aliases: ").fg(theme.detailSeparatorColor()));
+                for (int i = 0; i < vuln.aliases.size(); i++) {
+                    if (i > 0) aliasSpans.add(Span.raw(", "));
+                    String alias = vuln.aliases.get(i);
+                    aliasSpans.add(Span.raw(alias).hyperlink(vulnUrl(alias)));
+                }
+                lines.add(Line.from(aliasSpans));
+            }
+            if (vuln.published != null && !vuln.published.isEmpty()) {
+                String pub = vuln.published.length() > 10 ? vuln.published.substring(0, 10) : vuln.published;
+                lines.add(Line.from(Span.raw("Published: ").fg(theme.detailSeparatorColor()), Span.raw(pub)));
+            }
+            lines.add(Line.from(Span.raw(vuln.summary != null ? vuln.summary : "")));
+            Line modulesLine = buildModulesLine(vr.entry());
+            if (modulesLine != null) lines.add(modulesLine);
         }
-        if (vuln.published != null && !vuln.published.isEmpty()) {
-            String pub = vuln.published.length() > 10 ? vuln.published.substring(0, 10) : vuln.published;
-            lines.add(Line.from(Span.raw("Published: ").fg(theme.detailSeparatorColor()), Span.raw(pub)));
-        }
-        lines.add(Line.from(Span.raw(vuln.summary != null ? vuln.summary : "")));
-        Line modulesLine = buildModulesLine(vr.entry);
-        if (modulesLine != null) lines.add(modulesLine);
 
         Paragraph detail =
                 Paragraph.builder().text(Text.from(lines)).block(block).build();
@@ -1457,10 +1753,12 @@ public class AuditTui extends ToolPanel {
 
                 ## Audit Actions
                 """ + NAV_KEYS + """
-                ← / →           Collapse / expand (By License view)
-                Tab             Switch between Licenses / By License / Vulns
+                ← / →           Collapse / expand (Vulns / grouped Licenses)
+                Enter / Space   Toggle expand/collapse on group header
+                Tab             Switch between Licenses / Vulns
+                g               Toggle flat / grouped license display
                 s               Cycle scope filter: all → compile → runtime → test → provided
-                m               Add selected dep to dependencyManagement
+                m               Add selected dep (or all in group) to dependencyManagement
                 d               Preview POM changes as unified diff
                 """);
     }
@@ -1470,10 +1768,12 @@ public class AuditTui extends ToolPanel {
         sections.addAll(HelpOverlay.parse("""
                 ## Keys
                 ↑ / ↓           Move selection up / down
-                ← / →           Collapse / expand (By License view)
-                Tab             Switch between Licenses / By License / Vulns
+                ← / →           Collapse / expand (Vulns / grouped Licenses)
+                Enter / Space   Toggle expand/collapse on group header
+                Tab             Switch between Licenses / Vulns
+                g               Toggle flat / grouped license display
                 s               Cycle scope filter: all → compile → runtime → test → provided
-                m               Add selected dep to dependencyManagement
+                m               Add selected dep (or all in group) to dependencyManagement
                 d               Preview POM changes as a unified diff
                 h               Toggle this help screen
                 q / Esc         Quit (prompts to save if modified)
@@ -1513,6 +1813,10 @@ public class AuditTui extends ToolPanel {
             spans.add(Span.raw(":Licenses/Vulns  "));
             spans.add(Span.raw("s").bold());
             spans.add(Span.raw(":Scope" + (scopeFilter != null ? "=" + scopeFilter : "") + "  "));
+            if (view == View.LICENSES) {
+                spans.add(Span.raw("g").bold());
+                spans.add(Span.raw(":Group  "));
+            }
             spans.add(Span.raw("m").bold());
             spans.add(Span.raw(":Manage dep  "));
             spans.add(Span.raw("d").bold());
@@ -1558,21 +1862,20 @@ public class AuditTui extends ToolPanel {
     private List<Constraint> currentTableWidths() {
         return switch (view) {
             case LICENSES ->
-                List.of(
-                        Constraint.percentage(40), Constraint.percentage(15),
-                        Constraint.percentage(30), Constraint.percentage(15));
-            case BY_LICENSE ->
-                List.of(
-                        Constraint.percentage(55), Constraint.percentage(20),
-                        Constraint.percentage(15), Constraint.percentage(10));
+                licensesGrouped
+                        ? List.of(
+                                Constraint.percentage(55), Constraint.percentage(20),
+                                Constraint.percentage(15), Constraint.percentage(10))
+                        : List.of(
+                                Constraint.percentage(40), Constraint.percentage(15),
+                                Constraint.percentage(30), Constraint.percentage(15));
             case VULNERABILITIES ->
                 List.of(
-                        Constraint.percentage(24),
-                        Constraint.percentage(14),
+                        Constraint.percentage(35),
+                        Constraint.percentage(10),
                         Constraint.percentage(9),
-                        Constraint.percentage(8),
                         Constraint.percentage(11),
-                        Constraint.percentage(34));
+                        Constraint.percentage(35));
         };
     }
 
@@ -1602,6 +1905,10 @@ public class AuditTui extends ToolPanel {
             spans.add(Span.raw(":Navigate  "));
             spans.add(Span.raw("m").bold());
             spans.add(Span.raw(":Manage dep  "));
+            if (view == View.LICENSES) {
+                spans.add(Span.raw("g").bold());
+                spans.add(Span.raw(":Group  "));
+            }
             spans.addAll(sortKeyHints());
             spans.add(Span.raw("/").bold());
             spans.add(Span.raw(":Search  "));

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -499,97 +499,8 @@ public class AuditTui extends ToolPanel {
             return true;
         }
 
-        // ←/→ for expand/collapse in VULNERABILITIES view
-        if (key.isRight() && view == View.VULNERABILITIES) {
-            int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
-            if (idx >= 0
-                    && idx < vulnDisplayRows.size()
-                    && vulnDisplayRows.get(idx).isGroupHeader()) {
-                var group = vulnDisplayRows.get(idx).group();
-                if (!group.expanded) {
-                    group.expanded = true;
-                    rebuildVulnDisplayRows();
-                } else {
-                    vulnTableState.selectNext(vulnDisplayRows.size());
-                }
-                return true;
-            }
-        }
-        if (key.isLeft() && view == View.VULNERABILITIES) {
-            int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
-            if (idx >= 0 && idx < vulnDisplayRows.size()) {
-                var dr = vulnDisplayRows.get(idx);
-                if (dr.isGroupHeader() && dr.group().expanded) {
-                    dr.group().expanded = false;
-                    rebuildVulnDisplayRows();
-                    return true;
-                } else if (!dr.isGroupHeader()) {
-                    for (int i = idx - 1; i >= 0; i--) {
-                        if (vulnDisplayRows.get(i).isGroupHeader()) {
-                            vulnTableState.select(i);
-                            break;
-                        }
-                    }
-                    return true;
-                }
-            }
-        }
-
-        // VULNERABILITIES: Enter/Space to expand/collapse groups
-        if (view == View.VULNERABILITIES && (key.isKey(KeyCode.ENTER) || key.isChar(' '))) {
-            int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
-            if (idx >= 0
-                    && idx < vulnDisplayRows.size()
-                    && vulnDisplayRows.get(idx).isGroupHeader()) {
-                var group = vulnDisplayRows.get(idx).group();
-                group.expanded = !group.expanded;
-                rebuildVulnDisplayRows();
-            }
-            return true;
-        }
-
-        // ←/→ for expand/collapse in grouped licenses view
-        if (key.isRight() && view == View.LICENSES && licensesGrouped) {
-            int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
-            if (idx >= 0 && idx < byLicenseRows.size() && byLicenseRows.get(idx).isGroup()) {
-                if (!byLicenseRows.get(idx).expanded) {
-                    byLicenseRows.get(idx).expanded = true;
-                    rebuildByLicenseRows();
-                } else {
-                    byLicenseTableState.selectNext(byLicenseRows.size());
-                }
-                return true;
-            }
-        }
-        if (key.isLeft() && view == View.LICENSES && licensesGrouped) {
-            int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
-            if (idx >= 0 && idx < byLicenseRows.size()) {
-                LicenseRow row = byLicenseRows.get(idx);
-                if (row.isGroup() && row.expanded) {
-                    row.expanded = false;
-                    rebuildByLicenseRows();
-                    return true;
-                } else if (!row.isGroup()) {
-                    for (int i = idx - 1; i >= 0; i--) {
-                        if (byLicenseRows.get(i).isGroup()) {
-                            byLicenseTableState.select(i);
-                            break;
-                        }
-                    }
-                    return true;
-                }
-            }
-        }
-
-        // Grouped licenses: Enter/Space to expand/collapse groups
-        if (view == View.LICENSES && licensesGrouped && (key.isKey(KeyCode.ENTER) || key.isChar(' '))) {
-            int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
-            if (idx >= 0 && idx < byLicenseRows.size() && byLicenseRows.get(idx).isGroup()) {
-                byLicenseRows.get(idx).expanded = !byLicenseRows.get(idx).expanded;
-                rebuildByLicenseRows();
-            }
-            return true;
-        }
+        if (view == View.VULNERABILITIES && handleVulnExpandCollapse(key)) return true;
+        if (view == View.LICENSES && licensesGrouped && handleLicenseExpandCollapse(key)) return true;
 
         if (key.isCharIgnoreCase('m')) {
             addManagedDependency();
@@ -613,6 +524,98 @@ public class AuditTui extends ToolPanel {
             return true;
         }
 
+        return false;
+    }
+
+    private boolean handleVulnExpandCollapse(KeyEvent key) {
+        if (key.isRight()) {
+            int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
+            if (idx >= 0
+                    && idx < vulnDisplayRows.size()
+                    && vulnDisplayRows.get(idx).isGroupHeader()) {
+                var group = vulnDisplayRows.get(idx).group();
+                if (!group.expanded) {
+                    group.expanded = true;
+                    rebuildVulnDisplayRows();
+                } else {
+                    vulnTableState.selectNext(vulnDisplayRows.size());
+                }
+                return true;
+            }
+        }
+        if (key.isLeft()) {
+            int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
+            if (idx >= 0 && idx < vulnDisplayRows.size()) {
+                var dr = vulnDisplayRows.get(idx);
+                if (dr.isGroupHeader() && dr.group().expanded) {
+                    dr.group().expanded = false;
+                    rebuildVulnDisplayRows();
+                    return true;
+                } else if (!dr.isGroupHeader()) {
+                    for (int i = idx - 1; i >= 0; i--) {
+                        if (vulnDisplayRows.get(i).isGroupHeader()) {
+                            vulnTableState.select(i);
+                            break;
+                        }
+                    }
+                    return true;
+                }
+            }
+        }
+        if (key.isKey(KeyCode.ENTER) || key.isChar(' ')) {
+            int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
+            if (idx >= 0
+                    && idx < vulnDisplayRows.size()
+                    && vulnDisplayRows.get(idx).isGroupHeader()) {
+                var group = vulnDisplayRows.get(idx).group();
+                group.expanded = !group.expanded;
+                rebuildVulnDisplayRows();
+            }
+            return true;
+        }
+        return false;
+    }
+
+    private boolean handleLicenseExpandCollapse(KeyEvent key) {
+        if (key.isRight()) {
+            int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
+            if (idx >= 0 && idx < byLicenseRows.size() && byLicenseRows.get(idx).isGroup()) {
+                if (!byLicenseRows.get(idx).expanded) {
+                    byLicenseRows.get(idx).expanded = true;
+                    rebuildByLicenseRows();
+                } else {
+                    byLicenseTableState.selectNext(byLicenseRows.size());
+                }
+                return true;
+            }
+        }
+        if (key.isLeft()) {
+            int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
+            if (idx >= 0 && idx < byLicenseRows.size()) {
+                LicenseRow row = byLicenseRows.get(idx);
+                if (row.isGroup() && row.expanded) {
+                    row.expanded = false;
+                    rebuildByLicenseRows();
+                    return true;
+                } else if (!row.isGroup()) {
+                    for (int i = idx - 1; i >= 0; i--) {
+                        if (byLicenseRows.get(i).isGroup()) {
+                            byLicenseTableState.select(i);
+                            break;
+                        }
+                    }
+                    return true;
+                }
+            }
+        }
+        if (key.isKey(KeyCode.ENTER) || key.isChar(' ')) {
+            int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
+            if (idx >= 0 && idx < byLicenseRows.size() && byLicenseRows.get(idx).isGroup()) {
+                byLicenseRows.get(idx).expanded = !byLicenseRows.get(idx).expanded;
+                rebuildByLicenseRows();
+            }
+            return true;
+        }
         return false;
     }
 
@@ -1107,18 +1110,6 @@ public class AuditTui extends ToolPanel {
             return row.licenseName != null && row.licenseName.toLowerCase().contains(query);
         }
         return auditEntryMatchesSearch(row.entry, query);
-    }
-
-    @Override
-    protected Line buildSubViewTabLine() {
-        Line base = super.buildSubViewTabLine();
-        if (vulnsLoaded < entries.size()) {
-            List<Span> spans = new ArrayList<>(base.spans());
-            spans.add(Span.raw("  Checking vulnerabilities\u2026 " + vulnsLoaded + "/" + entries.size())
-                    .fg(Color.DARK_GRAY));
-            return Line.from(spans);
-        }
-        return base;
     }
 
     @Override

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -95,6 +95,7 @@ public class AuditTui extends ToolPanel {
     private static final String SEVERITY_HIGH = "HIGH";
     private static final String SEVERITY_MEDIUM = "MEDIUM";
     private static final String SEVERITY_LOW = "LOW";
+    private static final String TO_DEPENDENCY_MANAGEMENT = " to dependencyManagement";
 
     private enum View {
         VULNERABILITIES,
@@ -693,11 +694,12 @@ public class AuditTui extends ToolPanel {
                 int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
                 if (idx >= 0 && idx < vulnDisplayRows.size()) {
                     var dr = vulnDisplayRows.get(idx);
-                    yield dr.row() != null
-                            ? dr.row().entry()
-                            : (dr.group().rows.isEmpty()
-                                    ? null
-                                    : dr.group().rows.get(0).entry());
+                    if (dr.row() != null) {
+                        yield dr.row().entry();
+                    }
+                    yield dr.group().rows.isEmpty()
+                            ? null
+                            : dr.group().rows.get(0).entry();
                 }
                 yield null;
             }
@@ -735,9 +737,9 @@ public class AuditTui extends ToolPanel {
                     PomEditSession.ChangeType.ADD,
                     "managed",
                     entry.ga(),
-                    "added " + entry.version + " to dependencyManagement",
+                    "added " + entry.version + TO_DEPENDENCY_MANAGEMENT,
                     "audit");
-            status = "Added " + entry.ga() + ":" + entry.version + " to dependencyManagement";
+            status = "Added " + entry.ga() + ":" + entry.version + TO_DEPENDENCY_MANAGEMENT;
         } catch (Exception e) {
             status = "Failed: " + e.getMessage();
         }
@@ -754,7 +756,7 @@ public class AuditTui extends ToolPanel {
         if (count == 0) {
             status = "All artifacts in " + group.id + " already managed";
         } else {
-            status = "Added " + count + " artifact(s) from " + group.id + " to dependencyManagement";
+            status = "Added " + count + " artifact(s) from " + group.id + TO_DEPENDENCY_MANAGEMENT;
         }
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -49,6 +49,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
@@ -223,50 +224,8 @@ public class AuditTui extends ToolPanel {
 
     private void fetchAllData() {
         for (var entry : entries) {
-            if (entry.licenseLoaded) {
-                licensesLoaded++;
-            } else {
-                CompletableFuture.supplyAsync(
-                                () -> SearchTui.fetchPomFromCentral(entry.groupId, entry.artifactId, entry.version),
-                                httpPool)
-                        .thenAccept(info -> runner.runOnRenderThread(() -> {
-                            if (info != null && info.license != null) {
-                                entry.license = info.license;
-                                entry.licenseUrl = info.licenseUrl;
-                            }
-                            entry.licenseLoaded = true;
-                            licensesLoaded++;
-                            rebuildByLicenseRows();
-                            updateStatus();
-                        }));
-            }
-
-            if (entry.vulnsLoaded) {
-                vulnsLoaded++;
-                if (entry.hasVulnerabilities()) {
-                    vulnCount += entry.vulnerabilities.size();
-                }
-            } else {
-                CompletableFuture.supplyAsync(
-                                () -> {
-                                    try {
-                                        return osvClient.query(entry.groupId, entry.artifactId, entry.version);
-                                    } catch (Exception e) {
-                                        return List.<OsvClient.Vulnerability>of();
-                                    }
-                                },
-                                httpPool)
-                        .thenAccept(vulns -> runner.runOnRenderThread(() -> {
-                            entry.vulnerabilities = vulns;
-                            entry.vulnsLoaded = true;
-                            vulnsLoaded++;
-                            if (!vulns.isEmpty()) {
-                                vulnCount += vulns.size();
-                                rebuildVulnRows();
-                            }
-                            updateStatus();
-                        }));
-            }
+            fetchLicenseForEntry(entry);
+            fetchVulnsForEntry(entry);
         }
         if (licensesLoaded > 0) {
             rebuildByLicenseRows();
@@ -275,6 +234,54 @@ public class AuditTui extends ToolPanel {
             rebuildVulnRows();
         }
         updateStatus();
+    }
+
+    private void fetchLicenseForEntry(AuditEntry entry) {
+        if (entry.licenseLoaded) {
+            licensesLoaded++;
+            return;
+        }
+        CompletableFuture.supplyAsync(
+                        () -> SearchTui.fetchPomFromCentral(entry.groupId, entry.artifactId, entry.version), httpPool)
+                .thenAccept(info -> runner.runOnRenderThread(() -> {
+                    if (info != null && info.license != null) {
+                        entry.license = info.license;
+                        entry.licenseUrl = info.licenseUrl;
+                    }
+                    entry.licenseLoaded = true;
+                    licensesLoaded++;
+                    rebuildByLicenseRows();
+                    updateStatus();
+                }));
+    }
+
+    private void fetchVulnsForEntry(AuditEntry entry) {
+        if (entry.vulnsLoaded) {
+            vulnsLoaded++;
+            if (entry.hasVulnerabilities()) {
+                vulnCount += entry.vulnerabilities.size();
+            }
+            return;
+        }
+        CompletableFuture.supplyAsync(
+                        () -> {
+                            try {
+                                return osvClient.query(entry.groupId, entry.artifactId, entry.version);
+                            } catch (Exception e) {
+                                return List.<OsvClient.Vulnerability>of();
+                            }
+                        },
+                        httpPool)
+                .thenAccept(vulns -> runner.runOnRenderThread(() -> {
+                    entry.vulnerabilities = vulns;
+                    entry.vulnsLoaded = true;
+                    vulnsLoaded++;
+                    if (!vulns.isEmpty()) {
+                        vulnCount += vulns.size();
+                        rebuildVulnRows();
+                    }
+                    updateStatus();
+                }));
     }
 
     void rebuildVulnRows() {
@@ -288,8 +295,18 @@ public class AuditTui extends ToolPanel {
             }
         }
 
-        // Preserve expansion state — save all known IDs and aliases for expanded groups
-        // so that re-ordering due to async loading doesn't lose the state
+        Set<String> expandedIds = collectExpandedIds();
+        vulnGroups = groupVulnsByCve(expandedIds);
+        rebuildVulnDisplayRows();
+
+        if (vulnDisplayRows.isEmpty()) {
+            vulnTableState.clearSelection();
+        } else if (vulnTableState.selected() == null || vulnTableState.selected() >= vulnDisplayRows.size()) {
+            vulnTableState.select(0);
+        }
+    }
+
+    private Set<String> collectExpandedIds() {
         var expandedIds = new HashSet<String>();
         for (var group : vulnGroups) {
             if (group.expanded) {
@@ -302,13 +319,14 @@ public class AuditTui extends ToolPanel {
                 }
             }
         }
+        return expandedIds;
+    }
 
-        // Group by CVE ID, using aliases to unify GHSA/CVE references
+    private List<VulnGroup> groupVulnsByCve(Set<String> expandedIds) {
         Map<String, VulnGroup> groupMap = new LinkedHashMap<>();
         Map<String, String> aliasToId = new HashMap<>();
         for (var vr : vulnRows) {
             String id = vr.vuln().id;
-            // Check if this vuln's ID or any alias matches an existing group
             String groupId = aliasToId.getOrDefault(id, id);
             if (vr.vuln().aliases != null) {
                 for (String alias : vr.vuln().aliases) {
@@ -332,23 +350,13 @@ public class AuditTui extends ToolPanel {
                     }
                 }
             }
-            // Avoid duplicate artifacts in the same group
             boolean alreadyPresent = group.rows.stream()
                     .anyMatch(r -> r.entry().gav().equals(vr.entry().gav()));
             if (!alreadyPresent) {
                 group.rows.add(vr);
             }
         }
-        vulnGroups = new ArrayList<>(groupMap.values());
-
-        // Build display rows
-        rebuildVulnDisplayRows();
-
-        if (vulnDisplayRows.isEmpty()) {
-            vulnTableState.clearSelection();
-        } else if (vulnTableState.selected() == null || vulnTableState.selected() >= vulnDisplayRows.size()) {
-            vulnTableState.select(0);
-        }
+        return new ArrayList<>(groupMap.values());
     }
 
     private void rebuildVulnDisplayRows() {
@@ -677,33 +685,34 @@ public class AuditTui extends ToolPanel {
 
     private AuditEntry selectedEntry() {
         return switch (view) {
-            case LICENSES -> {
-                if (licensesGrouped) {
-                    int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
-                    yield (idx >= 0
-                                    && idx < byLicenseRows.size()
-                                    && !byLicenseRows.get(idx).isGroup())
-                            ? byLicenseRows.get(idx).entry
-                            : null;
-                } else {
-                    int idx = tableState.selected() != null ? tableState.selected() : -1;
-                    yield (idx >= 0 && idx < filteredEntries.size()) ? filteredEntries.get(idx) : null;
-                }
-            }
-            case VULNERABILITIES -> {
-                int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
-                if (idx >= 0 && idx < vulnDisplayRows.size()) {
-                    var dr = vulnDisplayRows.get(idx);
-                    if (dr.row() != null) {
-                        yield dr.row().entry();
-                    }
-                    yield dr.group().rows.isEmpty()
-                            ? null
-                            : dr.group().rows.get(0).entry();
-                }
-                yield null;
-            }
+            case LICENSES -> selectedLicenseEntry();
+            case VULNERABILITIES -> selectedVulnEntry();
         };
+    }
+
+    private AuditEntry selectedLicenseEntry() {
+        if (licensesGrouped) {
+            int idx = byLicenseTableState.selected() != null ? byLicenseTableState.selected() : -1;
+            return (idx >= 0
+                            && idx < byLicenseRows.size()
+                            && !byLicenseRows.get(idx).isGroup())
+                    ? byLicenseRows.get(idx).entry
+                    : null;
+        }
+        int idx = tableState.selected() != null ? tableState.selected() : -1;
+        return (idx >= 0 && idx < filteredEntries.size()) ? filteredEntries.get(idx) : null;
+    }
+
+    private AuditEntry selectedVulnEntry() {
+        int idx = vulnTableState.selected() != null ? vulnTableState.selected() : -1;
+        if (idx >= 0 && idx < vulnDisplayRows.size()) {
+            var dr = vulnDisplayRows.get(idx);
+            if (dr.row() != null) {
+                return dr.row().entry();
+            }
+            return dr.group().rows.isEmpty() ? null : dr.group().rows.get(0).entry();
+        }
+        return null;
     }
 
     private void addManagedDependency() {
@@ -1344,49 +1353,7 @@ public class AuditTui extends ToolPanel {
 
         List<Row> rows = new ArrayList<>();
         for (int i = 0; i < vulnDisplayRows.size(); i++) {
-            var dr = vulnDisplayRows.get(i);
-            if (dr.isGroupHeader()) {
-                var group = dr.group();
-                boolean allManaged = editSession != null
-                        && group.rows.stream()
-                                .allMatch(r -> editSession.isChanged(r.entry().ga()));
-                String arrow = group.expanded ? "▾ " : "▸ ";
-                String severity = normalizeSeverity(group.severity);
-                String published = formatPublished(group.published);
-                int affected = group.rows.size();
-                String countLabel = affected > 1 ? " (" + affected + " artifacts)" : "";
-                Style style = allManaged
-                        ? Style.create().dim()
-                        : getSeverityStyle(severity).bold();
-                if (view == View.VULNERABILITIES && isSearchMatch(i)) {
-                    style = style.bg(theme.searchHighlightBg());
-                }
-                String statusIcon = allManaged ? "✓ " : "";
-                rows.add(Row.from(
-                        Cell.from(statusIcon + arrow + group.id + countLabel).style(style),
-                        Cell.from(severity).style(style),
-                        Cell.from("").style(style),
-                        Cell.from(published).style(style),
-                        Cell.from(truncateSummary(group.summary, 50)).style(style)));
-            } else {
-                var vr = dr.row();
-                boolean managed =
-                        editSession != null && editSession.isChanged(vr.entry().ga());
-                String severity = normalizeSeverity(vr.vuln().severity);
-                Style style = managed ? Style.create().dim() : getSeverityStyle(severity);
-                if (view == View.VULNERABILITIES && isSearchMatch(i)) {
-                    style = style.bg(theme.searchHighlightBg());
-                }
-                String marker = managed ? "  ✓ " : "    ";
-                rows.add(Row.from(
-                        Cell.from(marker + vr.entry().ga() + ":" + vr.entry().version)
-                                .style(style),
-                        Cell.from("").style(style),
-                        Cell.from(vr.entry().scope)
-                                .style(managed ? Style.create().dim() : getScopeStyle(vr.entry().scope)),
-                        Cell.from("").style(style),
-                        Cell.from("").style(style)));
-            }
+            rows.add(buildVulnTableRow(vulnDisplayRows.get(i), i));
         }
 
         Row header = sortState.decorateHeader(
@@ -1414,6 +1381,48 @@ public class AuditTui extends ToolPanel {
         renderVulnDetail(frame, zones.get(2));
     }
 
+    private Row buildVulnTableRow(VulnDisplayRow dr, int i) {
+        if (dr.isGroupHeader()) {
+            var group = dr.group();
+            boolean allManaged = editSession != null
+                    && group.rows.stream()
+                            .allMatch(r -> editSession.isChanged(r.entry().ga()));
+            String arrow = group.expanded ? "▾ " : "▸ ";
+            String severity = normalizeSeverity(group.severity);
+            String published = formatPublished(group.published);
+            int affected = group.rows.size();
+            String countLabel = affected > 1 ? " (" + affected + " artifacts)" : "";
+            Style style = allManaged
+                    ? Style.create().dim()
+                    : getSeverityStyle(severity).bold();
+            if (view == View.VULNERABILITIES && isSearchMatch(i)) {
+                style = style.bg(theme.searchHighlightBg());
+            }
+            String statusIcon = allManaged ? "✓ " : "";
+            return Row.from(
+                    Cell.from(statusIcon + arrow + group.id + countLabel).style(style),
+                    Cell.from(severity).style(style),
+                    Cell.from("").style(style),
+                    Cell.from(published).style(style),
+                    Cell.from(truncateSummary(group.summary, 50)).style(style));
+        }
+        var vr = dr.row();
+        boolean managed =
+                editSession != null && editSession.isChanged(vr.entry().ga());
+        String severity = normalizeSeverity(vr.vuln().severity);
+        Style style = managed ? Style.create().dim() : getSeverityStyle(severity);
+        if (view == View.VULNERABILITIES && isSearchMatch(i)) {
+            style = style.bg(theme.searchHighlightBg());
+        }
+        String marker = managed ? "  ✓ " : "    ";
+        return Row.from(
+                Cell.from(marker + vr.entry().ga() + ":" + vr.entry().version).style(style),
+                Cell.from("").style(style),
+                Cell.from(vr.entry().scope).style(managed ? Style.create().dim() : getScopeStyle(vr.entry().scope)),
+                Cell.from("").style(style),
+                Cell.from("").style(style));
+    }
+
     private void renderVulnDetail(Frame frame, Rect area) {
         Block block = Block.builder()
                 .title(" Details ")
@@ -1428,74 +1437,78 @@ public class AuditTui extends ToolPanel {
         }
 
         var dr = vulnDisplayRows.get(idx);
-        List<Line> lines = new ArrayList<>();
-
-        if (dr.isGroupHeader()) {
-            var group = dr.group();
-            String url = vulnUrl(group.id);
-            String severity = normalizeSeverity(group.severity);
-            lines.add(Line.from(
-                    Span.raw(group.id).bold().cyan().hyperlink(url),
-                    Span.raw("  "),
-                    Span.raw(severity).style(getSeverityStyle(severity).bold()),
-                    Span.raw("  " + group.rows.size() + " affected artifact(s)").fg(theme.detailSeparatorColor())));
-            lines.add(Line.from(
-                    Span.raw("↗ ").fg(theme.detailSeparatorColor()),
-                    Span.raw(url).fg(theme.linkColor()).hyperlink(url)));
-            if (group.published != null && !group.published.isEmpty()) {
-                String pub = group.published.length() > 10 ? group.published.substring(0, 10) : group.published;
-                lines.add(Line.from(Span.raw("Published: ").fg(theme.detailSeparatorColor()), Span.raw(pub)));
-            }
-            lines.add(Line.from(Span.raw(group.summary != null ? group.summary : "")));
-            List<Span> artifacts = new ArrayList<>();
-            artifacts.add(Span.raw("Artifacts: ").fg(theme.detailSeparatorColor()));
-            for (int i = 0; i < group.rows.size(); i++) {
-                if (i > 0) artifacts.add(Span.raw(", ").fg(theme.detailSeparatorColor()));
-                var r = group.rows.get(i);
-                artifacts.add(Span.raw(r.entry().ga() + ":" + r.entry().version));
-            }
-            lines.add(Line.from(artifacts));
-        } else {
-            var vr = dr.row();
-            var vuln = vr.vuln();
-            String url = vulnUrl(vuln.id);
-            String severity = normalizeSeverity(vuln.severity);
-            String centralUrl = centralUrl(vr.entry().groupId, vr.entry().artifactId);
-            lines.add(Line.from(
-                    Span.raw(vuln.id).bold().cyan().hyperlink(url),
-                    Span.raw("  "),
-                    Span.raw(severity).style(getSeverityStyle(severity).bold()),
-                    Span.raw(LABEL_SCOPE).fg(Color.DARK_GRAY),
-                    Span.raw(vr.entry().scope).style(getScopeStyle(vr.entry().scope)),
-                    Span.raw("  "),
-                    Span.raw(vr.entry().ga() + ":" + vr.entry().version)
-                            .fg(theme.detailSeparatorColor())
-                            .hyperlink(centralUrl)));
-            lines.add(Line.from(
-                    Span.raw("↗ ").fg(theme.detailSeparatorColor()),
-                    Span.raw(url).fg(theme.linkColor()).hyperlink(url)));
-            if (!vuln.aliases.isEmpty()) {
-                List<Span> aliasSpans = new ArrayList<>();
-                aliasSpans.add(Span.raw("Aliases: ").fg(theme.detailSeparatorColor()));
-                for (int i = 0; i < vuln.aliases.size(); i++) {
-                    if (i > 0) aliasSpans.add(Span.raw(", "));
-                    String alias = vuln.aliases.get(i);
-                    aliasSpans.add(Span.raw(alias).hyperlink(vulnUrl(alias)));
-                }
-                lines.add(Line.from(aliasSpans));
-            }
-            if (vuln.published != null && !vuln.published.isEmpty()) {
-                String pub = vuln.published.length() > 10 ? vuln.published.substring(0, 10) : vuln.published;
-                lines.add(Line.from(Span.raw("Published: ").fg(theme.detailSeparatorColor()), Span.raw(pub)));
-            }
-            lines.add(Line.from(Span.raw(vuln.summary != null ? vuln.summary : "")));
-            Line modulesLine = buildModulesLine(vr.entry());
-            if (modulesLine != null) lines.add(modulesLine);
-        }
+        List<Line> lines = dr.isGroupHeader() ? buildGroupDetailLines(dr.group()) : buildArtifactDetailLines(dr.row());
 
         Paragraph detail =
                 Paragraph.builder().text(Text.from(lines)).block(block).build();
         frame.renderWidget(detail, area);
+    }
+
+    private List<Line> buildGroupDetailLines(VulnGroup group) {
+        List<Line> lines = new ArrayList<>();
+        String url = vulnUrl(group.id);
+        String severity = normalizeSeverity(group.severity);
+        lines.add(Line.from(
+                Span.raw(group.id).bold().cyan().hyperlink(url),
+                Span.raw("  "),
+                Span.raw(severity).style(getSeverityStyle(severity).bold()),
+                Span.raw("  " + group.rows.size() + " affected artifact(s)").fg(theme.detailSeparatorColor())));
+        lines.add(Line.from(
+                Span.raw("↗ ").fg(theme.detailSeparatorColor()),
+                Span.raw(url).fg(theme.linkColor()).hyperlink(url)));
+        if (group.published != null && !group.published.isEmpty()) {
+            String pub = group.published.length() > 10 ? group.published.substring(0, 10) : group.published;
+            lines.add(Line.from(Span.raw("Published: ").fg(theme.detailSeparatorColor()), Span.raw(pub)));
+        }
+        lines.add(Line.from(Span.raw(group.summary != null ? group.summary : "")));
+        List<Span> artifacts = new ArrayList<>();
+        artifacts.add(Span.raw("Artifacts: ").fg(theme.detailSeparatorColor()));
+        for (int i = 0; i < group.rows.size(); i++) {
+            if (i > 0) artifacts.add(Span.raw(", ").fg(theme.detailSeparatorColor()));
+            var r = group.rows.get(i);
+            artifacts.add(Span.raw(r.entry().ga() + ":" + r.entry().version));
+        }
+        lines.add(Line.from(artifacts));
+        return lines;
+    }
+
+    private List<Line> buildArtifactDetailLines(VulnRow vr) {
+        List<Line> lines = new ArrayList<>();
+        var vuln = vr.vuln();
+        String url = vulnUrl(vuln.id);
+        String severity = normalizeSeverity(vuln.severity);
+        String cUrl = centralUrl(vr.entry().groupId, vr.entry().artifactId);
+        lines.add(Line.from(
+                Span.raw(vuln.id).bold().cyan().hyperlink(url),
+                Span.raw("  "),
+                Span.raw(severity).style(getSeverityStyle(severity).bold()),
+                Span.raw(LABEL_SCOPE).fg(Color.DARK_GRAY),
+                Span.raw(vr.entry().scope).style(getScopeStyle(vr.entry().scope)),
+                Span.raw("  "),
+                Span.raw(vr.entry().ga() + ":" + vr.entry().version)
+                        .fg(theme.detailSeparatorColor())
+                        .hyperlink(cUrl)));
+        lines.add(Line.from(
+                Span.raw("↗ ").fg(theme.detailSeparatorColor()),
+                Span.raw(url).fg(theme.linkColor()).hyperlink(url)));
+        if (!vuln.aliases.isEmpty()) {
+            List<Span> aliasSpans = new ArrayList<>();
+            aliasSpans.add(Span.raw("Aliases: ").fg(theme.detailSeparatorColor()));
+            for (int i = 0; i < vuln.aliases.size(); i++) {
+                if (i > 0) aliasSpans.add(Span.raw(", "));
+                String alias = vuln.aliases.get(i);
+                aliasSpans.add(Span.raw(alias).hyperlink(vulnUrl(alias)));
+            }
+            lines.add(Line.from(aliasSpans));
+        }
+        if (vuln.published != null && !vuln.published.isEmpty()) {
+            String pub = vuln.published.length() > 10 ? vuln.published.substring(0, 10) : vuln.published;
+            lines.add(Line.from(Span.raw("Published: ").fg(theme.detailSeparatorColor()), Span.raw(pub)));
+        }
+        lines.add(Line.from(Span.raw(vuln.summary != null ? vuln.summary : "")));
+        Line modulesLine = buildModulesLine(vr.entry());
+        if (modulesLine != null) lines.add(modulesLine);
+        return lines;
     }
 
     private static String centralUrl(String groupId, String artifactId) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -330,6 +330,10 @@ public class AuditTui extends ToolPanel {
             VulnGroup group = groupMap.get(groupId);
             if (group == null) {
                 group = createVulnGroup(vr, groupId, expandedIds, aliasToId, groupMap);
+            } else if (vr.vuln().aliases != null) {
+                for (String alias : vr.vuln().aliases) {
+                    aliasToId.putIfAbsent(alias, groupId);
+                }
             }
             boolean alreadyPresent = group.rows.stream()
                     .anyMatch(r -> r.entry().gav().equals(vr.entry().gav()));
@@ -1058,8 +1062,8 @@ public class AuditTui extends ToolPanel {
                         }
                     }
                 } else {
-                    for (int i = 0; i < entries.size(); i++) {
-                        if (auditEntryMatchesSearch(entries.get(i), query)) {
+                    for (int i = 0; i < filteredEntries.size(); i++) {
+                        if (auditEntryMatchesSearch(filteredEntries.get(i), query)) {
                             searchMatches.add(i);
                         }
                     }
@@ -1071,14 +1075,15 @@ public class AuditTui extends ToolPanel {
                     if (dr.isGroupHeader()) {
                         var g = dr.group();
                         if (g.id.toLowerCase().contains(query)
-                                || g.summary.toLowerCase().contains(query)) {
+                                || (g.summary != null && g.summary.toLowerCase().contains(query))) {
                             searchMatches.add(i);
                         }
                     } else {
                         var vr = dr.row();
                         if (auditEntryMatchesSearch(vr.entry(), query)
                                 || vr.vuln().id.toLowerCase().contains(query)
-                                || vr.vuln().summary.toLowerCase().contains(query)) {
+                                || (vr.vuln().summary != null
+                                        && vr.vuln().summary.toLowerCase().contains(query))) {
                             searchMatches.add(i);
                         }
                     }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -714,13 +714,14 @@ public class ConflictsTui extends ToolPanel {
 
         List<Row> rows = new ArrayList<>();
         for (var group : displayed) {
-            String icon = group.hasConflict() ? "⚠" : "✓";
+            boolean pinned = editSession != null && editSession.isChanged(group.ga);
+            String icon = pinned ? "✓" : (group.hasConflict() ? "⚠" : "✓");
             String versions = group.entries.stream()
                     .map(e -> e.requestedVersion)
                     .distinct()
                     .collect(Collectors.joining(", "));
 
-            Style style = group.hasConflict() ? Style.create() : Style.create().dim();
+            Style style = (pinned || !group.hasConflict()) ? Style.create().dim() : Style.create();
 
             rows.add(Row.from(icon, group.ga, group.resolvedVersion(), versions).style(style));
         }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -715,7 +715,12 @@ public class ConflictsTui extends ToolPanel {
         List<Row> rows = new ArrayList<>();
         for (var group : displayed) {
             boolean pinned = editSession != null && editSession.isChanged(group.ga);
-            String icon = pinned ? "✓" : (group.hasConflict() ? "⚠" : "✓");
+            String icon;
+            if (pinned || !group.hasConflict()) {
+                icon = "✓";
+            } else {
+                icon = "⚠";
+            }
             String versions = group.entries.stream()
                     .map(e -> e.requestedVersion)
                     .distinct()

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -301,6 +301,33 @@ public class DependenciesTui extends ToolPanel {
         }
     }
 
+    @Override
+    boolean onSessionChanged() {
+        if (editSession == null) return true;
+        Set<String> existingGAs = managed.stream().map(ManagedEntry::ga).collect(java.util.stream.Collectors.toSet());
+        for (PomEditSession.Change change : editSession.changes()) {
+            if (change.type() == PomEditSession.ChangeType.ADD
+                    && "managed".equals(change.target())
+                    && !existingGAs.contains(change.ga())) {
+                String[] parts = change.ga().split(":");
+                if (parts.length == 2) {
+                    String version = "";
+                    String desc = change.description();
+                    int idx = desc.indexOf("pinned to ");
+                    if (idx >= 0) version = desc.substring(idx + 10);
+                    idx = desc.indexOf("added ");
+                    if (idx >= 0) {
+                        int toIdx = desc.indexOf(" to ");
+                        if (toIdx > idx) version = desc.substring(idx + 6, toIdx);
+                    }
+                    managed.add(new ManagedEntry(parts[0], parts[1], version, "compile", "jar", "own"));
+                    existingGAs.add(change.ga());
+                }
+            }
+        }
+        return true;
+    }
+
     private void updateStatus() {
         if (bytecodeAnalyzed) {
             long unused = declared.stream()
@@ -1083,7 +1110,8 @@ public class DependenciesTui extends ToolPanel {
         List<Row> rows = new ArrayList<>();
         for (int i = 0; i < managed.size(); i++) {
             ManagedEntry e = managed.get(i);
-            String icon = e.isBom ? "B" : " ";
+            boolean changed = editSession != null && editSession.isChanged(e.ga());
+            String icon = changed ? "✓" : (e.isBom ? "B" : " ");
             String typeLabel = e.isBom ? "bom" : e.scope;
             Style rowStyle = "inherited".equals(e.source) ? Style.create().dim() : Style.create();
             if (isSearchMatch(i)) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -306,26 +306,30 @@ public class DependenciesTui extends ToolPanel {
         if (editSession == null) return true;
         Set<String> existingGAs = managed.stream().map(ManagedEntry::ga).collect(java.util.stream.Collectors.toSet());
         for (PomEditSession.Change change : editSession.changes()) {
-            if (change.type() == PomEditSession.ChangeType.ADD
-                    && "managed".equals(change.target())
-                    && !existingGAs.contains(change.ga())) {
-                String[] parts = change.ga().split(":");
-                if (parts.length == 2) {
-                    String version = "";
-                    String desc = change.description();
-                    int idx = desc.indexOf("pinned to ");
-                    if (idx >= 0) version = desc.substring(idx + 10);
-                    idx = desc.indexOf("added ");
-                    if (idx >= 0) {
-                        int toIdx = desc.indexOf(" to ");
-                        if (toIdx > idx) version = desc.substring(idx + 6, toIdx);
-                    }
-                    managed.add(new ManagedEntry(parts[0], parts[1], version, "compile", "jar", "own"));
-                    existingGAs.add(change.ga());
-                }
+            if (change.type() != PomEditSession.ChangeType.ADD
+                    || !"managed".equals(change.target())
+                    || existingGAs.contains(change.ga())) {
+                continue;
+            }
+            String[] parts = change.ga().split(":");
+            if (parts.length == 2) {
+                String version = parseVersionFromDescription(change.description());
+                managed.add(new ManagedEntry(parts[0], parts[1], version, COMPILE_SCOPE, "jar", "own"));
+                existingGAs.add(change.ga());
             }
         }
         return true;
+    }
+
+    private static String parseVersionFromDescription(String desc) {
+        int idx = desc.indexOf("pinned to ");
+        if (idx >= 0) return desc.substring(idx + 10);
+        idx = desc.indexOf("added ");
+        if (idx >= 0) {
+            int toIdx = desc.indexOf(" to ");
+            if (toIdx > idx) return desc.substring(idx + 6, toIdx);
+        }
+        return "";
     }
 
     private void updateStatus() {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -1111,7 +1111,14 @@ public class DependenciesTui extends ToolPanel {
         for (int i = 0; i < managed.size(); i++) {
             ManagedEntry e = managed.get(i);
             boolean changed = editSession != null && editSession.isChanged(e.ga());
-            String icon = changed ? "✓" : (e.isBom ? "B" : " ");
+            String icon;
+            if (changed) {
+                icon = "✓";
+            } else if (e.isBom) {
+                icon = "B";
+            } else {
+                icon = " ";
+            }
             String typeLabel = e.isBom ? "bom" : e.scope;
             Style rowStyle = "inherited".equals(e.source) ? Style.create().dim() : Style.create();
             if (isSearchMatch(i)) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -306,6 +306,9 @@ public class DependenciesTui extends ToolPanel {
         if (editSession == null) return true;
         Set<String> existingGAs = managed.stream().map(ManagedEntry::ga).collect(java.util.stream.Collectors.toSet());
         for (PomEditSession.Change change : editSession.changes()) {
+            if (change.type() == PomEditSession.ChangeType.REMOVE) {
+                return false;
+            }
             if (change.type() != PomEditSession.ChangeType.ADD
                     || !"managed".equals(change.target())
                     || existingGAs.contains(change.ga())) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -44,6 +44,7 @@ public class PilotEngine {
     private final List<PilotProject> allProjects;
     private final String scope;
     private final Map<String, DependencyTreeModel> treeCache = new java.util.concurrent.ConcurrentHashMap<>();
+    private final Map<String, AuditTui.AuditEntry> auditEntryCache = new java.util.concurrent.ConcurrentHashMap<>();
 
     public PilotEngine(PilotResolver resolver, List<PilotProject> allProjects, String scope) {
         this.resolver = resolver;
@@ -86,7 +87,7 @@ public class PilotEngine {
             case "conflicts" -> createConflictsPanel(proj, projects, session, progress);
             case "align" -> createAlignPanel(proj, projects);
             case "audit" -> createAuditPanel(proj, projects, session, progress);
-            case "pom" -> createPomPanel(proj);
+            case "pom" -> createPomPanel(proj, session);
             case "search" -> createSearchPanel();
             default -> null;
         };
@@ -240,8 +241,8 @@ public class PilotEngine {
         }
     }
 
-    private ToolPanel createPomPanel(PilotProject proj) throws Exception {
-        String rawPom = Files.readString(proj.pomPath);
+    private ToolPanel createPomPanel(PilotProject proj, PomEditSession session) throws Exception {
+        String rawPom = (session != null && session.isDirty()) ? session.currentXml() : Files.readString(proj.pomPath);
         String effectivePom = resolver.effectivePom(proj);
         XmlTreeModel effectiveTree = XmlTreeModel.parse(effectivePom);
 
@@ -334,7 +335,7 @@ public class PilotEngine {
         return projects.get(0);
     }
 
-    private static void collectAuditNode(
+    private void collectAuditNode(
             DependencyTreeModel.TreeNode node,
             Map<String, AuditTui.AuditEntry> entryMap,
             String moduleName,
@@ -342,7 +343,9 @@ public class PilotEngine {
         if (!isRoot) {
             String gav = node.ga() + ":" + node.version;
             AuditTui.AuditEntry entry = entryMap.computeIfAbsent(
-                    gav, k -> new AuditTui.AuditEntry(node.groupId, node.artifactId, node.version, node.scope));
+                    gav,
+                    k -> auditEntryCache.computeIfAbsent(
+                            k, kk -> new AuditTui.AuditEntry(node.groupId, node.artifactId, node.version, node.scope)));
             if (moduleName != null && !entry.modules.contains(moduleName)) {
                 entry.modules.add(moduleName);
             }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -241,7 +241,7 @@ public class PilotEngine {
         }
     }
 
-    private ToolPanel createPomPanel(PilotProject proj, PomEditSession session) throws Exception {
+    private ToolPanel createPomPanel(PilotProject proj, PomEditSession session) throws java.io.IOException {
         String rawPom = (session != null && session.isDirty()) ? session.currentXml() : Files.readString(proj.pomPath);
         String effectivePom = resolver.effectivePom(proj);
         XmlTreeModel effectiveTree = XmlTreeModel.parse(effectivePom);

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -599,9 +599,18 @@ public class PilotShell {
         if (cached == null) {
             return false;
         }
+        // Check if the session has been mutated since this panel was cached
+        PomEditSession session = currentSession();
+        if (session != null && session.mutationCount() != cached.lastSeenMutationCount) {
+            cached.lastSeenMutationCount = session.mutationCount();
+            if (!cached.onSessionChanged()) {
+                panelCache.remove(cacheKey);
+                return false;
+            }
+        }
         activePanel = cached;
-        // Restore sub-view to keep navigation homogeneous across modules
-        if (currentSubView < activePanel.subViewCount()) {
+        activePanel.setFocused(focus == Focus.CONTENT);
+        if (currentSubView < activePanel.subViewCount() && currentSubView != activePanel.activeSubView()) {
             activePanel.setActiveSubView(currentSubView);
         }
         loadingCacheKey = null;
@@ -640,6 +649,10 @@ public class PilotShell {
 
     private void onPanelLoaded(String cacheKey, ToolPanel panel, int subView) {
         panel.setRunner(runner);
+        PomEditSession session = currentSession();
+        if (session != null) {
+            panel.lastSeenMutationCount = session.mutationCount();
+        }
         panelCache.put(cacheKey, panel);
         runningTasks.remove(cacheKey);
         // Only set active if still waiting for this panel

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomEditSession.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomEditSession.java
@@ -57,6 +57,7 @@ public class PomEditSession {
     private PomEditor editor;
     private final List<Change> changes = new ArrayList<>();
     private final Deque<String> undoStack = new ArrayDeque<>();
+    private int mutationCount;
 
     PomEditSession(Path pomPath) {
         this.pomPath = pomPath;
@@ -107,6 +108,11 @@ public class PomEditSession {
      */
     void recordChange(ChangeType type, String target, String ga, String description, String tool) {
         changes.add(new Change(type, target, ga, description, tool));
+        mutationCount++;
+    }
+
+    int mutationCount() {
+        return mutationCount;
     }
 
     List<Change> changes() {
@@ -208,6 +214,7 @@ public class PomEditSession {
         if (!changes.isEmpty()) {
             changes.remove(changes.size() - 1);
         }
+        mutationCount++;
         return true;
     }
 
@@ -218,5 +225,6 @@ public class PomEditSession {
         editor = new PomEditor(Document.of(originalContent));
         changes.clear();
         undoStack.clear();
+        mutationCount++;
     }
 }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
@@ -51,6 +51,11 @@ import java.util.Map;
  */
 public class PomTui extends ToolPanel {
 
+    @Override
+    boolean onSessionChanged() {
+        return false;
+    }
+
     private enum View {
         RAW,
         EFFECTIVE

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
@@ -65,6 +65,7 @@ public class ReactorCollector {
         String newestVersion;
         VersionComparator.UpdateType updateType;
         boolean selected;
+        boolean applied;
         LocalDate currentReleaseDate;
         LocalDate newestReleaseDate;
         float libYears = -1;
@@ -101,6 +102,7 @@ public class ReactorCollector {
         String newestVersion;
         VersionComparator.UpdateType updateType;
         boolean selected;
+        boolean applied;
         boolean expanded = false;
         float libYears = -1;
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -65,6 +65,21 @@ public abstract class ToolPanel {
     /** Shared POM edit session, or null for read-only tools. */
     protected PomEditSession editSession;
 
+    /** Mutation count snapshot when this panel was last built/refreshed. */
+    int lastSeenMutationCount;
+
+    /**
+     * Called when the panel is activated and the shared session has been mutated
+     * since this panel was last seen. Panels can override this to refresh their
+     * data models without a full rebuild.
+     *
+     * @return {@code true} if the panel handled the change (re-render is enough),
+     *         {@code false} if the panel must be fully rebuilt (cache invalidated)
+     */
+    boolean onSessionChanged() {
+        return true;
+    }
+
     /** Help overlay for standalone mode (shell has its own for panel mode). */
     protected final HelpOverlay helpOverlay = new HelpOverlay();
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -139,6 +139,7 @@ public class UpdatesTui extends ToolPanel {
     Set<String> duplicatePropertyNames = Set.of();
     private Filter filter = Filter.ALL;
     private final DiffOverlay diffOverlay = new DiffOverlay();
+    private final Set<PomEditSession> mutatedSessions = new LinkedHashSet<>();
     private final TableState detailTableState = new TableState();
     boolean showDetails = true;
     private int lastContentHeight;
@@ -148,6 +149,7 @@ public class UpdatesTui extends ToolPanel {
     int failedCount = 0;
     int dateFetchesPending;
     boolean datesLoading;
+    private boolean pendingQuit;
 
     /**
      * Standalone constructor — creates a local session cache.
@@ -184,6 +186,25 @@ public class UpdatesTui extends ToolPanel {
     private static Function<Path, PomEditSession> defaultSessionProvider() {
         Map<String, PomEditSession> localCache = new ConcurrentHashMap<>();
         return path -> localCache.computeIfAbsent(path.toString(), k -> new PomEditSession(path));
+    }
+
+    @Override
+    boolean isDirty() {
+        return mutatedSessions.stream().anyMatch(PomEditSession::isDirty);
+    }
+
+    @Override
+    boolean save() {
+        for (PomEditSession session : mutatedSessions) {
+            if (session.isDirty()) {
+                PomEditSession.SaveResult result = session.save();
+                if (!result.success()) {
+                    status = result.message();
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     // -- Version resolution --
@@ -611,6 +632,20 @@ public class UpdatesTui extends ToolPanel {
             return true;
         }
 
+        // Pending quit confirmation
+        if (pendingQuit) {
+            if (key.isCharIgnoreCase('y')) {
+                if (save()) runner.quit();
+                else pendingQuit = false;
+            } else if (key.isCharIgnoreCase('n')) {
+                runner.quit();
+            } else if (key.isKey(KeyCode.ESCAPE)) {
+                pendingQuit = false;
+                status = "";
+            }
+            return true;
+        }
+
         // Diff overlay in standalone — allow q to quit
         if (diffOverlay.isActive()) {
             if (key.isKey(KeyCode.ESCAPE)) {
@@ -619,7 +654,7 @@ public class UpdatesTui extends ToolPanel {
             }
             if (diffOverlay.handleScrollKey(key, lastContentHeight)) return true;
             if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
-                runner.quit();
+                requestQuit();
                 return true;
             }
             return false;
@@ -629,14 +664,14 @@ public class UpdatesTui extends ToolPanel {
         if (helpOverlay.isActive()) {
             if (helpOverlay.handleKey(key)) return true;
             if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
-                runner.quit();
+                requestQuit();
                 return true;
             }
             return false;
         }
 
         if (key.isCtrlC()) {
-            runner.quit();
+            requestQuit();
             return true;
         }
 
@@ -653,7 +688,7 @@ public class UpdatesTui extends ToolPanel {
 
         // Standalone-specific keys
         if (key.isCharIgnoreCase('q') || key.isKey(KeyCode.ESCAPE)) {
-            runner.quit();
+            requestQuit();
             return true;
         }
 
@@ -865,6 +900,7 @@ public class UpdatesTui extends ToolPanel {
         var row = displayRows.get(sel);
         if (row.isGroupHeader()) {
             var group = row.propertyGroup;
+            if (group.applied) return;
             boolean newState = !group.selected;
             group.selected = newState;
             for (var dep : group.dependencies) {
@@ -872,6 +908,7 @@ public class UpdatesTui extends ToolPanel {
             }
         } else if (row.dependency != null && row.dependency.hasUpdate()) {
             var dep = row.dependency;
+            if (dep.applied) return;
             boolean newState = !dep.selected;
             dep.selected = newState;
             // If part of a property group, toggle the whole group
@@ -891,12 +928,15 @@ public class UpdatesTui extends ToolPanel {
 
     private void selectAll() {
         for (var row : displayRows) {
-            if (row.isGroupHeader() && row.propertyGroup.hasUpdate()) {
+            if (row.isGroupHeader() && row.propertyGroup.hasUpdate() && !row.propertyGroup.applied) {
                 row.propertyGroup.selected = true;
                 for (var dep : row.propertyGroup.dependencies) {
                     dep.selected = true;
                 }
-            } else if (row.dependency != null && !row.dependency.isPropertyManaged() && row.dependency.hasUpdate()) {
+            } else if (row.dependency != null
+                    && !row.dependency.isPropertyManaged()
+                    && row.dependency.hasUpdate()
+                    && !row.dependency.applied) {
                 row.dependency.selected = true;
             }
         }
@@ -949,16 +989,25 @@ public class UpdatesTui extends ToolPanel {
             }
         }
 
+        // If nothing selected, show diff of already-applied changes
         if (previewEditors.isEmpty()) {
-            status = "No updates selected";
-            return;
-        }
-
-        for (var entry : previewEditors.entrySet()) {
-            PomEditSession session = sessionProvider.apply(entry.getKey());
-            String original = session.originalContent();
-            String modified = entry.getValue().toXml();
-            fileDiffs.put(entry.getKey().toString(), Map.entry(original, modified));
+            for (PomEditSession session : mutatedSessions) {
+                if (session.isDirty()) {
+                    fileDiffs.put(
+                            session.pomPath().toString(), Map.entry(session.originalContent(), session.currentXml()));
+                }
+            }
+            if (fileDiffs.isEmpty()) {
+                status = "No updates selected";
+                return;
+            }
+        } else {
+            for (var entry : previewEditors.entrySet()) {
+                PomEditSession session = sessionProvider.apply(entry.getKey());
+                String original = session.originalContent();
+                String modified = entry.getValue().toXml();
+                fileDiffs.put(entry.getKey().toString(), Map.entry(original, modified));
+            }
         }
 
         long changes = diffOverlay.openMulti(fileDiffs);
@@ -1047,28 +1096,31 @@ public class UpdatesTui extends ToolPanel {
         return count;
     }
 
-    private void clearAppliedUpdates() {
+    private void markAppliedUpdates() {
         for (var group : reactorResult.propertyGroups) {
             if (group.selected && group.hasUpdate()) {
-                group.resolvedVersion = group.newestVersion;
-                group.newestVersion = null;
+                group.applied = true;
                 group.selected = false;
-                group.updateType = null;
                 for (var dep : group.dependencies) {
-                    dep.primaryVersion = group.resolvedVersion;
-                    dep.newestVersion = null;
+                    dep.applied = true;
                     dep.selected = false;
-                    dep.updateType = null;
                 }
             }
         }
         for (var dep : reactorResult.ungroupedDependencies) {
             if (dep.selected && dep.hasUpdate()) {
-                dep.primaryVersion = dep.newestVersion;
-                dep.newestVersion = null;
+                dep.applied = true;
                 dep.selected = false;
-                dep.updateType = null;
             }
+        }
+    }
+
+    private void requestQuit() {
+        if (isDirty()) {
+            pendingQuit = true;
+            status = "Save changes to POM? (y/n/Esc)";
+        } else {
+            runner.quit();
         }
     }
 
@@ -1097,22 +1149,11 @@ public class UpdatesTui extends ToolPanel {
             int totalUpdates = applyPropertyChanges(propertyUpdates, sessions);
             totalUpdates += applyDependencyChanges(depUpdates, sessions);
 
-            // Save all modified sessions
-            int updatedFiles = 0;
-            for (PomEditSession session : sessions.values()) {
-                PomEditSession.SaveResult result = session.save();
-                if (result.success()) {
-                    updatedFiles++;
-                } else {
-                    status = result.message();
-                    return;
-                }
-            }
-
-            clearAppliedUpdates();
+            mutatedSessions.addAll(sessions.values());
+            markAppliedUpdates();
             updateReactorCounts();
             buildDisplayRows();
-            status = "Applied " + totalUpdates + " update(s) to " + updatedFiles + " POM file(s)";
+            status = "Applied " + totalUpdates + " update(s) — save on exit";
         } catch (Exception e) {
             status = "Failed to apply: " + e.getMessage();
         }
@@ -1238,7 +1279,7 @@ public class UpdatesTui extends ToolPanel {
 
     private Row createGroupHeaderRow(ReactorRow row, boolean highlight) {
         var group = row.propertyGroup;
-        String check = group.selected ? "[✓]" : "[ ]";
+        String check = group.applied ? "[·]" : (group.selected ? "[✓]" : "[ ]");
         String name = (group.expanded ? "▾ " : "▸ ") + "${" + group.propertyName + "}";
         if (duplicatePropertyNames.contains(group.propertyName)) {
             name += " (" + group.origin.artifactId + ")";
@@ -1250,7 +1291,7 @@ public class UpdatesTui extends ToolPanel {
         String age = formatAge(group.libYears, group.hasUpdate());
         String info = singleModule ? "" : group.totalModuleCount() + " mod";
 
-        Style style = updateTypeStyle(group.updateType);
+        Style style = group.applied ? Style.create().dim() : updateTypeStyle(group.updateType);
         if (highlight) style = style.bg(theme.searchHighlightBg());
         return Row.from(check, name, current, arrow, available, type, age, info).style(style);
     }
@@ -1266,21 +1307,21 @@ public class UpdatesTui extends ToolPanel {
     private Row createGroupedDependencyRow(ReactorCollector.AggregatedDependency dep, boolean highlight) {
         String check = "   ";
         String ga = "  ↳ " + dep.artifactId;
-        Style style = Style.create();
+        Style style = dep.applied ? Style.create().dim() : Style.create();
         if (highlight) style = style.bg(theme.searchHighlightBg());
         String info = buildModuleInfo(dep);
         return Row.from(check, ga, "", "", "", "", "", info).style(style);
     }
 
     private Row createStandaloneDependencyRow(ReactorCollector.AggregatedDependency dep, boolean highlight) {
-        String check = dep.selected ? "[✓]" : "[ ]";
+        String check = dep.applied ? "[·]" : (dep.selected ? "[✓]" : "[ ]");
         String ga = dep.artifactId;
         String current = dep.primaryVersion != null ? dep.primaryVersion : "";
         String arrow = dep.hasUpdate() ? "→" : "";
         String available = dep.hasUpdate() ? dep.newestVersion : "";
         String type = updateTypeLabel(dep.updateType);
         String age = formatAge(dep.libYears, dep.hasUpdate());
-        Style style = updateTypeStyle(dep.updateType);
+        Style style = dep.applied ? Style.create().dim() : updateTypeStyle(dep.updateType);
         if (highlight) style = style.bg(theme.searchHighlightBg());
         String info = buildModuleInfo(dep);
         return Row.from(check, ga, current, arrow, available, type, age, info).style(style);
@@ -1521,9 +1562,14 @@ public class UpdatesTui extends ToolPanel {
         long selectedCount = reactorResult.allDependencies.stream()
                 .filter(d -> d.selected && d.hasUpdate())
                 .count();
+        long appliedCount =
+                reactorResult.allDependencies.stream().filter(d -> d.applied).count();
         if (selectedCount > 0) {
             statusSpans.add(
                     Span.raw("  " + selectedCount + " update(s) selected").fg(theme.selectedCountColor()));
+        }
+        if (appliedCount > 0) {
+            statusSpans.add(Span.raw("  " + appliedCount + " applied").dim());
         }
         frame.renderWidget(Paragraph.from(Line.from(statusSpans)), rows.get(1));
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -957,26 +957,40 @@ public class UpdatesTui extends ToolPanel {
     // -- Diff preview --
 
     private void toggleDiffView() {
-        Map<String, Map.Entry<String, String>> fileDiffs = new LinkedHashMap<>();
+        Map<Path, PomEditor> previewEditors = buildPreviewEditors();
 
-        // Build preview editors from session state (not disk)
-        Map<Path, PomEditor> previewEditors = new LinkedHashMap<>();
+        Map<String, Map.Entry<String, String>> fileDiffs;
+        if (previewEditors.isEmpty()) {
+            fileDiffs = collectAppliedDiffs();
+            if (fileDiffs.isEmpty()) {
+                status = "No updates selected";
+                return;
+            }
+        } else {
+            fileDiffs = collectPreviewDiffs(previewEditors);
+        }
 
+        long changes = diffOverlay.openMulti(fileDiffs);
+        status = changes == 0
+                ? "No changes to show"
+                : changes + " line(s) changed across " + fileDiffs.size() + " file(s)";
+    }
+
+    private Map<Path, PomEditor> buildPreviewEditors() {
+        Map<Path, PomEditor> editors = new LinkedHashMap<>();
         for (var group : reactorResult.propertyGroups) {
             if (group.selected && group.hasUpdate()) {
-                Path pomPath = group.origin.pomPath;
-                PomEditor editor = previewEditors.computeIfAbsent(pomPath, p -> {
+                PomEditor editor = editors.computeIfAbsent(group.origin.pomPath, p -> {
                     PomEditSession session = sessionProvider.apply(p);
                     return new PomEditor(Document.of(session.currentXml()));
                 });
                 editor.properties().updateProperty(true, group.propertyName, group.newestVersion);
             }
         }
-
         for (var dep : reactorResult.ungroupedDependencies) {
             if (dep.selected && dep.hasUpdate() && !dep.usages.isEmpty()) {
                 var loc = findUpdateLocation(dep);
-                PomEditor editor = previewEditors.computeIfAbsent(loc.pomPath, p -> {
+                PomEditor editor = editors.computeIfAbsent(loc.pomPath, p -> {
                     PomEditSession session = sessionProvider.apply(p);
                     return new PomEditor(Document.of(session.currentXml()));
                 });
@@ -988,32 +1002,28 @@ public class UpdatesTui extends ToolPanel {
                 }
             }
         }
+        return editors;
+    }
 
-        // If nothing selected, show diff of already-applied changes
-        if (previewEditors.isEmpty()) {
-            for (PomEditSession session : mutatedSessions) {
-                if (session.isDirty()) {
-                    fileDiffs.put(
-                            session.pomPath().toString(), Map.entry(session.originalContent(), session.currentXml()));
-                }
-            }
-            if (fileDiffs.isEmpty()) {
-                status = "No updates selected";
-                return;
-            }
-        } else {
-            for (var entry : previewEditors.entrySet()) {
-                PomEditSession session = sessionProvider.apply(entry.getKey());
-                String original = session.originalContent();
-                String modified = entry.getValue().toXml();
-                fileDiffs.put(entry.getKey().toString(), Map.entry(original, modified));
+    private Map<String, Map.Entry<String, String>> collectAppliedDiffs() {
+        Map<String, Map.Entry<String, String>> diffs = new LinkedHashMap<>();
+        for (PomEditSession session : mutatedSessions) {
+            if (session.isDirty()) {
+                diffs.put(session.pomPath().toString(), Map.entry(session.originalContent(), session.currentXml()));
             }
         }
+        return diffs;
+    }
 
-        long changes = diffOverlay.openMulti(fileDiffs);
-        status = changes == 0
-                ? "No changes to show"
-                : changes + " line(s) changed across " + fileDiffs.size() + " file(s)";
+    private Map<String, Map.Entry<String, String>> collectPreviewDiffs(Map<Path, PomEditor> previewEditors) {
+        Map<String, Map.Entry<String, String>> diffs = new LinkedHashMap<>();
+        for (var entry : previewEditors.entrySet()) {
+            PomEditSession session = sessionProvider.apply(entry.getKey());
+            String original = session.originalContent();
+            String modified = entry.getValue().toXml();
+            diffs.put(entry.getKey().toString(), Map.entry(original, modified));
+        }
+        return diffs;
     }
 
     // -- Apply --

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -1279,7 +1279,14 @@ public class UpdatesTui extends ToolPanel {
 
     private Row createGroupHeaderRow(ReactorRow row, boolean highlight) {
         var group = row.propertyGroup;
-        String check = group.applied ? "[·]" : (group.selected ? "[✓]" : "[ ]");
+        String check;
+        if (group.applied) {
+            check = "[·]";
+        } else if (group.selected) {
+            check = "[✓]";
+        } else {
+            check = "[ ]";
+        }
         String name = (group.expanded ? "▾ " : "▸ ") + "${" + group.propertyName + "}";
         if (duplicatePropertyNames.contains(group.propertyName)) {
             name += " (" + group.origin.artifactId + ")";
@@ -1314,7 +1321,14 @@ public class UpdatesTui extends ToolPanel {
     }
 
     private Row createStandaloneDependencyRow(ReactorCollector.AggregatedDependency dep, boolean highlight) {
-        String check = dep.applied ? "[·]" : (dep.selected ? "[✓]" : "[ ]");
+        String check;
+        if (dep.applied) {
+            check = "[·]";
+        } else if (dep.selected) {
+            check = "[✓]";
+        } else {
+            check = "[ ]";
+        }
         String ga = dep.artifactId;
         String current = dep.primaryVersion != null ? dep.primaryVersion : "";
         String arrow = dep.hasUpdate() ? "→" : "";

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -641,7 +641,7 @@ public class UpdatesTui extends ToolPanel {
                 runner.quit();
             } else if (key.isKey(KeyCode.ESCAPE)) {
                 pendingQuit = false;
-                status = "";
+                updateStatusIfDone();
             }
             return true;
         }

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/AuditDemoTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/AuditDemoTest.java
@@ -74,16 +74,7 @@ class AuditDemoTest {
             // Initial view: Licenses tab active
             String rendered = renderToText(tui::renderStandalone);
             assertThat(rendered).contains("\u25B8 Licenses");
-            assertThat(rendered).doesNotContain("\u25B8 By License");
             assertThat(rendered).doesNotContain("\u25B8 Vulnerabilities");
-
-            // Switch to By License view
-            pilot.press(KeyCode.TAB);
-            pilot.pause();
-
-            rendered = renderToText(tui::renderStandalone);
-            assertThat(rendered).contains("\u25B8 By License");
-            assertThat(rendered).doesNotContain("\u25B8 Licenses");
 
             // Switch to Vulnerabilities view
             pilot.press(KeyCode.TAB);
@@ -91,7 +82,7 @@ class AuditDemoTest {
 
             rendered = renderToText(tui::renderStandalone);
             assertThat(rendered).contains("\u25B8 Vulnerabilities");
-            assertThat(rendered).doesNotContain("\u25B8 By License");
+            assertThat(rendered).doesNotContain("\u25B8 Licenses");
 
             // Switch back to Licenses view
             pilot.press(KeyCode.TAB);
@@ -119,14 +110,14 @@ class AuditDemoTest {
             // Verify tab bar renders even with empty data
             String rendered = renderToText(tui::renderStandalone);
             assertThat(rendered).contains("\u25B8 Licenses");
-            assertThat(rendered).doesNotContain("\u25B8 By License");
+            assertThat(rendered).doesNotContain("\u25B8 Vulnerabilities");
 
             // Switch views on empty data
             pilot.press(KeyCode.TAB);
             pilot.pause();
 
             rendered = renderToText(tui::renderStandalone);
-            assertThat(rendered).contains("\u25B8 By License");
+            assertThat(rendered).contains("\u25B8 Vulnerabilities");
             assertThat(rendered).doesNotContain("\u25B8 Licenses");
 
             pilot.press('q');

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/AuditTuiTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/AuditTuiTest.java
@@ -532,7 +532,6 @@ class AuditTuiTest {
 
             // Navigate to Vulnerabilities tab
             pilot.press(KeyCode.TAB);
-            pilot.press(KeyCode.TAB);
             pilot.pause();
 
             // Exercise detail pane rendering with the published date
@@ -560,7 +559,6 @@ class AuditTuiTest {
 
             // Navigate to Vulnerabilities tab — should not crash with null date
             pilot.press(KeyCode.TAB);
-            pilot.press(KeyCode.TAB);
             pilot.pause();
 
             // Exercise detail pane rendering — should not crash with null date
@@ -587,7 +585,6 @@ class AuditTuiTest {
             var pilot = testRunner.pilot();
 
             // Navigate to Vulnerabilities tab and select the entry to render detail pane
-            pilot.press(KeyCode.TAB);
             pilot.press(KeyCode.TAB);
             pilot.pause();
 
@@ -652,8 +649,7 @@ class AuditTuiTest {
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::renderStandalone, new Size(120, 30))) {
             var pilot = testRunner.pilot();
 
-            // Navigate to Vulnerabilities tab (Tab -> By License, Tab -> Vulnerabilities)
-            pilot.press(KeyCode.TAB);
+            // Navigate to Vulnerabilities tab
             pilot.press(KeyCode.TAB);
             pilot.pause();
 
@@ -699,7 +695,6 @@ class AuditTuiTest {
             pilot.pause();
 
             // Also test filtering on the vulnerabilities tab
-            pilot.press(KeyCode.TAB);
             pilot.press(KeyCode.TAB);
             pilot.press('s'); // compile — only CVE-2024-0002 visible
             pilot.pause();

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiRenderTest.java
@@ -383,23 +383,23 @@ class UpdatesTuiRenderTest {
     }
 
     @Test
-    void applyUpdatesRemovesAppliedDep() throws Exception {
+    void applyUpdatesShowsAppliedMarker() throws Exception {
         var tui = createTuiWithUpdates();
         tui.handleEvent(KeyEvent.ofChar(' '), null); // select first dep
         tui.handleEvent(KeyEvent.ofKey(KeyCode.ENTER), null);
 
         String output = render(tui::renderStandalone);
-        assertThat(output).doesNotContain("guava").contains("slf4j-api");
+        assertThat(output).contains("guava").contains("[·]").contains("slf4j-api");
     }
 
     @Test
-    void applyAllUpdatesShowsEmptyMessage() throws Exception {
+    void applyAllUpdatesShowsAllApplied() throws Exception {
         var tui = createTuiWithUpdates();
         tui.handleEvent(KeyEvent.ofChar('a'), null); // select all
         tui.handleEvent(KeyEvent.ofKey(KeyCode.ENTER), null);
 
         String output = render(tui::renderStandalone);
-        assertThat(output).contains("No updates available");
+        assertThat(output).contains("[·]").contains("applied");
     }
 
     // ── Diff overlay ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Merge Licenses + By License views**: Combined into a single Licenses view with `g` key toggle for flat/grouped display, reducing tab count from 3 to 2
- **Global sub-view selection**: Vulns/Licenses tab choice now persists across module switches instead of resetting per-panel
- **Shared audit entry caching**: `PilotEngine.auditEntryCache` shares loaded license/vuln data across panels, so switching modules skips already-fetched entries
- **Loading indicator UX**: Moved "Checking vulnerabilities…" from block title to inline after tabs in dim gray, preventing table header shift
- **Focus-aware placeholder border**: Loading placeholder panels now show cyan border when focused (matching other panels)
- **Sub-view tab support in ToolPanel**: Base class gains `subViewCount()`, `subViewNames()`, `activeSubView()`, `setActiveSubView()`, and `buildSubViewTabLine()` for consistent tab rendering

## Test plan

- [x] All 437 tests pass (`./mvnw test -B`)
- [ ] Manual: open audit on a multi-module project, verify Vulns/Licenses tabs with `Tab` key
- [ ] Manual: press `g` in Licenses view to toggle flat↔grouped display
- [ ] Manual: switch modules in tree — verify sub-view tab persists
- [ ] Manual: verify loading indicator appears inline after tabs in dim gray
- [ ] Manual: verify placeholder border is cyan when right pane has focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vulnerability grouping by CVE identity for easier management.
  * Dependency pinning status indicators in Conflicts view.
  * Session mutation tracking for smarter panel refreshing.

* **Bug Fixes**
  * Fixed license data re-fetching; cached entries are now properly reused.
  * Improved conflict pin state visualization and styling.

* **Changes**
  * Reorganized audit license view; removed separate tab and added grouped/flat toggle via 'g' key.
  * Applied dependency updates now marked for batch saving on exit instead of immediate removal.
  * Enhanced status indicators showing managed, pinned, and applied states across views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->