### PR TITLE
feat: cross-POM editing, root discovery, and diff UX improvements

### DIFF
--- a/pilot-cli/src/main/java/eu/maveniverse/maven/pilot/mvn4/PilotMain.java
+++ b/pilot-cli/src/main/java/eu/maveniverse/maven/pilot/mvn4/PilotMain.java
@@ -47,6 +47,8 @@ import org.apache.maven.api.services.ModelBuilder;
 import org.apache.maven.api.services.ModelBuilderRequest;
 import org.apache.maven.api.services.ModelBuilderResult;
 import org.apache.maven.api.services.Sources;
+import org.apache.maven.api.services.model.RootLocator;
+import org.apache.maven.impl.model.rootlocator.DefaultRootLocator;
 import org.apache.maven.impl.standalone.ApiRunner;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -63,13 +65,15 @@ import org.w3c.dom.NodeList;
  */
 public class PilotMain {
 
+    private static final String POM_XML = "pom.xml";
+
     record LoadedReactor(Map<Path, PilotProject> projectsByPomPath, PilotEngine engine) {}
 
     public static void main(String[] args) throws Exception {
         // Suppress noisy Maven resolver warnings (e.g., strict POM validation of third-party deps)
         System.setProperty("maven.logger.defaultLogLevel", "ERROR");
 
-        Path pomPath = args.length > 0 ? Path.of(args[0]) : Path.of("pom.xml");
+        Path pomPath = args.length > 0 ? Path.of(args[0]) : Path.of(POM_XML);
         pomPath = pomPath.toAbsolutePath().normalize();
 
         if (!Files.isRegularFile(pomPath)) {
@@ -77,11 +81,14 @@ public class PilotMain {
             System.exit(1);
         }
 
-        // Phase 1: Quick reactor discovery from raw XML (instant, no Maven API needed)
-        List<PilotProject> stubProjects = discoverReactorFromXml(pomPath);
+        // Find project root by walking up (like Maven bootstrap)
+        Path rootPom = findRootPom(pomPath);
 
-        // Phase 2: Start heavy Maven loading in background
-        final Path pom = pomPath;
+        // Phase 1: Quick reactor discovery from root POM (instant, no Maven API needed)
+        List<PilotProject> stubProjects = discoverReactorFromXml(rootPom);
+
+        // Phase 2: Start heavy Maven loading in background (from root for full context)
+        final Path pom = rootPom;
         AtomicReference<String> loadingStatus = new AtomicReference<>("Initializing Maven session…");
         CompletableFuture<LoadedReactor> loadingFuture = CompletableFuture.supplyAsync(() -> {
             try {
@@ -119,8 +126,12 @@ public class PilotMain {
                         + " scope projects not found in reactor (path mismatch)");
             }
             try {
-                return reactor.engine.createPanel(toolId, realProject, realScope, session, sessionProvider, progress);
+                var panel =
+                        reactor.engine.createPanel(toolId, realProject, realScope, session, sessionProvider, progress);
+                loadingStatus.set(null);
+                return panel;
             } catch (Exception e) {
+                loadingStatus.set(null);
                 System.err.println(
                         "[Pilot] Failed to create '" + toolId + "' panel for " + realProject.ga() + ": " + e);
                 e.printStackTrace(System.err);
@@ -131,6 +142,25 @@ public class PilotMain {
         // Phase 4: Launch TUI immediately with module tree visible
         ReactorModel reactorModel = stubProjects.size() > 1 ? ReactorModel.build(stubProjects) : null;
         new PilotShell(reactorModel, stubProjects, panelFactory, loadingStatus::get).run();
+    }
+
+    // ── Root POM discovery ──────────────────────────────────────────────
+
+    /**
+     * Find the project root using Maven 4's {@link RootLocator} API,
+     * which checks for {@code .mvn} directory and {@code root="true"} POM attribute.
+     * Falls back to the given POM if no root is found.
+     */
+    private static Path findRootPom(Path pomPath) {
+        RootLocator locator = new DefaultRootLocator();
+        Path rootDir = locator.findRoot(pomPath.getParent());
+        if (rootDir != null) {
+            Path rootPom = rootDir.resolve(POM_XML);
+            if (Files.isRegularFile(rootPom)) {
+                return rootPom;
+            }
+        }
+        return pomPath;
     }
 
     // ── Quick reactor discovery ─────────────────────────────────────────
@@ -215,7 +245,7 @@ public class PilotMain {
                 for (int i = 0; i < moduleNodes.getLength(); i++) {
                     String moduleName = moduleNodes.item(i).getTextContent().trim();
                     Path modulePom = basedir.resolve(moduleName)
-                            .resolve("pom.xml")
+                            .resolve(POM_XML)
                             .toAbsolutePath()
                             .normalize();
                     if (Files.isRegularFile(modulePom)) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -32,7 +32,6 @@ import dev.tamboui.tui.event.Event;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.MouseEvent;
-import dev.tamboui.tui.event.MouseEventKind;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.paragraph.Paragraph;
@@ -156,6 +155,7 @@ public class AuditTui extends ToolPanel {
     private int lastContentHeight;
     private int lastTableHeight;
     private String scopeFilter; // null = show all
+    private PomEditSession managementSession;
     private List<AuditEntry> filteredEntries;
     List<VulnRow> vulnRows = new ArrayList<>();
     private List<VulnGroup> vulnGroups = new ArrayList<>();
@@ -191,13 +191,18 @@ public class AuditTui extends ToolPanel {
 
     /** Standalone constructor — creates its own PomEditSession from the POM file path. */
     public AuditTui(List<AuditEntry> entries, String projectGav, DependencyTreeModel treeModel, String pomPath) {
-        this(entries, projectGav, treeModel, new PomEditSession(Path.of(pomPath)));
+        this(entries, projectGav, treeModel, new PomEditSession(Path.of(pomPath)), null);
     }
 
     /** Panel-mode constructor — uses a shared PomEditSession from the shell. */
     public AuditTui(
-            List<AuditEntry> entries, String projectGav, DependencyTreeModel treeModel, PomEditSession session) {
+            List<AuditEntry> entries,
+            String projectGav,
+            DependencyTreeModel treeModel,
+            PomEditSession session,
+            PomEditSession managementSession) {
         this.editSession = session;
+        this.managementSession = managementSession != null ? managementSession : session;
         this.entries = entries;
         this.filteredEntries = entries;
         this.projectGav = projectGav;
@@ -483,7 +488,7 @@ public class AuditTui extends ToolPanel {
     public boolean handleKeyEvent(KeyEvent key) {
         // Diff overlay mode — consume all keys
         if (diffOverlay.isActive()) {
-            if (key.isKey(KeyCode.ESCAPE)) {
+            if (key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q') || key.isCharIgnoreCase('d')) {
                 diffOverlay.close();
                 return true;
             }
@@ -655,14 +660,14 @@ public class AuditTui extends ToolPanel {
             return false;
         }
 
-        // Diff overlay in standalone — allow q to quit
+        // Diff overlay in standalone
         if (diffOverlay.isActive()) {
-            if (key.isKey(KeyCode.ESCAPE)) {
+            if (key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q') || key.isCharIgnoreCase('d')) {
                 diffOverlay.close();
                 return true;
             }
             if (diffOverlay.handleScrollKey(key, lastContentHeight)) return true;
-            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+            if (key.isCtrlC()) {
                 requestQuit();
                 return true;
             }
@@ -762,7 +767,7 @@ public class AuditTui extends ToolPanel {
         try {
             editSession.beforeMutation();
             var coords = Coordinates.of(entry.groupId, entry.artifactId, entry.version);
-            editSession.editor().dependencies().updateManagedDependency(true, coords);
+            editSession.addManagedDependencyAligned(coords, managementSession);
             editSession.recordChange(
                     PomEditSession.ChangeType.ADD,
                     "managed",
@@ -810,8 +815,13 @@ public class AuditTui extends ToolPanel {
     }
 
     private void toggleDiffView() {
-        long changes = diffOverlay.open(editSession.originalContent(), editSession.currentXml());
-        status = changes == 0 ? "No changes to show" : changes + " line(s) changed";
+        var diffs = collectAllDiffs();
+        if (diffs.isEmpty()) {
+            status = "No changes to show";
+            return;
+        }
+        long changes = diffOverlay.openMulti(diffs);
+        status = changes == 0 ? "No changes to show" : changes + " line(s) changed across " + diffs.size() + " file(s)";
     }
 
     @Override
@@ -1866,24 +1876,12 @@ public class AuditTui extends ToolPanel {
 
     @Override
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
+        if (diffOverlay.isActive()) {
+            return diffOverlay.handleMouseScroll(mouse, lastContentHeight);
+        }
         if (handleMouseTabBar(mouse)) return true;
         if (handleMouseSortHeader(mouse, currentTableWidths())) return true;
-        if (mouse.isClick()) {
-            int row = mouseToTableRow(mouse, activeRowCount(), activeTableState());
-            if (row >= 0) {
-                activeTableState().select(row);
-                return true;
-            }
-        }
-        if (mouse.isScroll()) {
-            if (mouse.kind() == MouseEventKind.SCROLL_UP) {
-                activeTableState().selectPrevious();
-            } else {
-                activeTableState().selectNext(activeRowCount());
-            }
-            return true;
-        }
-        return false;
+        return handleMouseTableInteraction(mouse, activeRowCount(), activeTableState());
     }
 
     private List<Constraint> currentTableWidths() {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -349,7 +349,8 @@ public class ConflictsTui extends ToolPanel {
     @Override
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
         if (diffOverlay.isActive()) {
-            return diffOverlay.handleMouseScroll(mouse, lastContentHeight);
+            diffOverlay.handleMouseScroll(mouse, lastContentHeight);
+            return true;
         }
         if (handleMouseSortHeader(
                 mouse,

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -30,7 +30,6 @@ import dev.tamboui.tui.event.Event;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.MouseEvent;
-import dev.tamboui.tui.event.MouseEventKind;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.paragraph.Paragraph;
@@ -110,8 +109,8 @@ public class ConflictsTui extends ToolPanel {
 
     private List<ConflictGroup> conflicts;
     private final String projectGav;
+    private PomEditSession managementSession;
     private final TableState tableState = new TableState();
-    private boolean showDetails = true;
     private boolean showAll = false;
     private String status;
 
@@ -155,6 +154,7 @@ public class ConflictsTui extends ToolPanel {
     /** Panel-mode constructor — uses a shared PomEditSession from the shell. */
     public ConflictsTui(List<ConflictGroup> conflicts, PomEditSession session, String projectGav) {
         this.editSession = session;
+        this.managementSession = session;
         this.conflicts = conflicts;
         this.projectGav = projectGav;
         this.status = conflicts.size() + " dependency group(s) with version variance";
@@ -166,8 +166,13 @@ public class ConflictsTui extends ToolPanel {
 
     /** Async-loading constructor — collects conflicts in the background after setRunner(). */
     public ConflictsTui(
-            List<PilotProject> projects, PomEditSession session, String projectGav, TreeResolver treeResolver) {
+            List<PilotProject> projects,
+            PomEditSession session,
+            PomEditSession managementSession,
+            String projectGav,
+            TreeResolver treeResolver) {
         this.editSession = session;
+        this.managementSession = managementSession;
         this.conflicts = new ArrayList<>();
         this.projectGav = projectGav;
         this.totalModules = projects.size();
@@ -209,14 +214,14 @@ public class ConflictsTui extends ToolPanel {
             return false;
         }
 
-        // Diff overlay mode — standalone allows q to quit
+        // Diff overlay mode — standalone
         if (diffOverlay.isActive()) {
-            if (key.isKey(KeyCode.ESCAPE)) {
+            if (key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q') || key.isCharIgnoreCase('d')) {
                 diffOverlay.close();
                 return true;
             }
             if (diffOverlay.handleScrollKey(key, lastContentHeight)) return true;
-            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+            if (key.isCtrlC()) {
                 requestQuit();
                 return true;
             }
@@ -274,25 +279,20 @@ public class ConflictsTui extends ToolPanel {
         } else if (helpOverlay.isActive()) {
             helpOverlay.render(frame, area);
         } else {
-            boolean detailsVisible = showDetails;
-            if (detailsVisible) {
-                var zones = Layout.vertical()
-                        .constraints(Constraint.fill(), Constraint.length(1), Constraint.percentage(30))
-                        .split(area);
-                lastContentHeight = zones.get(0).height();
-                renderConflicts(frame, zones.get(0));
-                renderDivider(frame, zones.get(1));
-                renderDetails(frame, zones.get(2));
-            } else {
-                renderConflicts(frame, area);
-            }
+            var zones = Layout.vertical()
+                    .constraints(Constraint.fill(), Constraint.length(1), Constraint.percentage(30))
+                    .split(area);
+            lastContentHeight = zones.get(0).height();
+            renderConflicts(frame, zones.get(0));
+            renderDivider(frame, zones.get(1));
+            renderDetails(frame, zones.get(2));
         }
     }
 
     @Override
     public boolean handleKeyEvent(KeyEvent key) {
         if (diffOverlay.isActive()) {
-            if (key.isKey(KeyCode.ESCAPE)) {
+            if (key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q') || key.isCharIgnoreCase('d')) {
                 diffOverlay.close();
                 return true;
             }
@@ -315,7 +315,6 @@ public class ConflictsTui extends ToolPanel {
         }
 
         if (key.isKey(KeyCode.ENTER) || key.isCharIgnoreCase(' ')) {
-            showDetails = !showDetails;
             return true;
         }
 
@@ -349,6 +348,9 @@ public class ConflictsTui extends ToolPanel {
 
     @Override
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
+        if (diffOverlay.isActive()) {
+            return diffOverlay.handleMouseScroll(mouse, lastContentHeight);
+        }
         if (handleMouseSortHeader(
                 mouse,
                 List.of(
@@ -356,26 +358,7 @@ public class ConflictsTui extends ToolPanel {
                         Constraint.percentage(15), Constraint.fill()))) {
             return true;
         }
-        if (mouse.isClick()) {
-            var displayed = displayedConflicts();
-            int row = mouseToTableRow(mouse, displayed.size(), tableState);
-            if (row >= 0) {
-                tableState.select(row);
-                return true;
-            }
-        }
-        if (mouse.isScroll()) {
-            var displayed = displayedConflicts();
-            if (displayed.isEmpty()) return false;
-            int sel = tableState.selected();
-            if (mouse.kind() == MouseEventKind.SCROLL_UP) {
-                tableState.select(Math.max(0, sel - 1));
-            } else {
-                tableState.select(Math.min(displayed.size() - 1, sel + 1));
-            }
-            return true;
-        }
-        return false;
+        return handleMouseTableInteraction(mouse, displayedConflicts().size(), tableState);
     }
 
     @Override
@@ -394,8 +377,6 @@ public class ConflictsTui extends ToolPanel {
         } else {
             spans.add(Span.raw("↑↓").bold());
             spans.add(Span.raw(":Navigate  "));
-            spans.add(Span.raw("Enter").bold());
-            spans.add(Span.raw(":Details  "));
             spans.add(Span.raw("t").bold());
             spans.add(Span.raw(showAll ? ":Conflicts only  " : ":Show all  "));
             spans.add(Span.raw("p").bold());
@@ -433,7 +414,6 @@ public class ConflictsTui extends ToolPanel {
 
                 ## Conflict Actions
                 ↑ / ↓           Move selection up / down
-                Enter / Space   Toggle dependency path details
                 t               Toggle between conflicts only / all groups
                 p               Pin resolved version in dependencyManagement
                 d               Preview POM changes as a unified diff
@@ -566,7 +546,7 @@ public class ConflictsTui extends ToolPanel {
             editSession.beforeMutation();
             String resolvedVersion = group.resolvedVersion();
             var coords = Coordinates.of(group.entries.get(0).groupId, group.entries.get(0).artifactId, resolvedVersion);
-            editSession.editor().dependencies().updateManagedDependency(true, coords);
+            editSession.addManagedDependencyAligned(coords, managementSession);
             editSession.recordChange(
                     PomEditSession.ChangeType.ADD, "managed", group.ga, "pinned to " + resolvedVersion, "conflicts");
 
@@ -596,8 +576,13 @@ public class ConflictsTui extends ToolPanel {
     }
 
     private void toggleDiffView() {
-        long changes = diffOverlay.open(editSession.originalContent(), editSession.currentXml());
-        status = changes == 0 ? "No changes to show" : changes + " line(s) changed";
+        var diffs = collectAllDiffs();
+        if (diffs.isEmpty()) {
+            status = "No changes to show";
+            return;
+        }
+        long changes = diffOverlay.openMulti(diffs);
+        status = changes == 0 ? "No changes to show" : changes + " line(s) changed across " + diffs.size() + " file(s)";
     }
 
     private List<HelpOverlay.Section> buildHelpStandalone() {
@@ -605,7 +590,6 @@ public class ConflictsTui extends ToolPanel {
         List<HelpOverlay.Section> parsed = HelpOverlay.parse("""
                 ## Keys
                 """ + NAV_KEYS + """
-                Enter / Space   Toggle dependency path details
                 t               Toggle between conflicts only / all groups
                 p               Pin resolved version in dependencyManagement
                 d               Preview POM changes as a unified diff
@@ -621,7 +605,7 @@ public class ConflictsTui extends ToolPanel {
     // -- Rendering --
 
     void renderStandalone(Frame frame) {
-        boolean detailsVisible = showDetails && !diffOverlay.isActive() && !helpOverlay.isActive();
+        boolean detailsVisible = !diffOverlay.isActive() && !helpOverlay.isActive();
         var zones = Layout.vertical()
                 .constraints(
                         Constraint.length(3),

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -600,7 +600,8 @@ public class DependenciesTui extends ToolPanel {
     @Override
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
         if (diffOverlay.isActive()) {
-            return diffOverlay.handleMouseScroll(mouse, lastContentHeight);
+            diffOverlay.handleMouseScroll(mouse, lastContentHeight);
+            return true;
         }
         if (handleMouseTabBar(mouse)) return true;
         if (view == View.TREE && treeTui != null) {
@@ -892,7 +893,9 @@ public class DependenciesTui extends ToolPanel {
         var dep = declared.get(sel);
 
         try {
-            Coordinates coords = Coordinates.of(dep.groupId, dep.artifactId, dep.version);
+            Coordinates coords = dep.hasClassifier()
+                    ? Coordinates.of(dep.groupId, dep.artifactId, dep.version, dep.classifier, "jar")
+                    : Coordinates.of(dep.groupId, dep.artifactId, dep.version);
             if (reactorMode && sessionProvider != null) {
                 for (Path pomPath : dep.modulePomPaths) {
                     PomEditSession session = sessionProvider.apply(pomPath);

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -301,6 +301,7 @@ public class DependenciesTui extends ToolPanel {
     }
 
     /** Panel-mode constructor with embedded tree view and management session. */
+    @SuppressWarnings("squid:S107") // delegation target for simpler constructors
     public DependenciesTui(
             List<DepEntry> declared,
             List<DepEntry> transitive,
@@ -584,7 +585,7 @@ public class DependenciesTui extends ToolPanel {
             return true;
         }
 
-        if (key.isCharIgnoreCase('c') && !reactorMode) {
+        if (key.isCharIgnoreCase('c')) {
             changeScope();
             return true;
         }
@@ -988,8 +989,8 @@ public class DependenciesTui extends ToolPanel {
         boolean hadManagedEntry = editor.document()
                 .root()
                 .childElement("dependencyManagement")
-                .flatMap(dm -> dm.childElement("dependencies"))
-                .flatMap(deps -> deps.childElements("dependency")
+                .flatMap(dm -> dm.childElement(SECTION_DEPENDENCIES))
+                .flatMap(deps -> deps.childElements(TARGET_DEPENDENCY)
                         .filter(coords.predicateGATC())
                         .findFirst())
                 .isPresent();

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -32,7 +32,6 @@ import dev.tamboui.tui.event.Event;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.MouseEvent;
-import dev.tamboui.tui.event.MouseEventKind;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.block.Title;
@@ -83,6 +82,7 @@ public class DependenciesTui extends ToolPanel {
         public int totalClasses; // total classes provided by this dep
         public List<String> spiServices; // SPI service interfaces provided by this dep
         public final List<String> modules = new ArrayList<>(); // reactor mode: which modules have this dep
+        public final List<Path> modulePomPaths = new ArrayList<>(); // reactor mode: POM paths for each module
 
         /**
          * Creates a DepEntry representing a dependency row in the TUI.
@@ -228,6 +228,8 @@ public class DependenciesTui extends ToolPanel {
     private final String projectGav;
     private final boolean bytecodeAnalyzed;
     private final boolean reactorMode;
+    private final PomEditSession managementSession;
+    private final java.util.function.Function<Path, PomEditSession> sessionProvider;
     private final TableState tableState = new TableState();
 
     private View view = View.DECLARED;
@@ -295,19 +297,22 @@ public class DependenciesTui extends ToolPanel {
             PomEditSession session,
             String projectGav,
             boolean bytecodeAnalyzed) {
-        this(declared, transitive, managed, session, projectGav, bytecodeAnalyzed, null);
+        this(declared, transitive, managed, session, null, projectGav, bytecodeAnalyzed, null);
     }
 
-    /** Panel-mode constructor with embedded tree view. */
+    /** Panel-mode constructor with embedded tree view and management session. */
     public DependenciesTui(
             List<DepEntry> declared,
             List<DepEntry> transitive,
             List<ManagedEntry> managed,
             PomEditSession session,
+            PomEditSession managementSession,
             String projectGav,
             boolean bytecodeAnalyzed,
             TreeTui treeTui) {
         this.editSession = session;
+        this.managementSession = managementSession;
+        this.sessionProvider = null;
         this.declared = declared;
         this.transitive = transitive;
         this.managed = managed;
@@ -332,8 +337,12 @@ public class DependenciesTui extends ToolPanel {
             List<DepEntry> usedTransitive,
             String projectGav,
             int modulesScanned,
-            int modulesSkipped) {
+            int modulesSkipped,
+            java.util.function.Function<Path, PomEditSession> sessionProvider,
+            PomEditSession managementSession) {
         this.editSession = null;
+        this.managementSession = managementSession;
+        this.sessionProvider = sessionProvider;
         this.declared = unusedDeclared;
         this.transitive = usedTransitive;
         this.managed = List.of();
@@ -426,12 +435,12 @@ public class DependenciesTui extends ToolPanel {
 
         // Diff overlay mode (standalone — panel mode handles in handleKeyEvent)
         if (diffOverlay.isActive()) {
-            if (key.isKey(KeyCode.ESCAPE)) {
+            if (key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q') || key.isCharIgnoreCase('d')) {
                 diffOverlay.close();
                 return true;
             }
             if (diffOverlay.handleScrollKey(key, lastContentHeight)) return true;
-            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+            if (key.isCtrlC()) {
                 requestQuit();
                 return true;
             }
@@ -506,7 +515,7 @@ public class DependenciesTui extends ToolPanel {
     public boolean handleKeyEvent(KeyEvent key) {
         // Diff overlay (panel mode — standalone handles before delegation)
         if (diffOverlay.isActive()) {
-            if (key.isKey(KeyCode.ESCAPE)) {
+            if (key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q') || key.isCharIgnoreCase('d')) {
                 diffOverlay.close();
                 return true;
             }
@@ -565,17 +574,17 @@ public class DependenciesTui extends ToolPanel {
             return true;
         }
 
-        if (key.isCharIgnoreCase('x')) {
+        if (key.isCharIgnoreCase('x') && (view == View.DECLARED || view == View.UNUSED_DECLARED)) {
             removeDeclared();
             return true;
         }
 
-        if (key.isCharIgnoreCase('a')) {
+        if (key.isCharIgnoreCase('a') && (view == View.TRANSITIVE || view == View.USED_TRANSITIVE)) {
             addTransitive();
             return true;
         }
 
-        if (key.isCharIgnoreCase('c')) {
+        if (key.isCharIgnoreCase('c') && !reactorMode) {
             changeScope();
             return true;
         }
@@ -590,30 +599,15 @@ public class DependenciesTui extends ToolPanel {
 
     @Override
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
+        if (diffOverlay.isActive()) {
+            return diffOverlay.handleMouseScroll(mouse, lastContentHeight);
+        }
         if (handleMouseTabBar(mouse)) return true;
         if (view == View.TREE && treeTui != null) {
             return treeTui.handleMouseEvent(mouse, area);
         }
         if (view != View.MANAGED && handleMouseSortHeader(mouse, List.of(getTableWidths()))) return true;
-        if (mouse.isClick()) {
-            int row = mouseToTableRow(mouse, currentListSize(), tableState);
-            if (row >= 0) {
-                tableState.select(row);
-                return true;
-            }
-        }
-        if (mouse.isScroll()) {
-            int size = currentListSize();
-            if (size == 0) return false;
-            int sel = tableState.selected();
-            if (mouse.kind() == MouseEventKind.SCROLL_UP) {
-                tableState.select(Math.max(0, sel - 1));
-            } else {
-                tableState.select(Math.min(size - 1, sel + 1));
-            }
-            return true;
-        }
-        return false;
+        return handleMouseTableInteraction(mouse, currentListSize(), tableState);
     }
 
     @Override
@@ -686,19 +680,19 @@ public class DependenciesTui extends ToolPanel {
         } else {
             spans.add(Span.raw("↑↓").bold());
             spans.add(Span.raw(":Nav  "));
-            if (view == View.DECLARED) {
+            if (view == View.DECLARED || view == View.UNUSED_DECLARED) {
                 spans.add(Span.raw("x/Enter").bold());
-                spans.add(Span.raw(":Delete  "));
-                spans.add(Span.raw("c").bold());
-                spans.add(Span.raw(":Scope  "));
-            } else if (view == View.TRANSITIVE) {
+                spans.add(Span.raw(":Remove  "));
+            } else if (view == View.TRANSITIVE || view == View.USED_TRANSITIVE) {
                 spans.add(Span.raw("a/Enter").bold());
                 spans.add(Span.raw(":Add  "));
-                spans.add(Span.raw("c").bold());
-                spans.add(Span.raw(":Scope  "));
             } else {
                 spans.add(Span.raw("x").bold());
                 spans.add(Span.raw(":Remove  "));
+            }
+            if (!reactorMode) {
+                spans.add(Span.raw("c").bold());
+                spans.add(Span.raw(":Scope  "));
             }
             spans.addAll(sortKeyHints());
             spans.add(Span.raw("/").bold());
@@ -877,7 +871,7 @@ public class DependenciesTui extends ToolPanel {
      * if the view is TRANSITIVE, adds the selected transitive dependency to the POM.
      */
     private void fixSelected() {
-        if (view == View.DECLARED) {
+        if (view == View.DECLARED || view == View.UNUSED_DECLARED) {
             removeDeclared();
         } else {
             addTransitive();
@@ -898,13 +892,25 @@ public class DependenciesTui extends ToolPanel {
         var dep = declared.get(sel);
 
         try {
-            editSession.beforeMutation();
-            editSession
-                    .editor()
-                    .dependencies()
-                    .deleteDependency(Coordinates.of(dep.groupId, dep.artifactId, dep.version));
-            editSession.recordChange(
-                    PomEditSession.ChangeType.REMOVE, TARGET_DEPENDENCY, dep.ga(), "removed", SECTION_DEPENDENCIES);
+            Coordinates coords = Coordinates.of(dep.groupId, dep.artifactId, dep.version);
+            if (reactorMode && sessionProvider != null) {
+                for (Path pomPath : dep.modulePomPaths) {
+                    PomEditSession session = sessionProvider.apply(pomPath);
+                    session.beforeMutation();
+                    session.editor().dependencies().deleteDependency(coords);
+                    session.recordChange(
+                            PomEditSession.ChangeType.REMOVE,
+                            TARGET_DEPENDENCY,
+                            dep.ga(),
+                            "removed",
+                            SECTION_DEPENDENCIES);
+                }
+            } else if (editSession != null) {
+                editSession.beforeMutation();
+                editSession.editor().dependencies().deleteDependency(coords);
+                editSession.recordChange(
+                        PomEditSession.ChangeType.REMOVE, TARGET_DEPENDENCY, dep.ga(), "removed", SECTION_DEPENDENCIES);
+            }
             declared.remove(sel);
             updateStatus();
             if (sel >= declared.size() && !declared.isEmpty()) {
@@ -928,43 +934,88 @@ public class DependenciesTui extends ToolPanel {
         var dep = transitive.get(sel);
 
         try {
-            editSession.beforeMutation();
             Coordinates coords = (dep.hasClassifier())
                     ? Coordinates.of(dep.groupId, dep.artifactId, dep.version, dep.classifier, "jar")
                     : Coordinates.of(dep.groupId, dep.artifactId, dep.version);
-            PomEditor editor = editSession.editor();
-            if (!COMPILE_SCOPE.equals(dep.scope)) {
-                AlignOptions detected = editor.dependencies().detectConventions();
-                AlignOptions options = AlignOptions.builder()
-                        .versionStyle(detected.versionStyle())
-                        .versionSource(detected.versionSource())
-                        .namingConvention(detected.namingConvention())
-                        .scope(dep.scope)
-                        .build();
-                editor.dependencies().addAligned(coords, options);
-            } else {
-                editor.dependencies().addAligned(coords);
+            if (reactorMode && sessionProvider != null) {
+                for (Path pomPath : dep.modulePomPaths) {
+                    PomEditSession session = sessionProvider.apply(pomPath);
+                    addDependencyToSession(session, coords, dep.scope);
+                    session.recordChange(
+                            PomEditSession.ChangeType.ADD,
+                            TARGET_DEPENDENCY,
+                            dep.ga(),
+                            "added from transitive",
+                            SECTION_DEPENDENCIES);
+                }
+            } else if (editSession != null) {
+                addDependencyToSession(editSession, coords, dep.scope);
+                editSession.recordChange(
+                        PomEditSession.ChangeType.ADD,
+                        TARGET_DEPENDENCY,
+                        dep.ga(),
+                        "added from transitive",
+                        SECTION_DEPENDENCIES);
             }
-            editSession.recordChange(
-                    PomEditSession.ChangeType.ADD,
-                    TARGET_DEPENDENCY,
-                    dep.ga(),
-                    "added from transitive",
-                    SECTION_DEPENDENCIES);
 
             // Move from transitive to declared
             transitive.remove(sel);
-            var promoted = new DepEntry(dep.groupId, dep.artifactId, dep.classifier, dep.version, dep.scope, true);
-            promoted.usageStatus = dep.usageStatus;
-            promoted.usedMembers = dep.usedMembers;
-            promoted.totalClasses = dep.totalClasses;
-            declared.add(promoted);
+            if (!reactorMode) {
+                var promoted = new DepEntry(dep.groupId, dep.artifactId, dep.classifier, dep.version, dep.scope, true);
+                promoted.usageStatus = dep.usageStatus;
+                promoted.usedMembers = dep.usedMembers;
+                promoted.totalClasses = dep.totalClasses;
+                declared.add(promoted);
+            }
             updateStatus();
             if (sel >= transitive.size() && !transitive.isEmpty()) {
                 tableState.select(transitive.size() - 1);
             }
         } catch (Exception e) {
             status = "Failed to add: " + e.getMessage();
+        }
+    }
+
+    private void addDependencyToSession(PomEditSession session, Coordinates coords, String scope) {
+        session.beforeMutation();
+        PomEditor editor = session.editor();
+        AlignOptions detected = editor.dependencies().detectConventions();
+        // TODO: replace with editor.dependencies().findManagedVersion(coords) != null
+        //  when DomTrip exposes it (https://github.com/maveniverse/domtrip/issues/215)
+        boolean hadManagedEntry = editor.document()
+                .root()
+                .childElement("dependencyManagement")
+                .flatMap(dm -> dm.childElement("dependencies"))
+                .flatMap(deps -> deps.childElements("dependency")
+                        .filter(coords.predicateGATC())
+                        .findFirst())
+                .isPresent();
+        AlignOptions.Builder builder = AlignOptions.builder()
+                .versionStyle(detected.versionStyle())
+                .versionSource(detected.versionSource())
+                .namingConvention(detected.namingConvention());
+        if (!COMPILE_SCOPE.equals(scope)) {
+            builder.scope(scope);
+        }
+        editor.dependencies().addAligned(coords, builder.build());
+        // If MANAGED style: the managed entry and version property belong in the
+        // management POM (parent), not the local module POM.
+        if (detected.versionStyle() == AlignOptions.VersionStyle.MANAGED && !hadManagedEntry) {
+            // Remove the local managed entry that addAligned just created
+            editor.dependencies().deleteManagedDependency(coords);
+            // Clean up empty <dependencyManagement> wrapper left behind
+            editor.document().root().childElement("dependencyManagement").ifPresent(dm -> {
+                boolean empty = dm.childElement("dependencies")
+                        .map(deps ->
+                                deps.childElements("dependency").findFirst().isEmpty())
+                        .orElse(true);
+                if (empty) {
+                    editor.document().root().removeChild(dm);
+                }
+            });
+            // Add the managed entry (and version property) to the management POM
+            PomEditSession mgmt = managementSession != null ? managementSession : session;
+            session.addManagedDependencyAligned(coords, mgmt);
         }
     }
 
@@ -1120,8 +1171,13 @@ public class DependenciesTui extends ToolPanel {
     }
 
     private void toggleDiffView() {
-        long changes = diffOverlay.open(editSession.originalContent(), editSession.currentXml());
-        status = changes == 0 ? "No changes to show" : changes + " line(s) changed";
+        var diffs = collectAllDiffs();
+        if (diffs.isEmpty()) {
+            status = "No changes to show";
+            return;
+        }
+        long changes = diffOverlay.openMulti(diffs);
+        status = changes == 0 ? "No changes to show" : changes + " line(s) changed across " + diffs.size() + " file(s)";
     }
 
     /**
@@ -1154,18 +1210,15 @@ public class DependenciesTui extends ToolPanel {
         Coordinates coords = (classifier != null && !classifier.isEmpty())
                 ? Coordinates.of(groupId, artifactId, version, classifier, "jar")
                 : Coordinates.of(groupId, artifactId, version);
+        AlignOptions detected = editor.dependencies().detectConventions();
+        AlignOptions.Builder builder = AlignOptions.builder()
+                .versionStyle(detected.versionStyle())
+                .versionSource(detected.versionSource())
+                .namingConvention(detected.namingConvention());
         if (scope != null && !scope.isEmpty() && !COMPILE_SCOPE.equals(scope)) {
-            AlignOptions detected = editor.dependencies().detectConventions();
-            AlignOptions options = AlignOptions.builder()
-                    .versionStyle(detected.versionStyle())
-                    .versionSource(detected.versionSource())
-                    .namingConvention(detected.namingConvention())
-                    .scope(scope)
-                    .build();
-            editor.dependencies().addAligned(coords, options);
-        } else {
-            editor.dependencies().addAligned(coords);
+            builder.scope(scope);
         }
+        editor.dependencies().addAligned(coords, builder.build());
         return editor.toXml();
     }
 
@@ -1458,21 +1511,18 @@ public class DependenciesTui extends ToolPanel {
         if (bytecodeAnalyzed && dep.usageStatus != null) {
             spans.add(Span.raw("  │ ").fg(theme.detailSeparatorColor()));
             spans.add(Span.raw("Usage: ").bold());
-            int used = dep.usedMembers != null ? dep.usedMembers.size() : 0;
             String usageText;
             if (dep.usageStatus == DependencyUsageAnalyzer.UsageStatus.UNDETERMINED) {
                 usageText = "Could not determine (no classes found in JAR)";
-            } else if (used > 0) {
-                usageText = used + " of " + dep.totalClasses + " classes referenced";
-                if (!dep.declared) {
-                    usageText += " (should be declared)";
-                }
-            } else if (hasSpi && dep.usageStatus == DependencyUsageAnalyzer.UsageStatus.USED) {
-                usageText = "Used via SPI/ServiceLoader";
-            } else {
+            } else if (dep.usageStatus == DependencyUsageAnalyzer.UsageStatus.USED) {
+                int usedCount = dep.usedMembers != null ? dep.usedMembers.size() : 0;
+                String classInfo = dep.totalClasses > 0 ? " (" + usedCount + "/" + dep.totalClasses + " classes)" : "";
                 usageText = dep.declared
-                        ? "0 of " + dep.totalClasses + " classes referenced (may be safe to remove)"
-                        : "Not directly referenced";
+                        ? "Directly referenced" + classInfo
+                        : "Directly referenced" + classInfo + " — should be declared";
+            } else {
+                usageText =
+                        dep.declared ? "Not directly referenced (may be safe to remove)" : "Not directly referenced";
             }
             Color usageColor =
                     switch (dep.usageStatus) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DiffOverlay.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DiffOverlay.java
@@ -22,6 +22,8 @@ import dev.tamboui.layout.Rect;
 import dev.tamboui.terminal.Frame;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.MouseEvent;
+import dev.tamboui.tui.event.MouseEventKind;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -83,7 +85,7 @@ class DiffOverlay {
                 if (!allLines.isEmpty()) {
                     allLines.add(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, ""));
                 }
-                allLines.add(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "── " + entry.getKey() + " ──"));
+                allLines.add(new UnifiedDiff.DiffLine(UnifiedDiff.Type.HEADER, "── " + entry.getKey() + " ──"));
                 allLines.addAll(UnifiedDiff.filterContext(fullDiff, 3));
                 totalChanges += changes;
             }
@@ -100,6 +102,35 @@ class DiffOverlay {
     void close() {
         lines = null;
         scroll = 0;
+    }
+
+    void scrollUp() {
+        if (scroll > 0) scroll--;
+    }
+
+    void scrollDown(int contentHeight) {
+        scroll = Math.min(scroll + 1, maxScroll(contentHeight));
+    }
+
+    private int maxScroll(int contentHeight) {
+        return UnifiedDiff.maxScroll(lines, contentHeight);
+    }
+
+    /**
+     * Handle mouse scroll events when the overlay is active.
+     *
+     * @return {@code true} if the event was handled
+     */
+    boolean handleMouseScroll(MouseEvent mouse, int contentHeight) {
+        if (!isActive() || !mouse.isScroll()) {
+            return false;
+        }
+        if (mouse.kind() == MouseEventKind.SCROLL_UP) {
+            scrollUp();
+        } else {
+            scrollDown(contentHeight);
+        }
+        return true;
     }
 
     /**

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -107,6 +107,7 @@ public class PilotEngine {
         return createSingleDependenciesPanel(proj, session, projects, sessionProvider);
     }
 
+    @SuppressWarnings("squid:S112") // private method; callers throw mixed checked exceptions
     private ToolPanel createSingleDependenciesPanel(
             PilotProject proj,
             PomEditSession session,
@@ -297,41 +298,58 @@ public class PilotEngine {
         Set<String> mainRefs = mainScan.referencedClasses();
         Set<String> allRefs = new HashSet<>(mainRefs);
         allRefs.addAll(testScan.referencedClasses());
-        Map<String, Set<String>> mainMembers = mainScan.memberReferences();
-        Map<String, Set<String>> testMembers = testScan.memberReferences();
 
         for (var deps : List.of(declared, transitive)) {
             for (var dep : deps) {
                 Set<String> depClasses = gaToClasses.get(dep.ga());
                 dep.totalClasses = depClasses != null ? depClasses.size() : 0;
-
                 if (depClasses != null) {
                     boolean isTest = TEST_SCOPES.contains(dep.scope);
-                    Set<String> refs = isTest ? allRefs : mainRefs;
-                    Map<String, List<String>> used = new LinkedHashMap<>();
-                    for (String cls : depClasses) {
-                        if (!refs.contains(cls)) continue;
-                        Set<String> memberSet = new HashSet<>();
-                        Set<String> m = mainMembers.get(cls);
-                        if (m != null) memberSet.addAll(m);
-                        if (isTest) {
-                            Set<String> t = testMembers.get(cls);
-                            if (t != null) memberSet.addAll(t);
-                        }
-                        used.put(cls, new ArrayList<>(memberSet));
-                    }
-                    dep.usedMembers = used.isEmpty() ? null : used;
+                    dep.usedMembers = findUsedMembers(
+                            depClasses,
+                            isTest,
+                            mainRefs,
+                            allRefs,
+                            mainScan.memberReferences(),
+                            testScan.memberReferences());
                 }
-
-                File jarFile = gaToJar.get(dep.ga());
-                if (jarFile != null) {
-                    Set<String> spi = DependencyUsageAnalyzer.getRuntimeDiscoveryClasses(jarFile);
-                    if (!spi.isEmpty()) {
-                        dep.spiServices = new ArrayList<>(spi);
-                    }
-                }
+                dep.spiServices = findSpiServices(gaToJar, dep.ga());
             }
         }
+    }
+
+    private static Map<String, List<String>> findUsedMembers(
+            Set<String> depClasses,
+            boolean isTest,
+            Set<String> mainRefs,
+            Set<String> allRefs,
+            Map<String, Set<String>> mainMembers,
+            Map<String, Set<String>> testMembers) {
+        Set<String> refs = isTest ? allRefs : mainRefs;
+        Map<String, List<String>> used = new LinkedHashMap<>();
+        for (String cls : depClasses) {
+            if (!refs.contains(cls)) continue;
+            Set<String> memberSet = new HashSet<>();
+            Set<String> m = mainMembers.get(cls);
+            if (m != null) memberSet.addAll(m);
+            if (isTest) {
+                Set<String> t = testMembers.get(cls);
+                if (t != null) memberSet.addAll(t);
+            }
+            used.put(cls, new ArrayList<>(memberSet));
+        }
+        return used.isEmpty() ? null : used;
+    }
+
+    private static List<String> findSpiServices(Map<String, File> gaToJar, String ga) {
+        File jarFile = gaToJar.get(ga);
+        if (jarFile != null) {
+            Set<String> spi = DependencyUsageAnalyzer.getRuntimeDiscoveryClasses(jarFile);
+            if (!spi.isEmpty()) {
+                return new ArrayList<>(spi);
+            }
+        }
+        return null;
     }
 
     private static String reactorGav(List<PilotProject> projects) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -45,6 +46,7 @@ public class PilotEngine {
     private final String scope;
     private final Map<String, DependencyTreeModel> treeCache = new java.util.concurrent.ConcurrentHashMap<>();
     private final Map<String, AuditTui.AuditEntry> auditEntryCache = new java.util.concurrent.ConcurrentHashMap<>();
+    private static final Set<String> TEST_SCOPES = Set.of("test", "test-only", "test-runtime");
 
     public PilotEngine(PilotResolver resolver, List<PilotProject> allProjects, String scope) {
         this.resolver = resolver;
@@ -81,10 +83,10 @@ public class PilotEngine {
             Consumer<String> progress)
             throws Exception {
         return switch (toolId) {
-            case "dependencies" -> createDependenciesPanel(proj, projects, session, progress);
+            case "dependencies" -> createDependenciesPanel(proj, projects, session, sessionProvider, progress);
             case "updates" -> createUpdatesPanel(proj, projects, session, sessionProvider, progress);
-            case "conflicts" -> createConflictsPanel(proj, projects, session, progress);
-            case "audit" -> createAuditPanel(proj, projects, session, progress);
+            case "conflicts" -> createConflictsPanel(proj, projects, session, sessionProvider, progress);
+            case "audit" -> createAuditPanel(proj, projects, session, sessionProvider, progress);
             case "pom" -> createPomPanel(proj, session);
             case "align" -> createAlignPanel(proj, projects);
             case "search" -> createSearchPanel();
@@ -93,15 +95,24 @@ public class PilotEngine {
     }
 
     private ToolPanel createDependenciesPanel(
-            PilotProject proj, List<PilotProject> projects, PomEditSession session, Consumer<String> progress)
+            PilotProject proj,
+            List<PilotProject> projects,
+            PomEditSession session,
+            java.util.function.Function<Path, PomEditSession> sessionProvider,
+            Consumer<String> progress)
             throws Exception {
         if (projects.size() > 1) {
-            return createReactorDependenciesPanel(projects, progress);
+            return createReactorDependenciesPanel(projects, sessionProvider, progress);
         }
-        return createSingleDependenciesPanel(proj, session);
+        return createSingleDependenciesPanel(proj, session, projects, sessionProvider);
     }
 
-    private ToolPanel createSingleDependenciesPanel(PilotProject proj, PomEditSession session) throws Exception {
+    private ToolPanel createSingleDependenciesPanel(
+            PilotProject proj,
+            PomEditSession session,
+            List<PilotProject> projects,
+            java.util.function.Function<Path, PomEditSession> sessionProvider)
+            throws Exception {
         Set<String> declaredGAs = new HashSet<>();
         List<DependenciesTui.DepEntry> declared = new ArrayList<>();
         for (PilotProject.Dep dep : proj.dependencies) {
@@ -149,6 +160,7 @@ public class PilotEngine {
                 dep.usageStatus = usage.transitiveUsage()
                         .getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
             }
+            populateDepDetails(declared, transitive, classIndex, gaToJar, mainScan, testScan);
         }
 
         List<DependenciesTui.ManagedEntry> managed = buildManagedEntries(proj);
@@ -157,10 +169,15 @@ public class PilotEngine {
         TreeTui treeTui = new TreeTui(treeModel, scope, proj.gav());
 
         PomEditSession s = session != null ? session : new PomEditSession(proj.pomPath);
-        return new DependenciesTui(declared, transitive, managed, s, proj.gav(), bytecodeAnalyzed, treeTui);
+        PomEditSession mgmtSession = resolveManagementSession(proj, projects, s, sessionProvider);
+        return new DependenciesTui(
+                declared, transitive, managed, s, mgmtSession, proj.gav(), bytecodeAnalyzed, treeTui);
     }
 
-    private ToolPanel createReactorDependenciesPanel(List<PilotProject> projects, Consumer<String> progress)
+    private ToolPanel createReactorDependenciesPanel(
+            List<PilotProject> projects,
+            java.util.function.Function<Path, PomEditSession> sessionProvider,
+            Consumer<String> progress)
             throws Exception {
         Map<String, DependenciesTui.DepEntry> unusedMap = new LinkedHashMap<>();
         Map<String, DependenciesTui.DepEntry> usedTransMap = new LinkedHashMap<>();
@@ -177,12 +194,16 @@ public class PilotEngine {
             analyzeModuleUsage(p, unusedMap, usedTransMap);
         }
 
+        PilotProject mgmtProject = findManagementPom(projects);
+        PomEditSession mgmtSession = sessionProvider != null ? sessionProvider.apply(mgmtProject.pomPath) : null;
         return new DependenciesTui(
                 new ArrayList<>(unusedMap.values()),
                 new ArrayList<>(usedTransMap.values()),
                 reactorGav(projects),
                 modulesScanned,
-                modulesSkipped);
+                modulesSkipped,
+                sessionProvider,
+                mgmtSession);
     }
 
     private void analyzeModuleUsage(
@@ -216,15 +237,22 @@ public class PilotEngine {
         Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
         DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.analyze(
                 mainScan.referencedClasses(), testScan.referencedClasses(), classIndex, gaToJar, declared, transitive);
+        populateDepDetails(declared, transitive, classIndex, gaToJar, mainScan, testScan);
 
         accumulateEntries(
-                declared, usage.declaredUsage(), DependencyUsageAnalyzer.UsageStatus.UNUSED, unusedMap, p.artifactId);
+                declared,
+                usage.declaredUsage(),
+                DependencyUsageAnalyzer.UsageStatus.UNUSED,
+                unusedMap,
+                p.artifactId,
+                p.pomPath);
         accumulateEntries(
                 transitive,
                 usage.transitiveUsage(),
                 DependencyUsageAnalyzer.UsageStatus.USED,
                 usedTransMap,
-                p.artifactId);
+                p.artifactId,
+                p.pomPath);
     }
 
     private static void accumulateEntries(
@@ -232,7 +260,8 @@ public class PilotEngine {
             Map<String, DependencyUsageAnalyzer.UsageStatus> usageMap,
             DependencyUsageAnalyzer.UsageStatus targetStatus,
             Map<String, DependenciesTui.DepEntry> accumulator,
-            String moduleName) {
+            String moduleName,
+            Path pomPath) {
         for (var dep : deps) {
             var us = usageMap.getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
             if (us == targetStatus) {
@@ -240,9 +269,66 @@ public class PilotEngine {
                 if (existing == null) {
                     dep.usageStatus = targetStatus;
                     dep.modules.add(moduleName);
+                    dep.modulePomPaths.add(pomPath);
                     accumulator.put(dep.ga(), dep);
                 } else if (!existing.modules.contains(moduleName)) {
                     existing.modules.add(moduleName);
+                    existing.modulePomPaths.add(pomPath);
+                }
+            }
+        }
+    }
+
+    /**
+     * Populate detail fields (totalClasses, usedMembers, spiServices) on each DepEntry
+     * using bytecode scan results and the class index.
+     */
+    private static void populateDepDetails(
+            List<DependenciesTui.DepEntry> declared,
+            List<DependenciesTui.DepEntry> transitive,
+            Map<String, String> classIndex,
+            Map<String, File> gaToJar,
+            ClassFileScanner.ScanResult mainScan,
+            ClassFileScanner.ScanResult testScan) {
+        Map<String, Set<String>> gaToClasses = new HashMap<>();
+        for (var entry : classIndex.entrySet()) {
+            gaToClasses.computeIfAbsent(entry.getValue(), k -> new HashSet<>()).add(entry.getKey());
+        }
+        Set<String> mainRefs = mainScan.referencedClasses();
+        Set<String> allRefs = new HashSet<>(mainRefs);
+        allRefs.addAll(testScan.referencedClasses());
+        Map<String, Set<String>> mainMembers = mainScan.memberReferences();
+        Map<String, Set<String>> testMembers = testScan.memberReferences();
+
+        for (var deps : List.of(declared, transitive)) {
+            for (var dep : deps) {
+                Set<String> depClasses = gaToClasses.get(dep.ga());
+                dep.totalClasses = depClasses != null ? depClasses.size() : 0;
+
+                if (depClasses != null) {
+                    boolean isTest = TEST_SCOPES.contains(dep.scope);
+                    Set<String> refs = isTest ? allRefs : mainRefs;
+                    Map<String, List<String>> used = new LinkedHashMap<>();
+                    for (String cls : depClasses) {
+                        if (!refs.contains(cls)) continue;
+                        Set<String> memberSet = new HashSet<>();
+                        Set<String> m = mainMembers.get(cls);
+                        if (m != null) memberSet.addAll(m);
+                        if (isTest) {
+                            Set<String> t = testMembers.get(cls);
+                            if (t != null) memberSet.addAll(t);
+                        }
+                        used.put(cls, new ArrayList<>(memberSet));
+                    }
+                    dep.usedMembers = used.isEmpty() ? null : used;
+                }
+
+                File jarFile = gaToJar.get(dep.ga());
+                if (jarFile != null) {
+                    Set<String> spi = DependencyUsageAnalyzer.getRuntimeDiscoveryClasses(jarFile);
+                    if (!spi.isEmpty()) {
+                        dep.spiServices = new ArrayList<>(spi);
+                    }
                 }
             }
         }
@@ -268,12 +354,17 @@ public class PilotEngine {
     }
 
     private ToolPanel createConflictsPanel(
-            PilotProject proj, List<PilotProject> projects, PomEditSession session, Consumer<String> progress) {
+            PilotProject proj,
+            List<PilotProject> projects,
+            PomEditSession session,
+            java.util.function.Function<java.nio.file.Path, PomEditSession> sessionProvider,
+            Consumer<String> progress) {
         List<PilotProject> targetProjects = projects.size() > 1 ? projects : List.of(proj);
         resolveAllDependencies(targetProjects, progress);
         String gav = projects.size() > 1 ? reactorGav(projects) : proj.gav();
         PomEditSession s = session != null ? session : new PomEditSession(proj.pomPath);
-        return new ConflictsTui(targetProjects, s, gav, this::cachedCollectDependencies);
+        PomEditSession mgmtSession = resolveManagementSession(proj, projects, s, sessionProvider);
+        return new ConflictsTui(targetProjects, s, mgmtSession, gav, this::cachedCollectDependencies);
     }
 
     private ToolPanel createAlignPanel(PilotProject proj, List<PilotProject> projects) throws Exception {
@@ -299,7 +390,11 @@ public class PilotEngine {
     }
 
     private ToolPanel createAuditPanel(
-            PilotProject proj, List<PilotProject> projects, PomEditSession session, Consumer<String> progress) {
+            PilotProject proj,
+            List<PilotProject> projects,
+            PomEditSession session,
+            java.util.function.Function<java.nio.file.Path, PomEditSession> sessionProvider,
+            Consumer<String> progress) {
         if (projects.size() > 1) {
             resolveAllDependencies(projects, progress);
             PilotProject root = projects.get(0);
@@ -319,7 +414,8 @@ public class PilotEngine {
             List<AuditTui.AuditEntry> entries = new ArrayList<>(entryMap.values());
             String gav = reactorGav(projects);
             if (session != null) {
-                return new AuditTui(entries, gav, treeModel, session);
+                PomEditSession mgmtSession = resolveManagementSession(proj, projects, session, sessionProvider);
+                return new AuditTui(entries, gav, treeModel, session, mgmtSession);
             }
             return new AuditTui(entries, gav, treeModel, root.pomPath.toString());
         } else {
@@ -328,7 +424,8 @@ public class PilotEngine {
             collectAuditNode(treeModel.root, entryMap, null, true);
             List<AuditTui.AuditEntry> entries = new ArrayList<>(entryMap.values());
             if (session != null) {
-                return new AuditTui(entries, proj.gav(), treeModel, session);
+                PomEditSession mgmtSession = resolveManagementSession(proj, projects, session, sessionProvider);
+                return new AuditTui(entries, proj.gav(), treeModel, session, mgmtSession);
             }
             return new AuditTui(entries, proj.gav(), treeModel, proj.pomPath.toString());
         }
@@ -405,17 +502,27 @@ public class PilotEngine {
 
     // ── Shared helpers ────────────────────────────────────────────────────
 
-    static PilotProject findManagementPom(List<PilotProject> projects) {
-        Set<String> projectPaths = new HashSet<>();
-        for (PilotProject p : projects) {
-            projectPaths.add(p.pomPath.toString());
+    private PomEditSession resolveManagementSession(
+            PilotProject proj,
+            List<PilotProject> projects,
+            PomEditSession currentSession,
+            java.util.function.Function<java.nio.file.Path, PomEditSession> sessionProvider) {
+        if (sessionProvider == null) {
+            return currentSession;
         }
+        PilotProject mgmtProject = findManagementPom(projects.size() > 1 ? projects : List.of(proj));
+        if (mgmtProject.pomPath.equals(proj.pomPath)) {
+            return currentSession;
+        }
+        return sessionProvider.apply(mgmtProject.pomPath);
+    }
 
+    static PilotProject findManagementPom(List<PilotProject> projects) {
         PilotProject child = projects.size() > 1 ? projects.get(1) : projects.get(0);
         PilotProject current = child.parent;
 
         while (current != null && current.pomPath != null) {
-            if (!projectPaths.contains(current.pomPath.toString())) {
+            if (isRepositoryPom(current.pomPath)) {
                 break;
             }
             var mgmt = current.originalManagedDependencies;
@@ -426,6 +533,15 @@ public class PilotEngine {
         }
 
         return projects.get(0);
+    }
+
+    /**
+     * Check if a POM path points to a Maven local repository artifact
+     * (which should never be modified).
+     */
+    static boolean isRepositoryPom(Path pomPath) {
+        String path = pomPath.toString();
+        return path.contains("/.m2/repository/") || path.contains("\\.m2\\repository\\");
     }
 
     private void collectAuditNode(

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -662,7 +662,9 @@ public class PilotShell {
                 if (panel != null && runner != null) {
                     runner.runOnRenderThread(() -> onPanelLoaded(cacheKey, panel, subView));
                 }
-            } catch (Throwable e) {
+            } catch (Exception e) {
+                handlePanelLoadError(cacheKey, e);
+            } catch (Error e) {
                 handlePanelLoadError(cacheKey, e);
             }
         });
@@ -691,6 +693,7 @@ public class PilotShell {
         }
     }
 
+    @SuppressWarnings("squid:S106") // no logger framework available; stderr is intentional for diagnostics
     private void handlePanelLoadError(String cacheKey, Throwable e) {
         System.err.println("[Pilot] Panel load error for " + cacheKey + ": " + e);
         e.printStackTrace(System.err);

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -139,6 +139,7 @@ public class PilotShell {
     private final Map<String, Future<?>> runningTasks = new HashMap<>();
     private String panelError;
     private volatile String panelLoadingStatus;
+    private volatile boolean pendingRedraw;
     private final LoadingStatusSupplier loadingStatusSupplier;
 
     public PilotShell(ReactorModel reactorModel, List<PilotProject> projects, ToolPanelFactory panelFactory) {
@@ -154,6 +155,11 @@ public class PilotShell {
         this.projects = projects;
         this.panelFactory = panelFactory;
         this.loadingStatusSupplier = loadingStatusSupplier;
+
+        // Set root directory for display paths (relative to project root, not CWD)
+        if (!projects.isEmpty()) {
+            ToolPanel.setRootDir(projects.get(0).pomPath.getParent());
+        }
 
         boolean singleModule = reactorModel == null || projects.size() <= 1;
 
@@ -243,6 +249,11 @@ public class PilotShell {
     }
 
     private boolean needsTickRedraw() {
+        // UI state changed from a background thread callback
+        if (pendingRedraw) {
+            pendingRedraw = false;
+            return true;
+        }
         // Tree width animation in progress
         if (currentTreeCols >= 0) {
             int fullWidth = 120;
@@ -268,25 +279,10 @@ public class PilotShell {
             runner.quit();
             return true;
         }
-
-        // Pending quit prompt: y/n/Esc
         if (pendingQuit) {
-            if (key.isCharIgnoreCase('y')) {
-                saveAllAndQuit();
-                return true;
-            }
-            if (key.isCharIgnoreCase('n')) {
-                runner.quit();
-                return true;
-            }
-            if (key.isKey(KeyCode.ESCAPE)) {
-                pendingQuit = false;
-                pendingQuitStatus = null;
-                return true;
-            }
-            return true; // consume all keys during quit prompt
+            handlePendingQuitKey(key);
+            return true;
         }
-
         // Alt+letter: switch tool (checked before delegation because
         // isCharIgnoreCase does not check modifiers)
         if (key.modifiers().alt() && key.code() == KeyCode.CHAR) {
@@ -298,39 +294,72 @@ public class PilotShell {
                 }
             }
         }
-
         // Edit lifecycle keys (before panel delegation so they're global)
-        PomEditSession session = currentSession();
-        if (key.isCharIgnoreCase('w') && session != null && session.isDirty()) {
-            PomEditSession.SaveResult result = session.save();
-            pendingQuitStatus = result.message();
-            return true;
-        }
-        if (key.isChar('z') && session != null && session.isDirty()) {
-            if (session.undoLast()) {
-                pendingQuitStatus = "Undid last change";
-            }
-            return true;
-        }
-        if (key.isChar('R') && session != null && session.isDirty()) {
-            session.revertAll();
-            // Invalidate cached panels for this POM so they refresh
-            invalidatePanelCacheForPom(session.pomPath());
-            refreshActivePanel();
-            pendingQuitStatus = "Reverted all changes";
-            return true;
-        }
-
+        if (handleEditLifecycleKey(key)) return true;
         // Delegate to focused pane (search inputs consume chars like q)
         if (focus == Focus.TREE && treePane != null) {
             if (treePane.handleKeyEvent(key)) return true;
         } else if (focus == Focus.CONTENT && activePanel != null) {
             if (activePanel.handleKeyEvent(key)) return true;
         }
-
         // Shell-level keys (unhandled by focused pane)
+        return handleShellKey(key);
+    }
+
+    /** Handles y/n/Esc keys while the quit confirmation prompt is active. */
+    private void handlePendingQuitKey(KeyEvent key) {
+        if (key.isCharIgnoreCase('y')) {
+            saveAllAndQuit();
+        } else if (key.isCharIgnoreCase('n')) {
+            runner.quit();
+        } else if (key.isKey(KeyCode.ESCAPE)) {
+            pendingQuit = false;
+            pendingQuitStatus = null;
+        }
+        // all other keys consumed silently during quit prompt
+    }
+
+    /** Handles save (w), undo (z), and revert (R) keys. */
+    private boolean handleEditLifecycleKey(KeyEvent key) {
+        List<PomEditSession> dirtySessions =
+                sessionCache.values().stream().filter(PomEditSession::isDirty).toList();
+        if (key.isCharIgnoreCase('w') && !dirtySessions.isEmpty()) {
+            int saved = 0;
+            for (PomEditSession s : dirtySessions) {
+                PomEditSession.SaveResult result = s.save();
+                if (!result.success()) {
+                    pendingQuitStatus = result.message();
+                    return true;
+                }
+                saved++;
+            }
+            pendingQuitStatus = "Saved " + saved + " file(s)";
+            return true;
+        }
+        PomEditSession session = currentSession();
+        if (key.isChar('z') && session != null && session.isDirty()) {
+            if (session.undoLast()) {
+                invalidatePanelCacheForPom(null);
+                refreshActivePanel();
+                pendingQuitStatus = "Undid last change";
+            }
+            return true;
+        }
+        if (key.isChar('R') && !dirtySessions.isEmpty()) {
+            for (PomEditSession s : dirtySessions) {
+                s.revertAll();
+            }
+            invalidatePanelCacheForPom(null);
+            refreshActivePanel();
+            pendingQuitStatus = "Reverted all changes across " + dirtySessions.size() + " file(s)";
+            return true;
+        }
+        return false;
+    }
+
+    /** Handles navigation keys: Tab, number keys, Enter, q, ?, h, backslash. */
+    private boolean handleShellKey(KeyEvent key) {
         if (key.isKey(KeyCode.TAB)) {
-            // Tab toggles focus between tree and content
             if (treePane != null) {
                 toggleFocus();
             }
@@ -342,23 +371,7 @@ public class PilotShell {
                 && !key.hasAlt()
                 && key.character() >= '0'
                 && key.character() <= '9') {
-            if (key.character() == '0') {
-                if (treePane != null) {
-                    setFocus(Focus.TREE);
-                }
-                return true;
-            }
-            int index = key.character() - '1';
-            if (activePanel != null && index < activePanel.subViewCount()) {
-                activePanel.setActiveSubView(index);
-                if (focus != Focus.CONTENT) setFocus(Focus.CONTENT);
-                return true;
-            }
-            // Even if panel has only one view, '1' focuses content
-            if (activePanel != null && index == 0) {
-                if (focus != Focus.CONTENT) setFocus(Focus.CONTENT);
-                return true;
-            }
+            return handleNumberKey(key);
         }
         if (key.isKey(KeyCode.ENTER) && focus == Focus.TREE) {
             setFocus(Focus.CONTENT);
@@ -376,7 +389,28 @@ public class PilotShell {
             cycleTreeWidth();
             return true;
         }
+        return false;
+    }
 
+    /** Handles digit keys: 0 focuses the module tree, 1-9 selects sub-view tabs. */
+    private boolean handleNumberKey(KeyEvent key) {
+        if (key.character() == '0') {
+            if (treePane != null) {
+                setFocus(Focus.TREE);
+            }
+            return true;
+        }
+        int index = key.character() - '1';
+        if (activePanel != null && index < activePanel.subViewCount()) {
+            activePanel.setActiveSubView(index);
+            if (focus != Focus.CONTENT) setFocus(Focus.CONTENT);
+            return true;
+        }
+        // Even if panel has only one view, '1' focuses content
+        if (activePanel != null && index == 0) {
+            if (focus != Focus.CONTENT) setFocus(Focus.CONTENT);
+            return true;
+        }
         return false;
     }
 
@@ -612,8 +646,12 @@ public class PilotShell {
         } else {
             session = null;
         }
-        final java.util.function.Function<java.nio.file.Path, PomEditSession> sessionProvider =
-                path -> sessionCache.computeIfAbsent(path.toString(), k -> new PomEditSession(path));
+        final java.util.function.Function<java.nio.file.Path, PomEditSession> sessionProvider = path -> {
+            if (PilotEngine.isRepositoryPom(path)) {
+                throw new IllegalArgumentException("Cannot modify repository POM: " + path);
+            }
+            return sessionCache.computeIfAbsent(path.toString(), k -> new PomEditSession(path));
+        };
         Future<?> task = panelExecutor.submit(() -> {
             try {
                 ToolPanel panel = panelFactory.create(tool.id, proj, scope, session, sessionProvider, s -> {
@@ -624,7 +662,7 @@ public class PilotShell {
                 if (panel != null && runner != null) {
                     runner.runOnRenderThread(() -> onPanelLoaded(cacheKey, panel, subView));
                 }
-            } catch (Exception e) {
+            } catch (Throwable e) {
                 handlePanelLoadError(cacheKey, e);
             }
         });
@@ -633,6 +671,7 @@ public class PilotShell {
 
     private void onPanelLoaded(String cacheKey, ToolPanel panel, int subView) {
         panel.setRunner(runner);
+        panel.setAllSessionsSupplier(sessionCache::values);
         PomEditSession session = currentSession();
         if (session != null) {
             panel.lastSeenMutationCount = session.mutationCount();
@@ -648,10 +687,13 @@ public class PilotShell {
                 activePanel.setActiveSubView(subView);
             }
             loadingCacheKey = null;
+            pendingRedraw = true;
         }
     }
 
-    private void handlePanelLoadError(String cacheKey, Exception e) {
+    private void handlePanelLoadError(String cacheKey, Throwable e) {
+        System.err.println("[Pilot] Panel load error for " + cacheKey + ": " + e);
+        e.printStackTrace(System.err);
         String msg = e.getMessage();
         if (msg == null) msg = e.getClass().getSimpleName();
         final String errorMsg = msg;
@@ -661,6 +703,7 @@ public class PilotShell {
                 if (cacheKey.equals(loadingCacheKey)) {
                     loadingCacheKey = null;
                     panelError = errorMsg;
+                    pendingRedraw = true;
                 }
             });
         }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomEditSession.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomEditSession.java
@@ -19,6 +19,8 @@
 package eu.maveniverse.maven.pilot;
 
 import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.maven.AlignOptions;
+import eu.maveniverse.domtrip.maven.Coordinates;
 import eu.maveniverse.domtrip.maven.PomEditor;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -156,6 +158,54 @@ public class PomEditSession {
             }
         }
         return null;
+    }
+
+    // -- Convention-aware managed dependency --
+
+    /**
+     * Add or update a managed dependency following the project's detected conventions,
+     * placing the managed dependency (and any version property) in this session's POM.
+     *
+     * @param coords the artifact coordinates (groupId, artifactId, version required)
+     */
+    void addManagedDependencyAligned(Coordinates coords) {
+        addManagedDependencyAligned(coords, this);
+    }
+
+    /**
+     * Add or update a managed dependency following conventions, placing the managed
+     * dependency and version property in the specified management session's POM.
+     *
+     * <p>Conventions are detected from the management POM. If the management session is
+     * different from this session, changes are recorded on the management session and
+     * its {@link #beforeMutation()} is called automatically.</p>
+     *
+     * @param coords            the artifact coordinates (groupId, artifactId, version required)
+     * @param managementSession the session whose POM should receive the managed dependency
+     */
+    void addManagedDependencyAligned(Coordinates coords, PomEditSession managementSession) {
+        PomEditor targetEditor = managementSession.editor();
+        AlignOptions conventions = targetEditor.dependencies().detectConventions();
+        AlignOptions.VersionSource versionSource = conventions.versionSource();
+        String version = coords.version();
+        if (managementSession != this) {
+            managementSession.beforeMutation();
+        }
+        if (versionSource == AlignOptions.VersionSource.PROPERTY) {
+            AlignOptions.PropertyNamingConvention naming = conventions.namingConvention();
+            String propName = AlignOptions.generatePropertyName(coords, naming);
+            targetEditor.properties().updateProperty(true, propName, version);
+            coords = Coordinates.of(coords.groupId(), coords.artifactId(), "${" + propName + "}");
+        }
+        targetEditor.dependencies().updateManagedDependency(true, coords);
+        if (managementSession != this) {
+            managementSession.recordChange(
+                    ChangeType.ADD,
+                    "managed",
+                    coords.groupId() + ":" + coords.artifactId(),
+                    "added " + version + " to dependencyManagement",
+                    "cross-module");
+        }
     }
 
     // -- Diff --

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 /**
@@ -214,10 +215,11 @@ public abstract class ToolPanel {
         this.allSessionsSupplier = supplier;
     }
 
-    private static volatile Path rootDir = Path.of("").toAbsolutePath();
+    private static final AtomicReference<Path> rootDir =
+            new AtomicReference<>(Path.of("").toAbsolutePath());
 
     static void setRootDir(Path dir) {
-        rootDir = dir;
+        rootDir.set(dir);
     }
 
     /**
@@ -225,7 +227,7 @@ public abstract class ToolPanel {
      */
     static String displayPath(Path path) {
         try {
-            return rootDir.relativize(path).toString();
+            return rootDir.get().relativize(path).toString();
         } catch (IllegalArgumentException e) {
             return path.toString();
         }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -35,9 +35,14 @@ import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.paragraph.Paragraph;
 import dev.tamboui.widgets.table.TableState;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * Base class for tool panels that render into the right-side area of the unified shell.
@@ -200,6 +205,52 @@ public abstract class ToolPanel {
     /** Called when the TuiRunner is available (for async operations). */
     void setRunner(TuiRunner runner) {
         this.runner = runner;
+    }
+
+    /** Supplier for all POM edit sessions across the reactor (set by PilotShell). */
+    protected Supplier<Collection<PomEditSession>> allSessionsSupplier;
+
+    void setAllSessionsSupplier(Supplier<Collection<PomEditSession>> supplier) {
+        this.allSessionsSupplier = supplier;
+    }
+
+    private static volatile Path rootDir = Path.of("").toAbsolutePath();
+
+    static void setRootDir(Path dir) {
+        rootDir = dir;
+    }
+
+    /**
+     * Return a display-friendly path, relative to the project root when possible.
+     */
+    static String displayPath(Path path) {
+        try {
+            return rootDir.relativize(path).toString();
+        } catch (IllegalArgumentException e) {
+            return path.toString();
+        }
+    }
+
+    /**
+     * Collect diffs from all dirty sessions across the reactor.
+     * Falls back to just the panel's own editSession in standalone mode.
+     */
+    protected Map<String, Map.Entry<String, String>> collectAllDiffs() {
+        Map<String, Map.Entry<String, String>> diffs = new LinkedHashMap<>();
+        Collection<PomEditSession> sessions;
+        if (allSessionsSupplier != null) {
+            sessions = allSessionsSupplier.get();
+        } else if (editSession != null) {
+            sessions = List.of(editSession);
+        } else {
+            sessions = List.of();
+        }
+        for (PomEditSession session : sessions) {
+            if (session.isDirty()) {
+                diffs.put(displayPath(session.pomPath()), Map.entry(session.originalContent(), session.currentXml()));
+            }
+        }
+        return diffs;
     }
 
     /**
@@ -423,6 +474,30 @@ public abstract class ToolPanel {
         int row = mouse.y() - dataStartY + state.offset();
         if (row < 0 || row >= rowCount) return -1;
         return row;
+    }
+
+    /**
+     * Handle mouse click-to-select and scroll-to-navigate on a table.
+     * Returns {@code true} if the event was consumed.
+     */
+    protected boolean handleMouseTableInteraction(MouseEvent mouse, int rowCount, TableState state) {
+        if (mouse.isClick()) {
+            int row = mouseToTableRow(mouse, rowCount, state);
+            if (row >= 0) {
+                state.select(row);
+                return true;
+            }
+        }
+        if (mouse.isScroll()) {
+            if (rowCount == 0) return false;
+            if (mouse.kind() == dev.tamboui.tui.event.MouseEventKind.SCROLL_UP) {
+                state.selectPrevious();
+            } else {
+                state.selectNext(rowCount);
+            }
+            return true;
+        }
+        return false;
     }
 
     /** Returns sort-specific key hints, or empty list if sorting is not active. */

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -695,6 +695,7 @@ public class TreeTui extends ToolPanel {
             sortChildrenRecursive(model.root, cmp);
         }
         refreshDisplay();
+        fetchPomInfoIfNeeded();
     }
 
     private void sortChildrenRecursive(

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UnifiedDiff.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UnifiedDiff.java
@@ -38,10 +38,15 @@ class UnifiedDiff {
     enum Type {
         CONTEXT,
         ADDED,
-        REMOVED
+        REMOVED,
+        HEADER
     }
 
-    record DiffLine(Type type, String text) {}
+    record DiffLine(Type type, String text, int lineNumber) {
+        DiffLine(Type type, String text) {
+            this(type, text, 0);
+        }
+    }
 
     /**
      * Compute a line-based diff between two strings.
@@ -68,19 +73,19 @@ class UnifiedDiff {
             }
         }
 
-        // Backtrack to produce diff
+        // Backtrack to produce diff with line numbers (based on new file)
         List<DiffLine> result = new ArrayList<>();
         int i = 0, j = 0;
         while (i < m || j < n) {
             if (i < m && j < n && oldLines[i].equals(newLines[j])) {
-                result.add(new DiffLine(Type.CONTEXT, oldLines[i]));
+                result.add(new DiffLine(Type.CONTEXT, oldLines[i], j + 1));
                 i++;
                 j++;
             } else if (i < m && (j >= n || lcs[i + 1][j] >= lcs[i][j + 1])) {
-                result.add(new DiffLine(Type.REMOVED, oldLines[i]));
+                result.add(new DiffLine(Type.REMOVED, oldLines[i], 0));
                 i++;
             } else if (j < n) {
-                result.add(new DiffLine(Type.ADDED, newLines[j]));
+                result.add(new DiffLine(Type.ADDED, newLines[j], j + 1));
                 j++;
             }
         }
@@ -124,24 +129,30 @@ class UnifiedDiff {
         int end = Math.min(scroll + innerHeight, lines.size());
         for (int idx = scroll; idx < end; idx++) {
             DiffLine dl = lines.get(idx);
+            Theme theme = Theme.DEFAULT;
+            if (dl.type() == Type.HEADER) {
+                visibleLines.add(Line.from(Span.raw(dl.text()).bold().white()));
+                continue;
+            }
             String prefix;
             Style style;
-            Theme theme = Theme.DEFAULT;
             switch (dl.type()) {
                 case ADDED -> {
-                    prefix = "+ ";
+                    prefix = "+";
                     style = theme.diffAdded();
                 }
                 case REMOVED -> {
-                    prefix = "- ";
+                    prefix = "-";
                     style = theme.diffRemoved();
                 }
                 default -> {
-                    prefix = "  ";
+                    prefix = " ";
                     style = Style.create().dim();
                 }
             }
-            visibleLines.add(Line.from(Span.raw(prefix + dl.text()).style(style)));
+            String lineNum = dl.lineNumber() > 0 ? String.format("%4d ", dl.lineNumber()) : "     ";
+            visibleLines.add(Line.from(
+                    Span.raw(lineNum).dim(), Span.raw(prefix + " " + dl.text()).style(style)));
         }
 
         // Build a single Text block from all visible lines

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -1704,7 +1704,8 @@ public class UpdatesTui extends ToolPanel {
     @Override
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
         if (diffOverlay.isActive()) {
-            return diffOverlay.handleMouseScroll(mouse, lastContentHeight);
+            diffOverlay.handleMouseScroll(mouse, lastContentHeight);
+            return true;
         }
         if (handleMouseTabBar(mouse)) return true;
         List<Constraint> widths;

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -646,14 +646,14 @@ public class UpdatesTui extends ToolPanel {
             return true;
         }
 
-        // Diff overlay in standalone — allow q to quit
+        // Diff overlay in standalone
         if (diffOverlay.isActive()) {
-            if (key.isKey(KeyCode.ESCAPE)) {
+            if (key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q') || key.isCharIgnoreCase('d')) {
                 diffOverlay.close();
                 return true;
             }
             if (diffOverlay.handleScrollKey(key, lastContentHeight)) return true;
-            if (key.isCharIgnoreCase('q') || key.isCtrlC()) {
+            if (key.isCtrlC()) {
                 requestQuit();
                 return true;
             }
@@ -704,7 +704,7 @@ public class UpdatesTui extends ToolPanel {
     public boolean handleKeyEvent(KeyEvent key) {
         // Diff overlay mode — consume all keys
         if (diffOverlay.isActive()) {
-            if (key.isKey(KeyCode.ESCAPE)) {
+            if (key.isKey(KeyCode.ESCAPE) || key.isCharIgnoreCase('q') || key.isCharIgnoreCase('d')) {
                 diffOverlay.close();
                 return true;
             }
@@ -959,15 +959,15 @@ public class UpdatesTui extends ToolPanel {
     private void toggleDiffView() {
         Map<Path, PomEditor> previewEditors = buildPreviewEditors();
 
-        Map<String, Map.Entry<String, String>> fileDiffs;
-        if (previewEditors.isEmpty()) {
-            fileDiffs = collectAppliedDiffs();
-            if (fileDiffs.isEmpty()) {
-                status = "No updates selected";
-                return;
-            }
-        } else {
-            fileDiffs = collectPreviewDiffs(previewEditors);
+        // Merge applied diffs (this tool's sessions) with cross-tool diffs
+        Map<String, Map.Entry<String, String>> fileDiffs = collectAppliedDiffs();
+        fileDiffs.putAll(collectAllDiffs());
+        if (!previewEditors.isEmpty()) {
+            fileDiffs.putAll(collectPreviewDiffs(previewEditors));
+        }
+        if (fileDiffs.isEmpty()) {
+            status = "No updates selected";
+            return;
         }
 
         long changes = diffOverlay.openMulti(fileDiffs);
@@ -1007,9 +1007,11 @@ public class UpdatesTui extends ToolPanel {
 
     private Map<String, Map.Entry<String, String>> collectAppliedDiffs() {
         Map<String, Map.Entry<String, String>> diffs = new LinkedHashMap<>();
-        for (PomEditSession session : mutatedSessions) {
+        // Check all reactor modules for dirty sessions (includes changes from other tools)
+        for (var module : reactorModel.allModules) {
+            PomEditSession session = sessionProvider.apply(Path.of(module.pomPath));
             if (session.isDirty()) {
-                diffs.put(session.pomPath().toString(), Map.entry(session.originalContent(), session.currentXml()));
+                diffs.put(displayPath(session.pomPath()), Map.entry(session.originalContent(), session.currentXml()));
             }
         }
         return diffs;
@@ -1021,7 +1023,7 @@ public class UpdatesTui extends ToolPanel {
             PomEditSession session = sessionProvider.apply(entry.getKey());
             String original = session.originalContent();
             String modified = entry.getValue().toXml();
-            diffs.put(entry.getKey().toString(), Map.entry(original, modified));
+            diffs.put(displayPath(entry.getKey()), Map.entry(original, modified));
         }
         return diffs;
     }
@@ -1701,6 +1703,9 @@ public class UpdatesTui extends ToolPanel {
 
     @Override
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
+        if (diffOverlay.isActive()) {
+            return diffOverlay.handleMouseScroll(mouse, lastContentHeight);
+        }
         if (handleMouseTabBar(mouse)) return true;
         List<Constraint> widths;
         if (view == View.DEPENDENCIES) {

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ConflictsTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ConflictsTuiRenderTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import dev.tamboui.terminal.TestBackend;
 import dev.tamboui.tui.TuiConfig;
 import dev.tamboui.tui.TuiRunner;
-import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -109,13 +108,13 @@ class ConflictsTuiRenderTest {
     }
 
     @Test
-    void panelModeNoDividerWhenDetailsHidden() {
+    void panelModeAlwaysShowsDetails() {
         var tui = createTuiWithConflicts();
-        tui.handleEvent(KeyEvent.ofKey(KeyCode.ENTER), null);
         String output = render(f -> tui.render(f, f.area()));
 
+        // Details pane is always visible — divider should be present
         long dividerLines = output.lines().filter(l -> l.matches("^─+$")).count();
-        assertThat(dividerLines).isZero();
+        assertThat(dividerLines).isGreaterThan(0);
     }
 
     @Test
@@ -234,7 +233,8 @@ class ConflictsTuiRenderTest {
         PomEditSession session = new PomEditSession(Path.of(pomPath));
         PilotProject project = createDummyProject("mod-a");
 
-        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+        var tui =
+                new ConflictsTui(List.of(project), session, session, "com.example:demo:1.0.0", p -> createEmptyTree());
         String output = render(tui::renderStandalone);
 
         assertThat(output).contains("Collecting Conflicts");
@@ -244,7 +244,7 @@ class ConflictsTuiRenderTest {
     void asyncConstructorEmptyProjectsNotLoading() {
         PomEditSession session = new PomEditSession(Path.of(pomPath));
 
-        var tui = new ConflictsTui(List.of(), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+        var tui = new ConflictsTui(List.of(), session, session, "com.example:demo:1.0.0", p -> createEmptyTree());
         String output = render(tui::renderStandalone);
 
         assertThat(output).contains("Conflict Resolution");
@@ -255,7 +255,7 @@ class ConflictsTuiRenderTest {
         PomEditSession session = new PomEditSession(Path.of(pomPath));
         PilotProject project = createDummyProject("my-module");
 
-        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> {
+        var tui = new ConflictsTui(List.of(project), session, session, "com.example:demo:1.0.0", p -> {
             return createEmptyTree();
         });
         String output = render(tui::renderStandalone);
@@ -268,7 +268,8 @@ class ConflictsTuiRenderTest {
         PomEditSession session = new PomEditSession(Path.of(pomPath));
         PilotProject project = createDummyProject("my-module");
 
-        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+        var tui =
+                new ConflictsTui(List.of(project), session, session, "com.example:demo:1.0.0", p -> createEmptyTree());
         String output = render(f -> tui.render(f, f.area()));
 
         assertThat(output).contains("Collecting conflicts");
@@ -280,7 +281,7 @@ class ConflictsTuiRenderTest {
         PilotProject p1 = createDummyProject("mod-a");
         PilotProject p2 = createDummyProject("mod-b");
 
-        var tui = new ConflictsTui(List.of(p1, p2), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+        var tui = new ConflictsTui(List.of(p1, p2), session, session, "com.example:demo:1.0.0", p -> createEmptyTree());
         String output = render(tui::renderStandalone);
 
         assertThat(output).contains("Collecting Conflicts").contains("0/2");
@@ -291,7 +292,8 @@ class ConflictsTuiRenderTest {
         PomEditSession session = new PomEditSession(Path.of(pomPath));
         PilotProject project = createDummyProject("mod-a");
 
-        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+        var tui =
+                new ConflictsTui(List.of(project), session, session, "com.example:demo:1.0.0", p -> createEmptyTree());
 
         assertThat(tui.status()).contains("Collecting conflicts");
     }
@@ -303,7 +305,8 @@ class ConflictsTuiRenderTest {
         PomEditSession session = new PomEditSession(Path.of(pomPath));
         PilotProject project = createDummyProject("mod-a");
 
-        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createTreeWithConflict());
+        var tui = new ConflictsTui(
+                List.of(project), session, session, "com.example:demo:1.0.0", p -> createTreeWithConflict());
 
         Map<String, List<ConflictsTui.ConflictEntry>> result = tui.resolveModule(project, false);
 
@@ -316,7 +319,8 @@ class ConflictsTuiRenderTest {
         PomEditSession session = new PomEditSession(Path.of(pomPath));
         PilotProject project = createDummyProject("mod-a");
 
-        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createTreeWithConflict());
+        var tui = new ConflictsTui(
+                List.of(project), session, session, "com.example:demo:1.0.0", p -> createTreeWithConflict());
 
         Map<String, List<ConflictsTui.ConflictEntry>> result = tui.resolveModule(project, true);
 
@@ -329,7 +333,7 @@ class ConflictsTuiRenderTest {
         PilotProject p1 = createDummyProject("mod-a");
         PilotProject p2 = createDummyProject("mod-b");
 
-        var tui = new ConflictsTui(List.of(p1, p2), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+        var tui = new ConflictsTui(List.of(p1, p2), session, session, "com.example:demo:1.0.0", p -> createEmptyTree());
 
         Map<String, List<ConflictsTui.ConflictEntry>> mergedMap = new HashMap<>();
         Map<String, List<ConflictsTui.ConflictEntry>> local = new HashMap<>();
@@ -348,7 +352,8 @@ class ConflictsTuiRenderTest {
         PomEditSession session = new PomEditSession(Path.of(pomPath));
         PilotProject project = createDummyProject("mod-a");
 
-        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> createEmptyTree());
+        var tui =
+                new ConflictsTui(List.of(project), session, session, "com.example:demo:1.0.0", p -> createEmptyTree());
 
         Map<String, List<ConflictsTui.ConflictEntry>> mergedMap = new HashMap<>();
         mergedMap.put(
@@ -371,7 +376,7 @@ class ConflictsTuiRenderTest {
         PilotProject project = createDummyProject("mod-a");
 
         CountDownLatch resolved = new CountDownLatch(1);
-        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> {
+        var tui = new ConflictsTui(List.of(project), session, session, "com.example:demo:1.0.0", p -> {
             resolved.countDown();
             return createTreeWithConflict();
         });
@@ -391,7 +396,7 @@ class ConflictsTuiRenderTest {
         PilotProject project = createDummyProject("mod-a");
 
         CountDownLatch failed = new CountDownLatch(1);
-        var tui = new ConflictsTui(List.of(project), session, "com.example:demo:1.0.0", p -> {
+        var tui = new ConflictsTui(List.of(project), session, session, "com.example:demo:1.0.0", p -> {
             failed.countDown();
             throw new RuntimeException("resolver failed");
         });

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UnifiedDiffTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UnifiedDiffTest.java
@@ -60,8 +60,8 @@ class UnifiedDiffTest {
         var result = UnifiedDiff.compute("hello", "world");
 
         assertThat(result).hasSize(2);
-        assertThat(result.get(0)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "hello"));
-        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "world"));
+        assertThat(result.get(0)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "hello", 0));
+        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "world", 1));
     }
 
     @Test
@@ -72,11 +72,11 @@ class UnifiedDiffTest {
         var result = UnifiedDiff.compute(original, modified);
 
         assertThat(result).hasSize(5);
-        assertThat(result.get(0)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "a"));
-        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "b"));
-        assertThat(result.get(2)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "B"));
-        assertThat(result.get(3)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "c"));
-        assertThat(result.get(4)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "d"));
+        assertThat(result.get(0)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "a", 1));
+        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "b", 0));
+        assertThat(result.get(2)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "B", 2));
+        assertThat(result.get(3)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "c", 3));
+        assertThat(result.get(4)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.CONTEXT, "d", 4));
     }
 
     @Test
@@ -88,7 +88,7 @@ class UnifiedDiffTest {
 
         assertThat(result).hasSize(3);
         assertThat(result.get(0).type()).isEqualTo(UnifiedDiff.Type.CONTEXT);
-        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "b"));
+        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.ADDED, "b", 2));
         assertThat(result.get(2).type()).isEqualTo(UnifiedDiff.Type.CONTEXT);
     }
 
@@ -101,7 +101,7 @@ class UnifiedDiffTest {
 
         assertThat(result).hasSize(3);
         assertThat(result.get(0).type()).isEqualTo(UnifiedDiff.Type.CONTEXT);
-        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "b"));
+        assertThat(result.get(1)).isEqualTo(new UnifiedDiff.DiffLine(UnifiedDiff.Type.REMOVED, "b", 0));
         assertThat(result.get(2).type()).isEqualTo(UnifiedDiff.Type.CONTEXT);
     }
 


### PR DESCRIPTION
## Summary

- **Cross-POM editing**: Managed dependencies and version properties are now added to the correct management POM (parent), not the local module POM. `PilotEngine` walks the parent hierarchy via `findManagementPom` to locate the POM with `originalManagedDependencies`.
- **Root discovery**: CLI now discovers the project root by walking up from the current POM (via `.mvn` marker or `root="true"`), enabling full reactor context when launched from any module directory.
- **Panel refresh fix**: TamboUI `UiRunnable` events don't trigger redraws — added `pendingRedraw` volatile flag checked by `needsTickRedraw()` so panels appear immediately after loading.
- **Diff UX improvements**: File headers use distinct `HEADER` type with white styling, line numbers shown in diff output, paths displayed relative to project root.
- **Usage details**: Bytecode analysis now populates `usedMembers`, `totalClasses`, and `spiServices` on each `DepEntry`, with a detail pane showing referenced classes and members.
- **Classifier-aware removal**: `removeDeclared` now uses classifier-aware coordinates, matching the `addTransitive` path.
- **Overlay mouse fix**: All panels (DependenciesTui, ConflictsTui, UpdatesTui) consume all mouse events when diff overlay is active.
- **Thread safety**: `rootDir` uses `AtomicReference<Path>` instead of `volatile Path`.
- **Complexity reduction**: Extracted `findUsedMembers`/`findSpiServices` helpers from `populateDepDetails`.

## Test plan
- [x] Compilation passes
- [x] Existing tests pass (UnifiedDiffTest, ConflictsTuiRenderTest updated)
- [x] CodeRabbit comments addressed
- [x] SonarCloud issues resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)