### PR TITLE
feat: tree detail pane, reactor dependencies view, UX improvements

### DIFF
--- a/pilot-cli/src/main/java/eu/maveniverse/maven/pilot/mvn4/Maven4PilotResolver.java
+++ b/pilot-cli/src/main/java/eu/maveniverse/maven/pilot/mvn4/Maven4PilotResolver.java
@@ -108,7 +108,8 @@ class Maven4PilotResolver implements PilotResolver {
             DependencyResolverResult result = resolver.resolve(request);
             return convertTree(result.getRoot());
         } catch (Exception e) {
-            // Return a minimal tree when collection fails (e.g., un-interpolated properties)
+            System.err.println("[Pilot] collectDependencies failed for " + model.getGroupId() + ":"
+                    + model.getArtifactId() + ": " + e);
             DependencyTreeModel.TreeNode root = new DependencyTreeModel.TreeNode(
                     model.getGroupId(),
                     model.getArtifactId(),
@@ -253,6 +254,11 @@ class Maven4PilotResolver implements PilotResolver {
 
         DependencyTreeModel.TreeNode treeNode =
                 new DependencyTreeModel.TreeNode(groupId, artifactId, classifier, version, scope, optional, depth);
+
+        try {
+            treeNode.repository = node.getRepository().map(r -> r.getId()).orElse(null);
+        } catch (UnsupportedOperationException ignored) {
+        }
 
         String nodeKey = treeNode.ga() + ":" + version;
         if (!visited.add(nodeKey)) {

--- a/pilot-cli/src/main/java/eu/maveniverse/maven/pilot/mvn4/Maven4PilotResolver.java
+++ b/pilot-cli/src/main/java/eu/maveniverse/maven/pilot/mvn4/Maven4PilotResolver.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Logger;
 import org.apache.maven.api.Artifact;
 import org.apache.maven.api.DependencyCoordinates;
 import org.apache.maven.api.DownloadedArtifact;
@@ -56,6 +57,8 @@ import org.apache.maven.api.services.xml.ModelXmlFactory;
  * is not available in the standalone API.
  */
 class Maven4PilotResolver implements PilotResolver {
+
+    private static final Logger LOGGER = Logger.getLogger(Maven4PilotResolver.class.getName());
 
     private final Session session;
     private final Map<String, Model> effectiveModels;
@@ -108,8 +111,8 @@ class Maven4PilotResolver implements PilotResolver {
             DependencyResolverResult result = resolver.resolve(request);
             return convertTree(result.getRoot());
         } catch (Exception e) {
-            System.err.println("[Pilot] collectDependencies failed for " + model.getGroupId() + ":"
-                    + model.getArtifactId() + ": " + e);
+            LOGGER.warning(
+                    "collectDependencies failed for " + model.getGroupId() + ":" + model.getArtifactId() + ": " + e);
             DependencyTreeModel.TreeNode root = new DependencyTreeModel.TreeNode(
                     model.getGroupId(),
                     model.getArtifactId(),
@@ -225,35 +228,7 @@ class Maven4PilotResolver implements PilotResolver {
     private static DependencyTreeModel.TreeNode convertNode(
             Node node, int depth, int[] counter, Set<String> visited, List<DependencyTreeModel.TreeNode> conflicts) {
         counter[0]++;
-
-        String groupId, artifactId, classifier, version, scope;
-        boolean optional = false;
-
-        if (node.getDependency() != null) {
-            var dep = node.getDependency();
-            groupId = dep.getGroupId();
-            artifactId = dep.getArtifactId();
-            classifier = dep.getClassifier() != null ? dep.getClassifier() : "";
-            version = dep.getVersion() != null ? dep.getVersion().toString() : "?";
-            scope = dep.getScope() != null ? dep.getScope().id() : "";
-            optional = dep.isOptional();
-        } else if (node.getArtifact() != null) {
-            Artifact a = node.getArtifact();
-            groupId = a.getGroupId();
-            artifactId = a.getArtifactId();
-            classifier = a.getClassifier() != null ? a.getClassifier() : "";
-            version = a.getVersion() != null ? a.getVersion().toString() : "?";
-            scope = "";
-        } else {
-            groupId = "?";
-            artifactId = "?";
-            classifier = "";
-            version = "?";
-            scope = "";
-        }
-
-        DependencyTreeModel.TreeNode treeNode =
-                new DependencyTreeModel.TreeNode(groupId, artifactId, classifier, version, scope, optional, depth);
+        DependencyTreeModel.TreeNode treeNode = createTreeNode(node, depth);
 
         try {
             treeNode.repository = node.getRepository().map(r -> r.getId()).orElse(null);
@@ -261,7 +236,7 @@ class Maven4PilotResolver implements PilotResolver {
             // Maven API does not guarantee getRepository() support on all node types
         }
 
-        String nodeKey = treeNode.ga() + ":" + version;
+        String nodeKey = treeNode.gav();
         if (!visited.add(nodeKey)) {
             return treeNode;
         }
@@ -272,5 +247,31 @@ class Maven4PilotResolver implements PilotResolver {
 
         visited.remove(nodeKey);
         return treeNode;
+    }
+
+    private static DependencyTreeModel.TreeNode createTreeNode(Node node, int depth) {
+        if (node.getDependency() != null) {
+            var dep = node.getDependency();
+            return new DependencyTreeModel.TreeNode(
+                    dep.getGroupId(),
+                    dep.getArtifactId(),
+                    dep.getClassifier() != null ? dep.getClassifier() : "",
+                    dep.getVersion() != null ? dep.getVersion().toString() : "?",
+                    dep.getScope() != null ? dep.getScope().id() : "",
+                    dep.isOptional(),
+                    depth);
+        }
+        if (node.getArtifact() != null) {
+            Artifact a = node.getArtifact();
+            return new DependencyTreeModel.TreeNode(
+                    a.getGroupId(),
+                    a.getArtifactId(),
+                    a.getClassifier() != null ? a.getClassifier() : "",
+                    a.getVersion() != null ? a.getVersion().toString() : "?",
+                    "",
+                    false,
+                    depth);
+        }
+        return new DependencyTreeModel.TreeNode("?", "?", "", "?", "", false, depth);
     }
 }

--- a/pilot-cli/src/main/java/eu/maveniverse/maven/pilot/mvn4/Maven4PilotResolver.java
+++ b/pilot-cli/src/main/java/eu/maveniverse/maven/pilot/mvn4/Maven4PilotResolver.java
@@ -258,6 +258,7 @@ class Maven4PilotResolver implements PilotResolver {
         try {
             treeNode.repository = node.getRepository().map(r -> r.getId()).orElse(null);
         } catch (UnsupportedOperationException ignored) {
+            // Maven API does not guarantee getRepository() support on all node types
         }
 
         String nodeKey = treeNode.ga() + ":" + version;

--- a/pilot-cli/src/test/java/eu/maveniverse/maven/pilot/mvn4/LoadReactorTest.java
+++ b/pilot-cli/src/test/java/eu/maveniverse/maven/pilot/mvn4/LoadReactorTest.java
@@ -48,8 +48,8 @@ class LoadReactorTest {
         for (PilotProject p : reactor.projectsByPomPath().values()) {
             System.out.println("  " + p.gav());
 
-            var panel = reactor.engine().createPanel("tree", p, List.of(p));
-            assertNotNull(panel, "Tree panel should not be null for " + p.ga());
+            var panel = reactor.engine().createPanel("dependencies", p, List.of(p));
+            assertNotNull(panel, "Dependencies panel should not be null for " + p.ga());
         }
     }
 }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ClassFileScanner.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ClassFileScanner.java
@@ -77,8 +77,8 @@ public final class ClassFileScanner {
                                 .computeIfAbsent(entry.getKey(), k -> new HashSet<>())
                                 .addAll(entry.getValue());
                     }
-                } catch (IOException ignored) {
-                    // skip corrupt or unreadable class files
+                } catch (IOException | IllegalArgumentException ignored) {
+                    // skip corrupt, unreadable, or unsupported class file versions
                 }
             });
         }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -514,15 +514,18 @@ public class DependenciesTui extends ToolPanel {
             return true; // consume all keys during overlay
         }
 
-        // Tab always cycles views (before delegation to treeTui)
-        if (key.isKey(KeyCode.TAB)) {
-            view = TabBar.next(view, views);
-            if (view != View.TREE) {
-                tableState.select(0);
-                clearSearch();
-                sortState = new SortState(sortColumnCount());
+        // Number keys switch sub-views
+        if (key.code() == KeyCode.CHAR && key.character() >= '1' && key.character() <= '9') {
+            int idx = key.character() - '1';
+            if (idx < views.length && views[idx] != view) {
+                view = views[idx];
+                if (view != View.TREE) {
+                    tableState.select(0);
+                    clearSearch();
+                    sortState = new SortState(sortColumnCount());
+                }
+                return true;
             }
-            return true;
         }
 
         // Tree view: delegate to TreeTui
@@ -736,7 +739,7 @@ public class DependenciesTui extends ToolPanel {
 
                 ## Dependencies Actions
                 ↑ / ↓           Move selection up / down
-                Tab             Switch Declared / Transitive / Managed view
+                1-4             Switch Declared / Transitive / Managed view
                 x / Enter       Remove selected (Declared view)
                 a / Enter       Add to POM (Transitive view)
                 x               Remove managed entry (Managed view)
@@ -1108,7 +1111,7 @@ public class DependenciesTui extends ToolPanel {
         sections.addAll(HelpOverlay.parse("""
                 ## General
                 """ + NAV_KEYS + """
-                Tab             Switch between Declared, Transitive, and Managed views
+                1-4             Switch between Declared, Transitive, and Managed views
                 d               Preview POM changes as a unified diff
                 h               Toggle this help screen
                 q / Esc         Quit (prompts to save if modified)
@@ -1212,8 +1215,10 @@ public class DependenciesTui extends ToolPanel {
         String managedLabel = "Managed: " + managed.size();
         spans.addAll(TabBar.render(view, views, v -> switch (v) {
             case TREE -> "Tree: " + (treeTui != null ? treeTui.nodeCount() : 0);
-            case DECLARED, UNUSED_DECLARED -> declaredLabel;
-            case TRANSITIVE, USED_TRANSITIVE -> transitiveLabel;
+            case DECLARED -> declaredLabel;
+            case TRANSITIVE -> transitiveLabel;
+            case UNUSED_DECLARED -> "Unused Declared: " + declared.size();
+            case USED_TRANSITIVE -> "Used Transitive: " + transitive.size();
             case MANAGED -> managedLabel;
         }));
 
@@ -1353,7 +1358,7 @@ public class DependenciesTui extends ToolPanel {
         if (reactorMode) {
             String icon = usageIcon(dep);
             String modules = String.join(", ", dep.modules);
-            return Row.from(icon, dep.ga(), dep.version, modules).style(usageRowStyle(dep));
+            return Row.from(icon, dep.ga(), dep.version, modules);
         }
         String via = dep.pulledBy != null ? "(via " + dep.pulledBy + ")" : "";
         if (bytecodeAnalyzed) {
@@ -1372,8 +1377,7 @@ public class DependenciesTui extends ToolPanel {
         if (reactorMode) {
             String icon = usageIcon(dep);
             String modules = String.join(", ", dep.modules);
-            return Row.from(icon, dep.ga(), dep.version, modules)
-                    .style(usageRowStyle(dep).bg(theme.searchHighlightBg()));
+            return Row.from(icon, dep.ga(), dep.version, modules).style(theme.searchHighlight());
         }
         String via = dep.pulledBy != null ? "(via " + dep.pulledBy + ")" : "";
         if (bytecodeAnalyzed) {
@@ -1585,7 +1589,7 @@ public class DependenciesTui extends ToolPanel {
         } else {
             spans.add(Span.raw("↑↓").bold());
             spans.add(Span.raw(":Navigate  "));
-            spans.add(Span.raw("Tab").bold());
+            spans.add(Span.raw("1-" + views.length).bold());
             spans.add(Span.raw(":Switch view  "));
             if (view == View.DECLARED) {
                 spans.add(Span.raw("x/Enter").bold());

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -82,6 +82,7 @@ public class DependenciesTui extends ToolPanel {
         public Map<String, List<String>> usedMembers; // class -> list of member references (methods/fields)
         public int totalClasses; // total classes provided by this dep
         public List<String> spiServices; // SPI service interfaces provided by this dep
+        public final List<String> modules = new ArrayList<>(); // reactor mode: which modules have this dep
 
         /**
          * Creates a DepEntry representing a dependency row in the TUI.
@@ -214,7 +215,9 @@ public class DependenciesTui extends ToolPanel {
         TREE,
         DECLARED,
         TRANSITIVE,
-        MANAGED
+        MANAGED,
+        UNUSED_DECLARED,
+        USED_TRANSITIVE
     }
 
     private final TreeTui treeTui;
@@ -224,6 +227,7 @@ public class DependenciesTui extends ToolPanel {
     private final List<ManagedEntry> managed;
     private final String projectGav;
     private final boolean bytecodeAnalyzed;
+    private final boolean reactorMode;
     private final TableState tableState = new TableState();
 
     private View view = View.DECLARED;
@@ -309,12 +313,41 @@ public class DependenciesTui extends ToolPanel {
         this.managed = managed;
         this.projectGav = projectGav;
         this.bytecodeAnalyzed = bytecodeAnalyzed;
+        this.reactorMode = false;
         this.treeTui = treeTui;
-        this.views = treeTui != null ? View.values() : new View[] {View.DECLARED, View.TRANSITIVE, View.MANAGED};
+        this.views = treeTui != null
+                ? new View[] {View.TREE, View.DECLARED, View.TRANSITIVE, View.MANAGED}
+                : new View[] {View.DECLARED, View.TRANSITIVE, View.MANAGED};
         this.view = views[0];
         this.sortState = view != View.TREE ? new SortState(sortColumnCount()) : null;
         updateStatus();
         if (!declared.isEmpty()) {
+            tableState.select(0);
+        }
+    }
+
+    /** Reactor-mode constructor — aggregated dependency hygiene issues across modules. */
+    public DependenciesTui(
+            List<DepEntry> unusedDeclared,
+            List<DepEntry> usedTransitive,
+            String projectGav,
+            int modulesScanned,
+            int modulesSkipped) {
+        this.editSession = null;
+        this.declared = unusedDeclared;
+        this.transitive = usedTransitive;
+        this.managed = List.of();
+        this.projectGav = projectGav;
+        this.bytecodeAnalyzed = true;
+        this.reactorMode = true;
+        this.treeTui = null;
+        this.views = new View[] {View.UNUSED_DECLARED, View.USED_TRANSITIVE};
+        this.view = views[0];
+        this.sortState = new SortState(sortColumnCount());
+        this.status = modulesScanned + " modules scanned"
+                + (modulesSkipped > 0 ? " (" + modulesSkipped + " skipped — not compiled)" : "") + ", "
+                + unusedDeclared.size() + " unused declared, " + usedTransitive.size() + " used transitive";
+        if (!unusedDeclared.isEmpty()) {
             tableState.select(0);
         }
     }
@@ -520,6 +553,10 @@ public class DependenciesTui extends ToolPanel {
             return false;
         }
 
+        if (reactorMode) {
+            return false;
+        }
+
         if (key.isKey(KeyCode.ENTER)) {
             fixSelected();
             return true;
@@ -609,6 +646,8 @@ public class DependenciesTui extends ToolPanel {
                         case DECLARED -> "Declared: " + declared.size();
                         case TRANSITIVE -> "Transitive: " + transitive.size();
                         case MANAGED -> "Managed: " + managed.size();
+                        case UNUSED_DECLARED -> "Unused Declared: " + declared.size();
+                        case USED_TRANSITIVE -> "Used Transitive: " + transitive.size();
                     });
         }
         return names;
@@ -732,19 +771,24 @@ public class DependenciesTui extends ToolPanel {
     }
 
     private List<DepEntry> currentList() {
-        return view == View.DECLARED ? declared : transitive;
+        return switch (view) {
+            case DECLARED, UNUSED_DECLARED -> declared;
+            case TRANSITIVE, USED_TRANSITIVE -> transitive;
+            default -> declared;
+        };
     }
 
     private int currentListSize() {
         return switch (view) {
             case TREE -> 0;
-            case DECLARED -> declared.size();
-            case TRANSITIVE -> transitive.size();
+            case DECLARED, UNUSED_DECLARED -> declared.size();
+            case TRANSITIVE, USED_TRANSITIVE -> transitive.size();
             case MANAGED -> managed.size();
         };
     }
 
     private int sortColumnCount() {
+        if (reactorMode) return 4; // icon, ga, version, modules
         int count = 3; // ga, version, scope
         if (bytecodeAnalyzed) count++; // icon column
         if (view == View.TRANSITIVE) count++; // pulled by column
@@ -758,9 +802,13 @@ public class DependenciesTui extends ToolPanel {
         }
         extractors.add(DepEntry::ga);
         extractors.add(dep -> dep.version);
-        extractors.add(dep -> dep.scope);
-        if (view == View.TRANSITIVE) {
-            extractors.add(dep -> dep.pulledBy != null ? dep.pulledBy : "");
+        if (reactorMode) {
+            extractors.add(dep -> String.join(", ", dep.modules));
+        } else {
+            extractors.add(dep -> dep.scope);
+            if (view == View.TRANSITIVE) {
+                extractors.add(dep -> dep.pulledBy != null ? dep.pulledBy : "");
+            }
         }
         return extractors;
     }
@@ -1164,8 +1212,8 @@ public class DependenciesTui extends ToolPanel {
         String managedLabel = "Managed: " + managed.size();
         spans.addAll(TabBar.render(view, views, v -> switch (v) {
             case TREE -> "Tree: " + (treeTui != null ? treeTui.nodeCount() : 0);
-            case DECLARED -> declaredLabel;
-            case TRANSITIVE -> transitiveLabel;
+            case DECLARED, UNUSED_DECLARED -> declaredLabel;
+            case TRANSITIVE, USED_TRANSITIVE -> transitiveLabel;
             case MANAGED -> managedLabel;
         }));
 
@@ -1292,12 +1340,21 @@ public class DependenciesTui extends ToolPanel {
         if (bytecodeAnalyzed) headers.add("");
         headers.add(COL_GA);
         headers.add(COL_VERSION);
-        headers.add(COL_SCOPE);
-        if (view == View.TRANSITIVE) headers.add("pulled by");
+        if (reactorMode) {
+            headers.add("modules");
+        } else {
+            headers.add(COL_SCOPE);
+            if (view == View.TRANSITIVE) headers.add("pulled by");
+        }
         return sortState.decorateHeader(headers, theme.tableHeader());
     }
 
     private Row buildRow(DepEntry dep) {
+        if (reactorMode) {
+            String icon = usageIcon(dep);
+            String modules = String.join(", ", dep.modules);
+            return Row.from(icon, dep.ga(), dep.version, modules).style(usageRowStyle(dep));
+        }
         String via = dep.pulledBy != null ? "(via " + dep.pulledBy + ")" : "";
         if (bytecodeAnalyzed) {
             String icon = usageIcon(dep);
@@ -1312,6 +1369,12 @@ public class DependenciesTui extends ToolPanel {
     }
 
     private Row buildSearchRow(DepEntry dep) {
+        if (reactorMode) {
+            String icon = usageIcon(dep);
+            String modules = String.join(", ", dep.modules);
+            return Row.from(icon, dep.ga(), dep.version, modules)
+                    .style(usageRowStyle(dep).bg(theme.searchHighlightBg()));
+        }
         String via = dep.pulledBy != null ? "(via " + dep.pulledBy + ")" : "";
         if (bytecodeAnalyzed) {
             String icon = usageIcon(dep);
@@ -1327,6 +1390,11 @@ public class DependenciesTui extends ToolPanel {
     }
 
     private Constraint[] getTableWidths() {
+        if (reactorMode) {
+            return new Constraint[] {
+                Constraint.length(4), Constraint.percentage(35), Constraint.percentage(15), Constraint.percentage(46)
+            };
+        }
         if (bytecodeAnalyzed) {
             return (view == View.DECLARED)
                     ? new Constraint[] {
@@ -1413,6 +1481,16 @@ public class DependenciesTui extends ToolPanel {
 
         List<Line> lines = new ArrayList<>();
         lines.add(Line.from(spans));
+
+        if (!dep.modules.isEmpty()) {
+            List<Span> moduleSpans = new ArrayList<>();
+            moduleSpans.add(Span.raw(" Modules (" + dep.modules.size() + "): ").bold());
+            for (int i = 0; i < dep.modules.size(); i++) {
+                if (i > 0) moduleSpans.add(Span.raw(", ").fg(theme.detailSeparatorColor()));
+                moduleSpans.add(Span.raw(dep.modules.get(i)).cyan());
+            }
+            lines.add(Line.from(moduleSpans));
+        }
 
         int maxLines = Math.max(1, area.height() - 4);
         int lineCount = 0;

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -211,11 +211,14 @@ public class DependenciesTui extends ToolPanel {
     }
 
     private enum View {
+        TREE,
         DECLARED,
         TRANSITIVE,
         MANAGED
     }
 
+    private final TreeTui treeTui;
+    private final View[] views;
     private final List<DepEntry> declared;
     private final List<DepEntry> transitive;
     private final List<ManagedEntry> managed;
@@ -288,13 +291,28 @@ public class DependenciesTui extends ToolPanel {
             PomEditSession session,
             String projectGav,
             boolean bytecodeAnalyzed) {
+        this(declared, transitive, managed, session, projectGav, bytecodeAnalyzed, null);
+    }
+
+    /** Panel-mode constructor with embedded tree view. */
+    public DependenciesTui(
+            List<DepEntry> declared,
+            List<DepEntry> transitive,
+            List<ManagedEntry> managed,
+            PomEditSession session,
+            String projectGav,
+            boolean bytecodeAnalyzed,
+            TreeTui treeTui) {
         this.editSession = session;
         this.declared = declared;
         this.transitive = transitive;
         this.managed = managed;
         this.projectGav = projectGav;
         this.bytecodeAnalyzed = bytecodeAnalyzed;
-        this.sortState = new SortState(sortColumnCount());
+        this.treeTui = treeTui;
+        this.views = treeTui != null ? View.values() : new View[] {View.DECLARED, View.TRANSITIVE, View.MANAGED};
+        this.view = views[0];
+        this.sortState = view != View.TREE ? new SortState(sortColumnCount()) : null;
         updateStatus();
         if (!declared.isEmpty()) {
             tableState.select(0);
@@ -433,6 +451,10 @@ public class DependenciesTui extends ToolPanel {
             return;
         }
         Rect contentArea = renderTabBar(frame, area);
+        if (view == View.TREE && treeTui != null) {
+            treeTui.render(frame, contentArea);
+            return;
+        }
         if (view == View.MANAGED) {
             lastContentHeight = contentArea.height();
             renderManagedTable(frame, contentArea);
@@ -459,6 +481,22 @@ public class DependenciesTui extends ToolPanel {
             return true; // consume all keys during overlay
         }
 
+        // Tab always cycles views (before delegation to treeTui)
+        if (key.isKey(KeyCode.TAB)) {
+            view = TabBar.next(view, views);
+            if (view != View.TREE) {
+                tableState.select(0);
+                clearSearch();
+                sortState = new SortState(sortColumnCount());
+            }
+            return true;
+        }
+
+        // Tree view: delegate to TreeTui
+        if (view == View.TREE && treeTui != null) {
+            return treeTui.handleKeyEvent(key);
+        }
+
         if (handleSearchInput(key)) return true;
         if (handleSortInput(key)) return true;
 
@@ -471,12 +509,6 @@ public class DependenciesTui extends ToolPanel {
             return true;
         }
         if (TableNavigation.handlePageKeys(key, tableState, currentListSize(), lastContentHeight)) {
-            return true;
-        }
-
-        if (key.isKey(KeyCode.TAB)) {
-            view = TabBar.next(view, View.values());
-            tableState.select(0);
             return true;
         }
 
@@ -519,6 +551,9 @@ public class DependenciesTui extends ToolPanel {
     @Override
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
         if (handleMouseTabBar(mouse)) return true;
+        if (view == View.TREE && treeTui != null) {
+            return treeTui.handleMouseEvent(mouse, area);
+        }
         if (view != View.MANAGED && handleMouseSortHeader(mouse, List.of(getTableWidths()))) return true;
         if (mouse.isClick()) {
             int row = mouseToTableRow(mouse, currentListSize(), tableState);
@@ -543,30 +578,47 @@ public class DependenciesTui extends ToolPanel {
 
     @Override
     int subViewCount() {
-        return 3;
+        return views.length;
     }
 
     @Override
     int activeSubView() {
-        return view.ordinal();
+        for (int i = 0; i < views.length; i++) {
+            if (views[i] == view) return i;
+        }
+        return 0;
     }
 
     @Override
     void setActiveSubView(int index) {
-        view = View.values()[index];
-        tableState.select(0);
-        clearSearch();
-        sortState = new SortState(sortColumnCount());
+        view = views[index];
+        if (view != View.TREE) {
+            tableState.select(0);
+            clearSearch();
+            sortState = new SortState(sortColumnCount());
+        }
     }
 
     @Override
     List<String> subViewNames() {
-        return List.of(
-                "Declared: " + declared.size(), "Transitive: " + transitive.size(), "Managed: " + managed.size());
+        List<String> names = new ArrayList<>();
+        for (View v : views) {
+            names.add(
+                    switch (v) {
+                        case TREE -> "Tree: " + (treeTui != null ? treeTui.nodeCount() : 0);
+                        case DECLARED -> "Declared: " + declared.size();
+                        case TRANSITIVE -> "Transitive: " + transitive.size();
+                        case MANAGED -> "Managed: " + managed.size();
+                    });
+        }
+        return names;
     }
 
     @Override
     public String status() {
+        if (view == View.TREE && treeTui != null) {
+            return treeTui.status();
+        }
         String search = searchStatus();
         if (search != null) {
             return searchMode ? search : status + " — " + search;
@@ -576,6 +628,9 @@ public class DependenciesTui extends ToolPanel {
 
     @Override
     public List<Span> keyHints() {
+        if (view == View.TREE && treeTui != null) {
+            return treeTui.keyHints();
+        }
         List<Span> searchHints = searchKeyHints();
         if (!searchHints.isEmpty()) {
             return searchHints;
@@ -614,7 +669,11 @@ public class DependenciesTui extends ToolPanel {
 
     @Override
     public List<HelpOverlay.Section> helpSections() {
-        return HelpOverlay.parse("""
+        List<HelpOverlay.Section> sections = new ArrayList<>();
+        if (treeTui != null) {
+            sections.addAll(treeTui.helpSections());
+        }
+        sections.addAll(HelpOverlay.parse("""
                 ## Dependency Analysis
                 Uses bytecode analysis to compare what is declared
                 in the POM against what is actually used in code.
@@ -645,7 +704,31 @@ public class DependenciesTui extends ToolPanel {
                 c               Cycle scope (compile → test → runtime → ...)
                 s / S           Sort by column / reverse direction
                 d               Preview POM changes as unified diff
-                """);
+                """));
+        return sections;
+    }
+
+    @Override
+    void close() {
+        if (treeTui != null) {
+            treeTui.close();
+        }
+    }
+
+    @Override
+    void setRunner(TuiRunner runner) {
+        super.setRunner(runner);
+        if (treeTui != null) {
+            treeTui.setRunner(runner);
+        }
+    }
+
+    @Override
+    void setFocused(boolean focused) {
+        super.setFocused(focused);
+        if (treeTui != null) {
+            treeTui.setFocused(focused);
+        }
     }
 
     private List<DepEntry> currentList() {
@@ -654,6 +737,7 @@ public class DependenciesTui extends ToolPanel {
 
     private int currentListSize() {
         return switch (view) {
+            case TREE -> 0;
             case DECLARED -> declared.size();
             case TRANSITIVE -> transitive.size();
             case MANAGED -> managed.size();
@@ -1078,7 +1162,8 @@ public class DependenciesTui extends ToolPanel {
         String declaredLabel = "Declared: " + declared.size() + (unused > 0 ? " (" + unused + " unused)" : "");
         String transitiveLabel = "Transitive: " + transitive.size() + (used > 0 ? " (" + used + " used)" : "");
         String managedLabel = "Managed: " + managed.size();
-        spans.addAll(TabBar.render(view, View.values(), v -> switch (v) {
+        spans.addAll(TabBar.render(view, views, v -> switch (v) {
+            case TREE -> "Tree: " + (treeTui != null ? treeTui.nodeCount() : 0);
             case DECLARED -> declaredLabel;
             case TRANSITIVE -> transitiveLabel;
             case MANAGED -> managedLabel;

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependencyTreeModel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependencyTreeModel.java
@@ -42,6 +42,7 @@ public class DependencyTreeModel {
         boolean expanded;
         public String requestedVersion; // non-null if conflict
         String managedFrom; // who pulled this in as transitive
+        public String repository; // repository id where this was resolved from
 
         public TreeNode(String groupId, String artifactId, String version, String scope, boolean optional, int depth) {
             this(groupId, artifactId, "", version, scope, optional, depth);
@@ -220,6 +221,7 @@ public class DependencyTreeModel {
                 depth);
         copy.requestedVersion = source.requestedVersion;
         copy.managedFrom = source.managedFrom;
+        copy.repository = source.repository;
         if (copy.isConflict()) {
             conflicts.add(copy);
         }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -81,21 +81,15 @@ public class PilotEngine {
             Consumer<String> progress)
             throws Exception {
         return switch (toolId) {
-            case "tree" -> createTreePanel(proj);
             case "dependencies" -> createDependenciesPanel(proj, session);
             case "updates" -> createUpdatesPanel(proj, projects, session, sessionProvider, progress);
             case "conflicts" -> createConflictsPanel(proj, projects, session, progress);
-            case "align" -> createAlignPanel(proj, projects);
             case "audit" -> createAuditPanel(proj, projects, session, progress);
             case "pom" -> createPomPanel(proj, session);
+            case "align" -> createAlignPanel(proj, projects);
             case "search" -> createSearchPanel();
             default -> null;
         };
-    }
-
-    private ToolPanel createTreePanel(PilotProject proj) {
-        DependencyTreeModel treeModel = cachedCollectDependencies(proj);
-        return new TreeTui(treeModel, scope, proj.gav());
     }
 
     private ToolPanel createDependenciesPanel(PilotProject proj, PomEditSession session) throws Exception {
@@ -150,11 +144,11 @@ public class PilotEngine {
 
         List<DependenciesTui.ManagedEntry> managed = buildManagedEntries(proj);
 
-        if (session != null) {
-            return new DependenciesTui(declared, transitive, managed, session, proj.gav(), bytecodeAnalyzed);
-        }
-        return new DependenciesTui(
-                declared, transitive, managed, new PomEditSession(proj.pomPath), proj.gav(), bytecodeAnalyzed);
+        DependencyTreeModel treeModel = cachedCollectDependencies(proj);
+        TreeTui treeTui = new TreeTui(treeModel, scope, proj.gav());
+
+        PomEditSession s = session != null ? session : new PomEditSession(proj.pomPath);
+        return new DependenciesTui(declared, transitive, managed, s, proj.gav(), bytecodeAnalyzed, treeTui);
     }
 
     @SuppressWarnings("unused")

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -162,8 +162,6 @@ public class PilotEngine {
 
     private ToolPanel createReactorDependenciesPanel(List<PilotProject> projects, Consumer<String> progress)
             throws Exception {
-        resolveAllDependencies(projects, progress);
-
         Map<String, DependenciesTui.DepEntry> unusedMap = new LinkedHashMap<>();
         Map<String, DependenciesTui.DepEntry> usedTransMap = new LinkedHashMap<>();
         int modulesScanned = 0;
@@ -177,7 +175,7 @@ public class PilotEngine {
                 continue;
             }
             modulesScanned++;
-            progress.accept("Analyzing bytecode… " + modulesScanned + "/" + projects.size() + "\n" + p.artifactId);
+            progress.accept("Analyzing dependencies… " + modulesScanned + "/" + projects.size() + "\n" + p.artifactId);
 
             Set<String> declaredGAs = new HashSet<>();
             List<DependenciesTui.DepEntry> declared = new ArrayList<>();

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -168,91 +168,88 @@ public class PilotEngine {
         int modulesSkipped = 0;
 
         for (PilotProject p : projects) {
-            Path classesDir = p.outputDirectory;
-            Path testClassesDir = p.testOutputDirectory;
-            if (classesDir == null || !Files.isDirectory(classesDir)) {
+            if (p.outputDirectory == null || !Files.isDirectory(p.outputDirectory)) {
                 modulesSkipped++;
                 continue;
             }
             modulesScanned++;
             progress.accept("Analyzing dependencies… " + modulesScanned + "/" + projects.size() + "\n" + p.artifactId);
-
-            Set<String> declaredGAs = new HashSet<>();
-            List<DependenciesTui.DepEntry> declared = new ArrayList<>();
-            for (PilotProject.Dep dep : p.dependencies) {
-                DependenciesTui.addDeclaredEntry(
-                        declaredGAs,
-                        declared,
-                        dep.groupId(),
-                        dep.artifactId(),
-                        dep.classifier(),
-                        dep.version(),
-                        dep.scope());
-            }
-
-            PilotResolver.ResolvedDependencies resolved = resolver.resolveDependencies(p);
-            Set<String> transitiveGAs = new HashSet<>();
-            List<DependenciesTui.DepEntry> transitive = new ArrayList<>();
-            DependenciesTui.collectTransitive(resolved.tree().root, declaredGAs, transitiveGAs, transitive);
-
-            Map<String, java.io.File> gaToJar = resolved.gaToJar();
-
-            ClassFileScanner.ScanResult mainScan = ClassFileScanner.scanDirectory(classesDir);
-            ClassFileScanner.ScanResult testScan = testClassesDir != null && Files.isDirectory(testClassesDir)
-                    ? ClassFileScanner.scanDirectory(testClassesDir)
-                    : new ClassFileScanner.ScanResult(Set.of(), Map.of());
-            Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
-            DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.analyze(
-                    mainScan.referencedClasses(),
-                    testScan.referencedClasses(),
-                    classIndex,
-                    gaToJar,
-                    declared,
-                    transitive);
-
-            for (var dep : declared) {
-                DependencyUsageAnalyzer.UsageStatus us =
-                        usage.declaredUsage().getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
-                if (us == DependencyUsageAnalyzer.UsageStatus.UNUSED) {
-                    DependenciesTui.DepEntry existing = unusedMap.get(dep.ga());
-                    if (existing == null) {
-                        dep.usageStatus = DependencyUsageAnalyzer.UsageStatus.UNUSED;
-                        dep.modules.add(p.artifactId);
-                        unusedMap.put(dep.ga(), dep);
-                    } else {
-                        if (!existing.modules.contains(p.artifactId)) {
-                            existing.modules.add(p.artifactId);
-                        }
-                    }
-                }
-            }
-
-            for (var dep : transitive) {
-                DependencyUsageAnalyzer.UsageStatus us = usage.transitiveUsage()
-                        .getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
-                if (us == DependencyUsageAnalyzer.UsageStatus.USED) {
-                    DependenciesTui.DepEntry existing = usedTransMap.get(dep.ga());
-                    if (existing == null) {
-                        dep.usageStatus = DependencyUsageAnalyzer.UsageStatus.USED;
-                        dep.modules.add(p.artifactId);
-                        usedTransMap.put(dep.ga(), dep);
-                    } else {
-                        if (!existing.modules.contains(p.artifactId)) {
-                            existing.modules.add(p.artifactId);
-                        }
-                    }
-                }
-            }
+            analyzeModuleUsage(p, unusedMap, usedTransMap);
         }
 
-        PilotProject root = projects.get(0);
-        String gav = root.gav() + " (reactor: " + projects.size() + " modules)";
         return new DependenciesTui(
                 new ArrayList<>(unusedMap.values()),
                 new ArrayList<>(usedTransMap.values()),
-                gav,
+                reactorGav(projects),
                 modulesScanned,
                 modulesSkipped);
+    }
+
+    private void analyzeModuleUsage(
+            PilotProject p,
+            Map<String, DependenciesTui.DepEntry> unusedMap,
+            Map<String, DependenciesTui.DepEntry> usedTransMap)
+            throws Exception {
+        Set<String> declaredGAs = new HashSet<>();
+        List<DependenciesTui.DepEntry> declared = new ArrayList<>();
+        for (PilotProject.Dep dep : p.dependencies) {
+            DependenciesTui.addDeclaredEntry(
+                    declaredGAs,
+                    declared,
+                    dep.groupId(),
+                    dep.artifactId(),
+                    dep.classifier(),
+                    dep.version(),
+                    dep.scope());
+        }
+
+        PilotResolver.ResolvedDependencies resolved = resolver.resolveDependencies(p);
+        Set<String> transitiveGAs = new HashSet<>();
+        List<DependenciesTui.DepEntry> transitive = new ArrayList<>();
+        DependenciesTui.collectTransitive(resolved.tree().root, declaredGAs, transitiveGAs, transitive);
+
+        Map<String, java.io.File> gaToJar = resolved.gaToJar();
+        ClassFileScanner.ScanResult mainScan = ClassFileScanner.scanDirectory(p.outputDirectory);
+        ClassFileScanner.ScanResult testScan = p.testOutputDirectory != null && Files.isDirectory(p.testOutputDirectory)
+                ? ClassFileScanner.scanDirectory(p.testOutputDirectory)
+                : new ClassFileScanner.ScanResult(Set.of(), Map.of());
+        Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
+        DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.analyze(
+                mainScan.referencedClasses(), testScan.referencedClasses(), classIndex, gaToJar, declared, transitive);
+
+        accumulateEntries(
+                declared, usage.declaredUsage(), DependencyUsageAnalyzer.UsageStatus.UNUSED, unusedMap, p.artifactId);
+        accumulateEntries(
+                transitive,
+                usage.transitiveUsage(),
+                DependencyUsageAnalyzer.UsageStatus.USED,
+                usedTransMap,
+                p.artifactId);
+    }
+
+    private static void accumulateEntries(
+            List<DependenciesTui.DepEntry> deps,
+            Map<String, DependencyUsageAnalyzer.UsageStatus> usageMap,
+            DependencyUsageAnalyzer.UsageStatus targetStatus,
+            Map<String, DependenciesTui.DepEntry> accumulator,
+            String moduleName) {
+        for (var dep : deps) {
+            var us = usageMap.getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
+            if (us == targetStatus) {
+                var existing = accumulator.get(dep.ga());
+                if (existing == null) {
+                    dep.usageStatus = targetStatus;
+                    dep.modules.add(moduleName);
+                    accumulator.put(dep.ga(), dep);
+                } else if (!existing.modules.contains(moduleName)) {
+                    existing.modules.add(moduleName);
+                }
+            }
+        }
+    }
+
+    private static String reactorGav(List<PilotProject> projects) {
+        return projects.get(0).gav() + " (reactor: " + projects.size() + " modules)";
     }
 
     @SuppressWarnings("unused")
@@ -274,9 +271,7 @@ public class PilotEngine {
             PilotProject proj, List<PilotProject> projects, PomEditSession session, Consumer<String> progress) {
         List<PilotProject> targetProjects = projects.size() > 1 ? projects : List.of(proj);
         resolveAllDependencies(targetProjects, progress);
-        String gav = projects.size() > 1
-                ? projects.get(0).gav() + " (reactor: " + projects.size() + " modules)"
-                : proj.gav();
+        String gav = projects.size() > 1 ? reactorGav(projects) : proj.gav();
         PomEditSession s = session != null ? session : new PomEditSession(proj.pomPath);
         return new ConflictsTui(targetProjects, s, gav, this::cachedCollectDependencies);
     }
@@ -322,7 +317,7 @@ public class PilotEngine {
                     + entryMap.size() + " unique dependencies, "
                     + emptyTrees + " modules with empty trees");
             List<AuditTui.AuditEntry> entries = new ArrayList<>(entryMap.values());
-            String gav = root.gav() + " (reactor: " + projects.size() + " modules)";
+            String gav = reactorGav(projects);
             if (session != null) {
                 return new AuditTui(entries, gav, treeModel, session);
             }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -81,7 +81,7 @@ public class PilotEngine {
             Consumer<String> progress)
             throws Exception {
         return switch (toolId) {
-            case "dependencies" -> createDependenciesPanel(proj, session);
+            case "dependencies" -> createDependenciesPanel(proj, projects, session, progress);
             case "updates" -> createUpdatesPanel(proj, projects, session, sessionProvider, progress);
             case "conflicts" -> createConflictsPanel(proj, projects, session, progress);
             case "audit" -> createAuditPanel(proj, projects, session, progress);
@@ -92,7 +92,16 @@ public class PilotEngine {
         };
     }
 
-    private ToolPanel createDependenciesPanel(PilotProject proj, PomEditSession session) throws Exception {
+    private ToolPanel createDependenciesPanel(
+            PilotProject proj, List<PilotProject> projects, PomEditSession session, Consumer<String> progress)
+            throws Exception {
+        if (projects.size() > 1) {
+            return createReactorDependenciesPanel(projects, progress);
+        }
+        return createSingleDependenciesPanel(proj, session);
+    }
+
+    private ToolPanel createSingleDependenciesPanel(PilotProject proj, PomEditSession session) throws Exception {
         Set<String> declaredGAs = new HashSet<>();
         List<DependenciesTui.DepEntry> declared = new ArrayList<>();
         for (PilotProject.Dep dep : proj.dependencies) {
@@ -149,6 +158,103 @@ public class PilotEngine {
 
         PomEditSession s = session != null ? session : new PomEditSession(proj.pomPath);
         return new DependenciesTui(declared, transitive, managed, s, proj.gav(), bytecodeAnalyzed, treeTui);
+    }
+
+    private ToolPanel createReactorDependenciesPanel(List<PilotProject> projects, Consumer<String> progress)
+            throws Exception {
+        resolveAllDependencies(projects, progress);
+
+        Map<String, DependenciesTui.DepEntry> unusedMap = new LinkedHashMap<>();
+        Map<String, DependenciesTui.DepEntry> usedTransMap = new LinkedHashMap<>();
+        int modulesScanned = 0;
+        int modulesSkipped = 0;
+
+        for (PilotProject p : projects) {
+            Path classesDir = p.outputDirectory;
+            Path testClassesDir = p.testOutputDirectory;
+            if (classesDir == null || !Files.isDirectory(classesDir)) {
+                modulesSkipped++;
+                continue;
+            }
+            modulesScanned++;
+            progress.accept("Analyzing bytecode… " + modulesScanned + "/" + projects.size() + "\n" + p.artifactId);
+
+            Set<String> declaredGAs = new HashSet<>();
+            List<DependenciesTui.DepEntry> declared = new ArrayList<>();
+            for (PilotProject.Dep dep : p.dependencies) {
+                DependenciesTui.addDeclaredEntry(
+                        declaredGAs,
+                        declared,
+                        dep.groupId(),
+                        dep.artifactId(),
+                        dep.classifier(),
+                        dep.version(),
+                        dep.scope());
+            }
+
+            PilotResolver.ResolvedDependencies resolved = resolver.resolveDependencies(p);
+            Set<String> transitiveGAs = new HashSet<>();
+            List<DependenciesTui.DepEntry> transitive = new ArrayList<>();
+            DependenciesTui.collectTransitive(resolved.tree().root, declaredGAs, transitiveGAs, transitive);
+
+            Map<String, java.io.File> gaToJar = resolved.gaToJar();
+
+            ClassFileScanner.ScanResult mainScan = ClassFileScanner.scanDirectory(classesDir);
+            ClassFileScanner.ScanResult testScan = testClassesDir != null && Files.isDirectory(testClassesDir)
+                    ? ClassFileScanner.scanDirectory(testClassesDir)
+                    : new ClassFileScanner.ScanResult(Set.of(), Map.of());
+            Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
+            DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.analyze(
+                    mainScan.referencedClasses(),
+                    testScan.referencedClasses(),
+                    classIndex,
+                    gaToJar,
+                    declared,
+                    transitive);
+
+            for (var dep : declared) {
+                DependencyUsageAnalyzer.UsageStatus us =
+                        usage.declaredUsage().getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
+                if (us == DependencyUsageAnalyzer.UsageStatus.UNUSED) {
+                    DependenciesTui.DepEntry existing = unusedMap.get(dep.ga());
+                    if (existing == null) {
+                        dep.usageStatus = DependencyUsageAnalyzer.UsageStatus.UNUSED;
+                        dep.modules.add(p.artifactId);
+                        unusedMap.put(dep.ga(), dep);
+                    } else {
+                        if (!existing.modules.contains(p.artifactId)) {
+                            existing.modules.add(p.artifactId);
+                        }
+                    }
+                }
+            }
+
+            for (var dep : transitive) {
+                DependencyUsageAnalyzer.UsageStatus us = usage.transitiveUsage()
+                        .getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
+                if (us == DependencyUsageAnalyzer.UsageStatus.USED) {
+                    DependenciesTui.DepEntry existing = usedTransMap.get(dep.ga());
+                    if (existing == null) {
+                        dep.usageStatus = DependencyUsageAnalyzer.UsageStatus.USED;
+                        dep.modules.add(p.artifactId);
+                        usedTransMap.put(dep.ga(), dep);
+                    } else {
+                        if (!existing.modules.contains(p.artifactId)) {
+                            existing.modules.add(p.artifactId);
+                        }
+                    }
+                }
+            }
+        }
+
+        PilotProject root = projects.get(0);
+        String gav = root.gav() + " (reactor: " + projects.size() + " modules)";
+        return new DependenciesTui(
+                new ArrayList<>(unusedMap.values()),
+                new ArrayList<>(usedTransMap.values()),
+                gav,
+                modulesScanned,
+                modulesSkipped);
     }
 
     @SuppressWarnings("unused")

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -91,13 +91,12 @@ public class PilotShell {
     }
 
     static final List<ToolDef> TOOLS = List.of(
-            new ToolDef("Tree", "tree", 't', false),
             new ToolDef("Deps", "dependencies", 'd', false),
-            new ToolDef("Pom", "pom", 'p', false),
-            new ToolDef("Align", "align", 'a', true),
             new ToolDef("Updates", "updates", 'u', true),
             new ToolDef("Conflicts", "conflicts", 'c', true),
-            new ToolDef("audIt", "audit", 'i', true),
+            new ToolDef("Audit", "audit", 'a', true),
+            new ToolDef("Pom", "pom", 'p', false),
+            new ToolDef("Align", "align", 'l', true),
             new ToolDef("Search", "search", 's', false));
 
     private final Theme theme = Theme.DEFAULT;
@@ -541,10 +540,6 @@ public class PilotShell {
     }
 
     private boolean isToolAvailable(int toolIndex) {
-        ToolDef tool = TOOLS.get(toolIndex);
-        if ("dependencies".equals(tool.id) && treePane != null && treePane.isSelectedParent()) {
-            return false;
-        }
         return true;
     }
 
@@ -770,13 +765,13 @@ public class PilotShell {
             String label;
             if (i == activeToolIndex) {
                 label = "[▸" + tool.name + "]";
-                spans.add(theme.activeToolTab(tool.name));
+                spans.addAll(theme.activeToolTab(tool.name, tool.mnemonic));
             } else if (isToolAvailable(i)) {
                 label = tool.name;
-                spans.add(theme.inactiveToolTab(label));
+                spans.addAll(theme.inactiveToolTab(label, tool.mnemonic));
             } else {
                 label = tool.name;
-                spans.add(theme.unavailableToolTab(label));
+                spans.addAll(theme.unavailableToolTab(label, tool.mnemonic));
             }
             xPos += label.length();
             toolTabEnds[i] = xPos;
@@ -997,7 +992,7 @@ public class PilotShell {
                         new HelpOverlay.Entry("1-9", "Focus sub-view tab by number"),
                         new HelpOverlay.Entry("Enter", "Switch focus to content pane (from tree)"),
                         new HelpOverlay.Entry("\\", "Cycle left panel: full → narrow → hidden"),
-                        new HelpOverlay.Entry("Alt+t/d/p/a/u/c/i/s", "Switch tool"),
+                        new HelpOverlay.Entry("Alt+d/u/c/a/p/l/s", "Switch tool"),
                         new HelpOverlay.Entry("? / h", "Toggle this help screen"),
                         new HelpOverlay.Entry("q / Ctrl+C", "Quit"))));
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -91,7 +91,7 @@ public class PilotShell {
     }
 
     static final List<ToolDef> TOOLS = List.of(
-            new ToolDef("Deps", "dependencies", 'd', false),
+            new ToolDef("Deps", "dependencies", 'd', true),
             new ToolDef("Updates", "updates", 'u', true),
             new ToolDef("Conflicts", "conflicts", 'c', true),
             new ToolDef("Audit", "audit", 'a', true),
@@ -684,7 +684,7 @@ public class PilotShell {
 
         ToolDef activeTool = TOOLS.get(activeToolIndex);
         if (!activeTool.isModuleIndependent()) {
-            refreshActivePanel(false);
+            refreshActivePanel(true);
         }
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -521,7 +521,6 @@ public class PilotShell {
 
     private void loadInitialPanel() {
         activeToolIndex = 0;
-        if (!isToolAvailable(0)) return;
         refreshActivePanel();
     }
 
@@ -531,16 +530,11 @@ public class PilotShell {
 
     private void switchTool(int toolIndex, boolean focusContent) {
         if (toolIndex < 0 || toolIndex >= TOOLS.size()) return;
-        if (!isToolAvailable(toolIndex)) return;
         activeToolIndex = toolIndex;
         refreshActivePanel();
         if (focusContent) {
             setFocus(Focus.CONTENT);
         }
-    }
-
-    private boolean isToolAvailable(int toolIndex) {
-        return true;
     }
 
     private void refreshActivePanel() {
@@ -549,11 +543,6 @@ public class PilotShell {
 
     private void refreshActivePanel(boolean clearPanel) {
         ToolDef tool = TOOLS.get(activeToolIndex);
-        if (!isToolAvailable(activeToolIndex)) {
-            activePanel = null;
-            loadingCacheKey = null;
-            return;
-        }
         // Remember current sub-view to carry over to new panel
         int currentSubView = activePanel != null ? activePanel.activeSubView() : 0;
 
@@ -766,12 +755,9 @@ public class PilotShell {
             if (i == activeToolIndex) {
                 label = "[▸" + tool.name + "]";
                 spans.addAll(theme.activeToolTab(tool.name, tool.mnemonic));
-            } else if (isToolAvailable(i)) {
-                label = tool.name;
-                spans.addAll(theme.inactiveToolTab(label, tool.mnemonic));
             } else {
                 label = tool.name;
-                spans.addAll(theme.unavailableToolTab(label, tool.mnemonic));
+                spans.addAll(theme.inactiveToolTab(label, tool.mnemonic));
             }
             xPos += label.length();
             toolTabEnds[i] = xPos;
@@ -853,9 +839,6 @@ public class PilotShell {
         } else if (panelError != null) {
             title = " " + tool.name + " ";
             message = "Error: " + panelError;
-        } else if (!isToolAvailable(activeToolIndex)) {
-            title = " " + tool.name + " ";
-            message = tool.name + " is not available for parent modules";
         } else {
             title = " No Tool Selected ";
             message = "Select a tool with Alt+letter";

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TabBar.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TabBar.java
@@ -58,6 +58,11 @@ class TabBar {
      * Cycle to the next enum value, wrapping around from last to first.
      */
     static <V extends Enum<V>> V next(V current, V[] values) {
-        return values[(current.ordinal() + 1) % values.length];
+        for (int i = 0; i < values.length; i++) {
+            if (values[i] == current) {
+                return values[(i + 1) % values.length];
+            }
+        }
+        return values[0];
     }
 }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/Theme.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/Theme.java
@@ -122,19 +122,61 @@ class Theme {
         return Span.raw(" ── ").fg(Color.DARK_GRAY);
     }
 
-    /** Active tool tab in the header. */
-    Span activeToolTab(String label) {
-        return Span.raw("[" + "▸" + label + "]").bold().cyan();
+    /** Active tool tab in the header with underlined mnemonic. */
+    List<Span> activeToolTab(String label, char mnemonic) {
+        int idx = Character.toLowerCase(mnemonic) == mnemonic
+                ? label.toLowerCase().indexOf(mnemonic)
+                : label.indexOf(mnemonic);
+        if (idx < 0) idx = label.toLowerCase().indexOf(Character.toLowerCase(mnemonic));
+        List<Span> spans = new java.util.ArrayList<>();
+        spans.add(Span.raw("[▸").bold().cyan());
+        if (idx >= 0) {
+            if (idx > 0) spans.add(Span.raw(label.substring(0, idx)).bold().cyan());
+            spans.add(Span.raw(String.valueOf(label.charAt(idx))).bold().cyan().underlined());
+            if (idx < label.length() - 1)
+                spans.add(Span.raw(label.substring(idx + 1)).bold().cyan());
+        } else {
+            spans.add(Span.raw(label).bold().cyan());
+        }
+        spans.add(Span.raw("]").bold().cyan());
+        return spans;
     }
 
-    /** Inactive but available tool tab in the header. */
-    Span inactiveToolTab(String label) {
-        return Span.raw(label);
+    /** Inactive but available tool tab with underlined mnemonic. */
+    List<Span> inactiveToolTab(String label, char mnemonic) {
+        int idx = Character.toLowerCase(mnemonic) == mnemonic
+                ? label.toLowerCase().indexOf(mnemonic)
+                : label.indexOf(mnemonic);
+        if (idx < 0) idx = label.toLowerCase().indexOf(Character.toLowerCase(mnemonic));
+        List<Span> spans = new java.util.ArrayList<>();
+        if (idx >= 0) {
+            if (idx > 0) spans.add(Span.raw(label.substring(0, idx)));
+            spans.add(Span.raw(String.valueOf(label.charAt(idx))).underlined());
+            if (idx < label.length() - 1) spans.add(Span.raw(label.substring(idx + 1)));
+        } else {
+            spans.add(Span.raw(label));
+        }
+        return spans;
     }
 
-    /** Unavailable tool tab in the header. */
-    Span unavailableToolTab(String label) {
-        return Span.raw(label).fg(Color.DARK_GRAY);
+    /** Unavailable tool tab with underlined mnemonic. */
+    List<Span> unavailableToolTab(String label, char mnemonic) {
+        int idx = Character.toLowerCase(mnemonic) == mnemonic
+                ? label.toLowerCase().indexOf(mnemonic)
+                : label.indexOf(mnemonic);
+        if (idx < 0) idx = label.toLowerCase().indexOf(Character.toLowerCase(mnemonic));
+        List<Span> spans = new java.util.ArrayList<>();
+        if (idx >= 0) {
+            if (idx > 0) spans.add(Span.raw(label.substring(0, idx)).fg(Color.DARK_GRAY));
+            spans.add(Span.raw(String.valueOf(label.charAt(idx)))
+                    .fg(Color.DARK_GRAY)
+                    .underlined());
+            if (idx < label.length() - 1)
+                spans.add(Span.raw(label.substring(idx + 1)).fg(Color.DARK_GRAY));
+        } else {
+            spans.add(Span.raw(label).fg(Color.DARK_GRAY));
+        }
+        return spans;
     }
 
     // ── Dividers & separators ──────────────────────────────────────────────

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -85,6 +85,7 @@ public class TreeTui extends ToolPanel {
         this.sortState = new SortState(3);
         if (!displayNodes.isEmpty()) {
             tableState.select(0);
+            fetchPomInfoIfNeeded();
         }
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -574,95 +574,93 @@ public class TreeTui extends ToolPanel {
                 .build();
 
         List<Line> lines = new ArrayList<>();
-
-        // Line 1: scope, classifier, optional, depth
-        List<Span> mainSpans = new ArrayList<>();
-        mainSpans.add(Span.raw(" Scope: ").bold());
-        mainSpans.add(Span.styled(node.scope, scopeStyle(node.scope)));
-
-        if (node.classifier != null && !node.classifier.isEmpty()) {
-            mainSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
-            mainSpans.add(Span.raw("Classifier: ").bold());
-            mainSpans.add(Span.raw(node.classifier));
-        }
-
-        if (node.optional) {
-            mainSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
-            mainSpans.add(Span.raw("Optional").bold().fg(theme.statusWarningColor()));
-        }
-
-        mainSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
-        mainSpans.add(Span.raw("Depth: ").bold());
-        mainSpans.add(Span.raw(String.valueOf(node.depth)));
-
-        if (node.hasChildren()) {
-            mainSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
-            mainSpans.add(Span.raw("Children: ").bold());
-            mainSpans.add(Span.raw(String.valueOf(node.children.size())));
-        }
-
-        if (node.repository != null && !node.repository.isEmpty()) {
-            mainSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
-            mainSpans.add(Span.raw("Repo: ").bold());
-            mainSpans.add(Span.raw(node.repository).dim());
-        }
-
-        lines.add(Line.from(mainSpans));
-
-        // Line 2: conflict info
-        if (node.isConflict()) {
-            List<Span> conflictSpans = new ArrayList<>();
-            conflictSpans.add(Span.raw(" ⚠ Conflict: ").bold().fg(theme.statusWarningColor()));
-            conflictSpans.add(Span.raw("requested ").dim());
-            conflictSpans.add(Span.raw(node.requestedVersion).fg(theme.statusWarningColor()));
-            conflictSpans.add(Span.raw(" → resolved ").dim());
-            conflictSpans.add(Span.raw(node.version).bold());
-            if (node.managedFrom != null) {
-                conflictSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
-                conflictSpans.add(Span.raw("Managed by: ").bold());
-                conflictSpans.add(Span.raw(node.managedFrom).dim());
-            }
-            lines.add(Line.from(conflictSpans));
-        } else if (node.managedFrom != null) {
-            List<Span> managedSpans = new ArrayList<>();
-            managedSpans.add(Span.raw(" Managed by: ").bold());
-            managedSpans.add(Span.raw(node.managedFrom).dim());
-            lines.add(Line.from(managedSpans));
-        }
-
-        // Line 3+: POM metadata from Central
-        String pomKey = node.gav();
-        SearchTui.PomInfo info = pomInfoCache.get(pomKey);
-        if (info != null && info.name != null) {
-            List<Span> pomSpans = new ArrayList<>();
-            pomSpans.add(Span.raw(" ").bold());
-            pomSpans.add(Span.raw(info.name).bold().cyan());
-            if (info.license != null) {
-                pomSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
-                pomSpans.add(Span.raw(info.license).fg(theme.metadataValueColor()));
-            }
-            if (info.organization != null) {
-                pomSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
-                pomSpans.add(Span.raw(info.organization).dim());
-            }
-            if (info.date != null) {
-                pomSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
-                pomSpans.add(Span.raw(info.date).dim());
-            }
-            lines.add(Line.from(pomSpans));
-
-            if (info.description != null) {
-                int maxWidth = Math.max(10, area.width() - 4);
-                String desc = info.description.length() > maxWidth
-                        ? info.description.substring(0, maxWidth - 3) + "..."
-                        : info.description;
-                lines.add(Line.from(Span.raw(" " + desc).dim()));
-            }
-        }
+        lines.add(buildNodeSummaryLine(node));
+        buildConflictLine(node, lines);
+        buildPomInfoLines(node, lines, area.width());
 
         Paragraph details =
                 Paragraph.builder().text(Text.from(lines)).block(block).build();
         frame.renderWidget(details, area);
+    }
+
+    private Line buildNodeSummaryLine(DependencyTreeModel.TreeNode node) {
+        List<Span> spans = new ArrayList<>();
+        spans.add(Span.raw(" Scope: ").bold());
+        spans.add(Span.styled(node.scope, scopeStyle(node.scope)));
+
+        if (node.classifier != null && !node.classifier.isEmpty()) {
+            spans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+            spans.add(Span.raw("Classifier: ").bold());
+            spans.add(Span.raw(node.classifier));
+        }
+        if (node.optional) {
+            spans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+            spans.add(Span.raw("Optional").bold().fg(theme.statusWarningColor()));
+        }
+        spans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+        spans.add(Span.raw("Depth: ").bold());
+        spans.add(Span.raw(String.valueOf(node.depth)));
+        if (node.hasChildren()) {
+            spans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+            spans.add(Span.raw("Children: ").bold());
+            spans.add(Span.raw(String.valueOf(node.children.size())));
+        }
+        if (node.repository != null && !node.repository.isEmpty()) {
+            spans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+            spans.add(Span.raw("Repo: ").bold());
+            spans.add(Span.raw(node.repository).dim());
+        }
+        return Line.from(spans);
+    }
+
+    private void buildConflictLine(DependencyTreeModel.TreeNode node, List<Line> lines) {
+        if (node.isConflict()) {
+            List<Span> spans = new ArrayList<>();
+            spans.add(Span.raw(" ⚠ Conflict: ").bold().fg(theme.statusWarningColor()));
+            spans.add(Span.raw("requested ").dim());
+            spans.add(Span.raw(node.requestedVersion).fg(theme.statusWarningColor()));
+            spans.add(Span.raw(" → resolved ").dim());
+            spans.add(Span.raw(node.version).bold());
+            if (node.managedFrom != null) {
+                spans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+                spans.add(Span.raw("Managed by: ").bold());
+                spans.add(Span.raw(node.managedFrom).dim());
+            }
+            lines.add(Line.from(spans));
+        } else if (node.managedFrom != null) {
+            lines.add(Line.from(
+                    Span.raw(" Managed by: ").bold(), Span.raw(node.managedFrom).dim()));
+        }
+    }
+
+    private void buildPomInfoLines(DependencyTreeModel.TreeNode node, List<Line> lines, int areaWidth) {
+        SearchTui.PomInfo info = pomInfoCache.get(node.gav());
+        if (info == null || info.name == null) return;
+
+        List<Span> spans = new ArrayList<>();
+        spans.add(Span.raw(" ").bold());
+        spans.add(Span.raw(info.name).bold().cyan());
+        if (info.license != null) {
+            spans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+            spans.add(Span.raw(info.license).fg(theme.metadataValueColor()));
+        }
+        if (info.organization != null) {
+            spans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+            spans.add(Span.raw(info.organization).dim());
+        }
+        if (info.date != null) {
+            spans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+            spans.add(Span.raw(info.date).dim());
+        }
+        lines.add(Line.from(spans));
+
+        if (info.description != null) {
+            int maxWidth = Math.max(10, areaWidth - 4);
+            String desc = info.description.length() > maxWidth
+                    ? info.description.substring(0, maxWidth - 3) + "..."
+                    : info.description;
+            lines.add(Line.from(Span.raw(" " + desc).dim()));
+        }
     }
 
     private Style scopeStyle(String scope) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -25,6 +25,7 @@ import dev.tamboui.style.Style;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.text.Line;
 import dev.tamboui.text.Span;
+import dev.tamboui.text.Text;
 import dev.tamboui.tui.TuiRunner;
 import dev.tamboui.tui.event.Event;
 import dev.tamboui.tui.event.KeyCode;
@@ -71,12 +72,17 @@ public class TreeTui extends ToolPanel {
 
     private int lastContentHeight;
 
+    private static final int COL_GA = 0;
+    private static final int COL_VERSION = 1;
+    private static final int COL_SCOPE = 2;
+
     public TreeTui(DependencyTreeModel fullModel, String scope, String projectGav) {
         this.fullModel = fullModel;
         this.scope = scope;
         this.projectGav = projectGav;
         this.model = fullModel.filterByScope(scope);
         this.displayNodes = model.visibleNodes();
+        this.sortState = new SortState(3);
         if (!displayNodes.isEmpty()) {
             tableState.select(0);
         }
@@ -139,6 +145,10 @@ public class TreeTui extends ToolPanel {
         return "Tree";
     }
 
+    int nodeCount() {
+        return model.totalNodes;
+    }
+
     @Override
     public void render(Frame frame, Rect area) {
         if (showReversePath) {
@@ -154,13 +164,15 @@ public class TreeTui extends ToolPanel {
             return handleReversePathKeys(key);
         }
         if (handleSearchInput(key)) return true;
+        if (handleSortInput(key)) return true;
         return handleTreeKeys(key);
     }
 
     @Override
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
+        if (handleMouseSortHeader(mouse, List.of(TREE_WIDTHS))) return true;
         if (mouse.isClick()) {
-            int row = mouse.y() - area.y() - 2 + tableState.offset(); // border + header + scroll
+            int row = mouse.y() - area.y() - 1 + tableState.offset(); // header + scroll
             if (row >= 0 && row < displayNodes.size()) {
                 tableState.select(row);
                 fetchPomInfoIfNeeded();
@@ -225,6 +237,7 @@ public class TreeTui extends ToolPanel {
             }
             spans.add(Span.raw("r").bold());
             spans.add(Span.raw(":Reverse  "));
+            spans.addAll(sortKeyHints());
             spans.add(Span.raw("f").bold());
             spans.add(Span.raw(":Scope(" + scope + ")  "));
             spans.add(Span.raw("E/W").bold());
@@ -477,25 +490,23 @@ public class TreeTui extends ToolPanel {
 
     // ── Rendering ───────────────────────────────────────────────────────────
 
+    private static final Constraint[] TREE_WIDTHS = {
+        Constraint.percentage(55), Constraint.percentage(25), Constraint.percentage(20)
+    };
+
     private void renderTree(Frame frame, Rect area) {
-        String conflictInfo = model.conflicts.isEmpty() ? "" : ", " + model.conflicts.size() + " conflicts";
-        String title = " Tree [" + scope + "] (" + model.totalNodes + " nodes" + conflictInfo + ") ";
-
-        Block block = Block.builder()
-                .title(title)
-                .borderType(BorderType.ROUNDED)
-                .borderStyle(borderStyle())
-                .build();
-
         if (displayNodes.isEmpty()) {
-            Paragraph empty = Paragraph.builder()
-                    .text("No dependencies")
-                    .block(block)
-                    .centered()
-                    .build();
+            Paragraph empty =
+                    Paragraph.builder().text("No dependencies").centered().build();
             frame.renderWidget(empty, area);
             return;
         }
+
+        var zones = Layout.vertical()
+                .constraints(Constraint.fill(), Constraint.length(1), Constraint.percentage(25))
+                .split(area);
+
+        Row header = sortState.decorateHeader(List.of("groupId:artifactId", "version", "scope"), theme.tableHeader());
 
         List<Row> rows = new ArrayList<>();
         for (int i = 0; i < displayNodes.size(); i++) {
@@ -507,46 +518,150 @@ public class TreeTui extends ToolPanel {
         }
 
         Table table = Table.builder()
+                .header(header)
                 .rows(rows)
-                .widths(Constraint.fill())
-                .highlightStyle(Style.create().reversed().bold())
-                .highlightSymbol("▸ ")
-                .block(block)
+                .widths(TREE_WIDTHS)
+                .highlightStyle(theme.highlightStyle())
+                .highlightSymbol(theme.highlightSymbol())
                 .build();
 
-        frame.renderStatefulWidget(table, area, tableState);
+        lastContentHeight = zones.get(0).height();
+        setTableArea(zones.get(0), null);
+        frame.renderStatefulWidget(table, zones.get(0), tableState);
+        renderDivider(frame, zones.get(1));
+        renderDetails(frame, zones.get(2));
     }
 
     private Row createTreeRow(DependencyTreeModel.TreeNode node) {
-        List<Span> spans = new ArrayList<>();
-
+        // Column 1: indented groupId:artifactId with expand/collapse arrow
+        List<Span> gaSpans = new ArrayList<>();
         String indent = "  ".repeat(node.depth);
-        spans.add(Span.raw(indent));
-
+        gaSpans.add(Span.raw(indent));
         if (node.hasChildren()) {
-            spans.add(Span.raw(node.expanded ? "▾ " : "▸ ").bold());
+            gaSpans.add(Span.raw(node.expanded ? "▾ " : "▸ ").bold());
         } else {
-            spans.add(Span.raw("  "));
+            gaSpans.add(Span.raw("  "));
+        }
+        String ga = node.groupId + ":" + node.artifactId;
+        gaSpans.add(Span.styled(ga, scopeStyle(node.scope)));
+        if (node.optional) {
+            gaSpans.add(Span.raw(" (opt)").dim());
         }
 
-        Style style = scopeStyle(node.scope);
-        String coords = node.groupId + ":" + node.artifactId + ":" + node.version;
-        spans.add(Span.styled(coords, style));
+        // Column 2: version with conflict info
+        List<Span> versionSpans = new ArrayList<>();
+        versionSpans.add(Span.raw(node.version));
+        if (node.isConflict()) {
+            versionSpans.add(Span.raw(" ⚠ " + node.requestedVersion).fg(theme.statusWarningColor()));
+        }
+
+        // Column 3: scope
+        String scopeLabel = node.scope;
+
+        return Row.from(Cell.from(Line.from(gaSpans)), Cell.from(Line.from(versionSpans)), Cell.from(scopeLabel));
+    }
+
+    private void renderDetails(Frame frame, Rect area) {
+        int sel = selectedIndex();
+        if (sel < 0 || sel >= displayNodes.size()) return;
+        var node = displayNodes.get(sel);
+
+        Block block = Block.builder()
+                .title(" " + node.gav() + " ")
+                .borderType(BorderType.ROUNDED)
+                .borderStyle(theme.unfocusedBorder())
+                .build();
+
+        List<Line> lines = new ArrayList<>();
+
+        // Line 1: scope, classifier, optional, depth
+        List<Span> mainSpans = new ArrayList<>();
+        mainSpans.add(Span.raw(" Scope: ").bold());
+        mainSpans.add(Span.styled(node.scope, scopeStyle(node.scope)));
+
+        if (node.classifier != null && !node.classifier.isEmpty()) {
+            mainSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+            mainSpans.add(Span.raw("Classifier: ").bold());
+            mainSpans.add(Span.raw(node.classifier));
+        }
 
         if (node.optional) {
-            spans.add(Span.raw(" (optional)").dim());
+            mainSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+            mainSpans.add(Span.raw("Optional").bold().fg(theme.statusWarningColor()));
         }
 
+        mainSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+        mainSpans.add(Span.raw("Depth: ").bold());
+        mainSpans.add(Span.raw(String.valueOf(node.depth)));
+
+        if (node.hasChildren()) {
+            mainSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+            mainSpans.add(Span.raw("Children: ").bold());
+            mainSpans.add(Span.raw(String.valueOf(node.children.size())));
+        }
+
+        if (node.repository != null && !node.repository.isEmpty()) {
+            mainSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+            mainSpans.add(Span.raw("Repo: ").bold());
+            mainSpans.add(Span.raw(node.repository).dim());
+        }
+
+        lines.add(Line.from(mainSpans));
+
+        // Line 2: conflict info
         if (node.isConflict()) {
-            spans.add(Span.raw(" ⚠ conflict").fg(theme.statusWarningColor()));
-            spans.add(Span.raw(" (wanted " + node.requestedVersion + ")").dim());
+            List<Span> conflictSpans = new ArrayList<>();
+            conflictSpans.add(Span.raw(" ⚠ Conflict: ").bold().fg(theme.statusWarningColor()));
+            conflictSpans.add(Span.raw("requested ").dim());
+            conflictSpans.add(Span.raw(node.requestedVersion).fg(theme.statusWarningColor()));
+            conflictSpans.add(Span.raw(" → resolved ").dim());
+            conflictSpans.add(Span.raw(node.version).bold());
+            if (node.managedFrom != null) {
+                conflictSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+                conflictSpans.add(Span.raw("Managed by: ").bold());
+                conflictSpans.add(Span.raw(node.managedFrom).dim());
+            }
+            lines.add(Line.from(conflictSpans));
+        } else if (node.managedFrom != null) {
+            List<Span> managedSpans = new ArrayList<>();
+            managedSpans.add(Span.raw(" Managed by: ").bold());
+            managedSpans.add(Span.raw(node.managedFrom).dim());
+            lines.add(Line.from(managedSpans));
         }
 
-        if (!"compile".equals(node.scope) && !node.scope.isEmpty()) {
-            spans.add(Span.raw(" [" + node.scope + "]").dim());
+        // Line 3+: POM metadata from Central
+        String pomKey = node.gav();
+        SearchTui.PomInfo info = pomInfoCache.get(pomKey);
+        if (info != null && info.name != null) {
+            List<Span> pomSpans = new ArrayList<>();
+            pomSpans.add(Span.raw(" ").bold());
+            pomSpans.add(Span.raw(info.name).bold().cyan());
+            if (info.license != null) {
+                pomSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+                pomSpans.add(Span.raw(info.license).fg(theme.metadataValueColor()));
+            }
+            if (info.organization != null) {
+                pomSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+                pomSpans.add(Span.raw(info.organization).dim());
+            }
+            if (info.date != null) {
+                pomSpans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
+                pomSpans.add(Span.raw(info.date).dim());
+            }
+            lines.add(Line.from(pomSpans));
+
+            if (info.description != null) {
+                int maxWidth = Math.max(10, area.width() - 4);
+                String desc = info.description.length() > maxWidth
+                        ? info.description.substring(0, maxWidth - 3) + "..."
+                        : info.description;
+                lines.add(Line.from(Span.raw(" " + desc).dim()));
+            }
         }
 
-        return Row.from(Cell.from(Line.from(spans)));
+        Paragraph details =
+                Paragraph.builder().text(Text.from(lines)).block(block).build();
+        frame.renderWidget(details, area);
     }
 
     private Style scopeStyle(String scope) {
@@ -558,6 +673,37 @@ public class TreeTui extends ToolPanel {
             case "system" -> theme.scopeSystem();
             default -> theme.scopeCompile();
         };
+    }
+
+    @Override
+    protected void onSortChanged() {
+        int col = sortState.sortColumn();
+        if (col < 0) {
+            model = fullModel.filterByScope(scope);
+        } else {
+            java.util.function.Function<DependencyTreeModel.TreeNode, String> extractor =
+                    switch (col) {
+                        case COL_GA -> n -> n.groupId + ":" + n.artifactId;
+                        case COL_VERSION -> n -> n.version;
+                        case COL_SCOPE -> n -> n.scope;
+                        default -> n -> "";
+                    };
+            java.util.Comparator<DependencyTreeModel.TreeNode> cmp =
+                    java.util.Comparator.comparing(extractor, String.CASE_INSENSITIVE_ORDER);
+            if (!sortState.ascending()) {
+                cmp = cmp.reversed();
+            }
+            sortChildrenRecursive(model.root, cmp);
+        }
+        refreshDisplay();
+    }
+
+    private void sortChildrenRecursive(
+            DependencyTreeModel.TreeNode node, java.util.Comparator<DependencyTreeModel.TreeNode> cmp) {
+        node.children.sort(cmp);
+        for (var child : node.children) {
+            sortChildrenRecursive(child, cmp);
+        }
     }
 
     private void renderReversePath(Frame frame, Rect area) {

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/DependenciesDemoTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/DependenciesDemoTest.java
@@ -78,15 +78,15 @@ class DependenciesDemoTest {
             pilot.pause();
 
             // Switch to transitive view
-            pilot.press(KeyCode.TAB);
+            pilot.press('2');
             pilot.pause();
 
             // Navigate transitive deps
             pilot.press(KeyCode.DOWN);
             pilot.pause();
 
-            // Switch back
-            pilot.press(KeyCode.TAB);
+            // Switch back to declared
+            pilot.press('1');
             pilot.pause();
 
             // Quit
@@ -118,7 +118,7 @@ class DependenciesDemoTest {
             pilot.pause();
 
             // Switch to transitive view
-            pilot.press(KeyCode.TAB);
+            pilot.press('2');
             pilot.pause();
 
             pilot.press('q');
@@ -137,7 +137,7 @@ class DependenciesDemoTest {
             pilot.pause();
 
             // Switch to transitive view (also empty)
-            pilot.press(KeyCode.TAB);
+            pilot.press('2');
             pilot.pause();
 
             pilot.press('q');
@@ -294,7 +294,7 @@ class DependenciesDemoTest {
             pilot.pause();
 
             // Switch to transitive view
-            pilot.press(KeyCode.TAB);
+            pilot.press('2');
             pilot.pause();
 
             // Press 'a' to add to POM

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/DependenciesTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/DependenciesTuiRenderTest.java
@@ -130,7 +130,7 @@ class DependenciesTuiRenderTest {
     @Test
     void tabSwitchShowsTransitiveDependencies() {
         var tui = createTuiWithDeps();
-        tui.handleEvent(KeyEvent.ofKey(KeyCode.TAB), null); // switch to Transitive tab
+        tui.handleEvent(KeyEvent.ofChar('2'), null); // switch to Transitive tab
 
         String output = render(tui::renderStandalone);
         assertThat(output).contains("failureaccess").contains("checker-qual");
@@ -139,12 +139,10 @@ class DependenciesTuiRenderTest {
     @Test
     void tabSwitchBackShowsDeclaredAgain() {
         var tui = createTuiWithDeps();
-        int tabCount = tui.subViewCount();
 
-        // Cycle through all tabs to get back to first
-        for (int i = 0; i < tabCount; i++) {
-            tui.handleEvent(KeyEvent.ofKey(KeyCode.TAB), null);
-        }
+        // Switch to transitive then back to declared
+        tui.handleEvent(KeyEvent.ofChar('2'), null);
+        tui.handleEvent(KeyEvent.ofChar('1'), null);
 
         String output = render(tui::renderStandalone);
         assertThat(output).contains("com.google.guava:guava").contains("org.slf4j:slf4j-api");
@@ -189,7 +187,7 @@ class DependenciesTuiRenderTest {
         declared.add(new DependenciesTui.DepEntry("com.example", "lib", "", "1.0", "compile", true));
 
         var tui = new DependenciesTui(declared, List.of(), pomPath, "com.example:app:1.0", true);
-        tui.handleEvent(KeyEvent.ofKey(KeyCode.TAB), null); // switch to Transitive tab
+        tui.handleEvent(KeyEvent.ofChar('2'), null); // switch to Transitive tab
 
         String output = render(tui::renderStandalone);
         // Should render without errors even with no transitive deps

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PageNavigationTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PageNavigationTest.java
@@ -219,7 +219,7 @@ class PageNavigationTest {
         try (var testRunner = TuiTestRunner.runTest(tui::handleEvent, tui::renderStandalone, new Size(100, 24))) {
             Pilot pilot = testRunner.pilot();
             pilot.pause();
-            pilot.press(KeyCode.TAB);
+            pilot.press('2');
             pilot.pause();
             pilot.press(KeyCode.DOWN);
             pilot.pause();

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PilotShellToolDefTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PilotShellToolDefTest.java
@@ -50,12 +50,12 @@ class PilotShellToolDefTest {
     }
 
     @Test
-    void nonAggregatableToolsAreTreeDepsPomSearch() {
+    void nonAggregatableToolsAreDepsPomSearch() {
         var nonAggregatable = PilotShell.TOOLS.stream()
                 .filter(t -> !t.aggregatable())
                 .map(PilotShell.ToolDef::id)
                 .toList();
-        assertThat(nonAggregatable).containsExactlyInAnyOrder("tree", "dependencies", "pom", "search");
+        assertThat(nonAggregatable).containsExactlyInAnyOrder("dependencies", "pom", "search");
     }
 
     @Test

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PilotShellToolDefTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PilotShellToolDefTest.java
@@ -46,7 +46,7 @@ class PilotShellToolDefTest {
                 .filter(PilotShell.ToolDef::aggregatable)
                 .map(PilotShell.ToolDef::id)
                 .toList();
-        assertThat(aggregatable).containsExactlyInAnyOrder("align", "updates", "conflicts", "audit");
+        assertThat(aggregatable).containsExactlyInAnyOrder("align", "updates", "conflicts", "audit", "dependencies");
     }
 
     @Test
@@ -55,7 +55,7 @@ class PilotShellToolDefTest {
                 .filter(t -> !t.aggregatable())
                 .map(PilotShell.ToolDef::id)
                 .toList();
-        assertThat(nonAggregatable).containsExactlyInAnyOrder("dependencies", "pom", "search");
+        assertThat(nonAggregatable).containsExactlyInAnyOrder("pom", "search");
     }
 
     @Test

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PilotShellToolDefTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PilotShellToolDefTest.java
@@ -50,7 +50,7 @@ class PilotShellToolDefTest {
     }
 
     @Test
-    void nonAggregatableToolsAreDepsPomSearch() {
+    void nonAggregatableToolsArePomSearch() {
         var nonAggregatable = PilotShell.TOOLS.stream()
                 .filter(t -> !t.aggregatable())
                 .map(PilotShell.ToolDef::id)

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/RecordingDemoTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/RecordingDemoTest.java
@@ -569,19 +569,19 @@ class RecordingDemoTest {
             recorder.scene(
                     "Dependencies marked as unused are highlighted, helping you identify candidates for removal to keep your POM clean.");
 
-            pilot.press(KeyCode.TAB);
+            pilot.press('2');
             pilot.pause();
             recorder.scene(
-                    "Press Tab to switch to the transitive dependencies view. These are dependencies pulled in by your declared dependencies.");
+                    "Press 2 to switch to the transitive dependencies view. These are dependencies pulled in by your declared dependencies.");
 
             pilot.press(KeyCode.DOWN);
             pilot.pause();
             recorder.scene(
                     "Transitive dependencies also show their usage status. If your code uses a transitive dependency directly, consider declaring it explicitly.");
 
-            pilot.press(KeyCode.TAB);
+            pilot.press('1');
             pilot.pause();
-            recorder.scene("Press Tab again to return to the declared dependencies view.");
+            recorder.scene("Press 1 to return to the declared dependencies view.");
 
             pilot.press('q');
         }

--- a/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/MojoHelper.java
+++ b/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/MojoHelper.java
@@ -270,6 +270,11 @@ public final class MojoHelper {
             conflicts.add(treeNode);
         }
 
+        var repos = node.getRepositories();
+        if (repos != null && !repos.isEmpty()) {
+            treeNode.repository = repos.get(0).getId();
+        }
+
         String nodeKey = treeNode.ga() + ":" + version;
         if (!visited.add(nodeKey)) {
             return treeNode;

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ under the License.
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
-        <version>9.7.1</version>
+        <version>9.9.1</version>
       </dependency>
 
       <!-- JSON -->


### PR DESCRIPTION
## Summary

- **Tree detail pane**: Dependency tree view now shows a detail pane (scope, classifier, optional, depth, children, repository, conflict info, POM metadata) for the selected node
- **Reactor dependencies view**: Aggregated dependency hygiene analysis across all reactor modules — shows unused declared and used transitive dependencies with per-module breakdown. Modules without compiled classes are skipped with a clear indicator.
- **Click-sortable tree headers**: Tree table columns are now sortable via mouse click
- **Underlined mnemonics**: Tool tab mnemonics use underline styling instead of uppercase/lowercase convention. Audit→`a`, Align→`l` keybindings.
- **ASM 9.9.1**: Upgraded from 9.7.1 to support Java 25 class files
- **Module navigation fix**: Switching modules now clears the stale panel to show loading indicators and errors

## Test plan

- [x] All 437 tests pass
- [ ] Open Dependencies tool in a multi-module reactor project with root selected — verify "Unused Declared" and "Used Transitive" tabs appear
- [ ] Navigate to a leaf module — verify single-module dependencies view with Tree/Declared/Transitive/Managed tabs
- [ ] Verify tree detail pane shows metadata for selected dependency node
- [ ] Verify click-sorting works on tree table headers
- [ ] Verify underlined mnemonics in tool tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for analyzing dependencies across multi-module projects.
  * Dependency tree view now includes sortable columns (group:artifact, version, scope) with a details panel.
  * Repository source tracking for resolved dependencies.

* **Bug Fixes**
  * Enhanced error reporting when dependency analysis encounters failures.
  * Improved handling of invalid class files during bytecode scanning.

* **Chores**
  * Updated ASM dependency to version 9.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->