### PR TITLE
fix: UpdatesTui immediate apply, incremental loading, and UX improvements

### DIFF
--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -1831,28 +1831,30 @@ public class AuditTui extends ToolPanel {
             int row = mouseToTableRow(mouse, activeRowCount(), state);
             if (row >= 0) {
                 state.select(row);
-                if (lastTableInner != null) {
-                    int arrowX = lastTableInner.x() + 2; // highlight(2)
-                    if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
-                        if (view == View.VULNERABILITIES
-                                && row < vulnDisplayRows.size()
-                                && vulnDisplayRows.get(row).isGroupHeader()) {
-                            var group = vulnDisplayRows.get(row).group();
-                            group.expanded = !group.expanded;
-                            rebuildVulnDisplayRows();
-                        } else if (view == View.LICENSES
-                                && licensesGrouped
-                                && row < byLicenseRows.size()
-                                && byLicenseRows.get(row).isGroup()) {
-                            byLicenseRows.get(row).expanded = !byLicenseRows.get(row).expanded;
-                            rebuildByLicenseRows();
-                        }
-                    }
-                }
+                toggleRowExpand(row, mouse);
                 return true;
             }
         }
         return handleMouseTableInteraction(mouse, activeRowCount(), activeTableState());
+    }
+
+    private void toggleRowExpand(int row, MouseEvent mouse) {
+        if (lastTableInner == null) return;
+        int arrowX = lastTableInner.x() + 2; // highlight(2)
+        if (mouse.x() < arrowX || mouse.x() >= arrowX + 2) return;
+        if (view == View.VULNERABILITIES
+                && row < vulnDisplayRows.size()
+                && vulnDisplayRows.get(row).isGroupHeader()) {
+            vulnDisplayRows.get(row).group().expanded =
+                    !vulnDisplayRows.get(row).group().expanded;
+            rebuildVulnDisplayRows();
+        } else if (view == View.LICENSES
+                && licensesGrouped
+                && row < byLicenseRows.size()
+                && byLicenseRows.get(row).isGroup()) {
+            byLicenseRows.get(row).expanded = !byLicenseRows.get(row).expanded;
+            rebuildByLicenseRows();
+        }
     }
 
     private List<Constraint> currentTableWidths() {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -1826,6 +1826,32 @@ public class AuditTui extends ToolPanel {
         }
         if (handleMouseTabBar(mouse)) return true;
         if (handleMouseSortHeader(mouse, currentTableWidths())) return true;
+        if (mouse.isClick()) {
+            var state = activeTableState();
+            int row = mouseToTableRow(mouse, activeRowCount(), state);
+            if (row >= 0) {
+                state.select(row);
+                if (lastTableInner != null) {
+                    int arrowX = lastTableInner.x() + 2; // highlight(2)
+                    if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
+                        if (view == View.VULNERABILITIES
+                                && row < vulnDisplayRows.size()
+                                && vulnDisplayRows.get(row).isGroupHeader()) {
+                            var group = vulnDisplayRows.get(row).group();
+                            group.expanded = !group.expanded;
+                            rebuildVulnDisplayRows();
+                        } else if (view == View.LICENSES
+                                && licensesGrouped
+                                && row < byLicenseRows.size()
+                                && byLicenseRows.get(row).isGroup()) {
+                            byLicenseRows.get(row).expanded = !byLicenseRows.get(row).expanded;
+                            rebuildByLicenseRows();
+                        }
+                    }
+                }
+                return true;
+            }
+        }
         return handleMouseTableInteraction(mouse, activeRowCount(), activeTableState());
     }
 
@@ -1892,6 +1918,11 @@ public class AuditTui extends ToolPanel {
     public void setRunner(TuiRunner runner) {
         super.setRunner(runner);
         fetchAllData();
+    }
+
+    @Override
+    boolean needsTickRedraw() {
+        return licensesLoaded < entries.size() || vulnsLoaded < entries.size();
     }
 
     @Override

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -415,6 +415,11 @@ public class ConflictsTui extends ToolPanel {
     }
 
     @Override
+    boolean needsTickRedraw() {
+        return loading;
+    }
+
+    @Override
     public void setRunner(TuiRunner runner) {
         super.setRunner(runner);
         if (loading && pendingProjects != null) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ModuleTreePane.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ModuleTreePane.java
@@ -232,7 +232,7 @@ class ModuleTreePane {
                 tableState.select(row);
                 var node = visible.get(row);
                 if (node.hasChildren()) {
-                    int arrowX = area.x() + 1 + node.depth * 2; // border(1) + indent
+                    int arrowX = area.x() + 1 + 2 + node.depth * 2; // border(1) + highlight(2) + indent
                     if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
                         node.expanded = !node.expanded;
                     }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ModuleTreePane.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ModuleTreePane.java
@@ -225,35 +225,41 @@ class ModuleTreePane {
 
     boolean handleMouseEvent(MouseEvent mouse, Rect area) {
         if (mouse.isClick()) {
-            // Calculate which row was clicked (area has border, no header + scroll offset)
-            int row = mouse.y() - area.y() - 1 + tableState.offset(); // border + scroll
-            var visible = visibleNodes();
-            if (row >= 0 && row < visible.size()) {
-                tableState.select(row);
-                var node = visible.get(row);
-                if (node.hasChildren()) {
-                    int arrowX = area.x() + 1 + 2 + node.depth * 2; // border(1) + highlight(2) + indent
-                    if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
-                        node.expanded = !node.expanded;
-                    }
-                }
-                notifySelection();
-                return true;
-            }
+            return handleMouseClick(mouse, area);
         }
         if (mouse.isScroll()) {
-            var visible = visibleNodes();
-            if (visible.isEmpty()) return false;
-            int sel = tableState.selected();
-            if (mouse.kind() == MouseEventKind.SCROLL_UP) {
-                tableState.select(Math.max(0, sel - 1));
-            } else {
-                tableState.select(Math.min(visible.size() - 1, sel + 1));
-            }
-            notifySelection();
-            return true;
+            return handleMouseScroll(mouse);
         }
         return false;
+    }
+
+    private boolean handleMouseClick(MouseEvent mouse, Rect area) {
+        int row = mouse.y() - area.y() - 1 + tableState.offset(); // border + scroll
+        var visible = visibleNodes();
+        if (row < 0 || row >= visible.size()) return false;
+        tableState.select(row);
+        var node = visible.get(row);
+        if (node.hasChildren()) {
+            int arrowX = area.x() + 1 + 2 + node.depth * 2; // border(1) + highlight(2) + indent
+            if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
+                node.expanded = !node.expanded;
+            }
+        }
+        notifySelection();
+        return true;
+    }
+
+    private boolean handleMouseScroll(MouseEvent mouse) {
+        var visible = visibleNodes();
+        if (visible.isEmpty()) return false;
+        int sel = tableState.selected();
+        if (mouse.kind() == MouseEventKind.SCROLL_UP) {
+            tableState.select(Math.max(0, sel - 1));
+        } else {
+            tableState.select(Math.min(visible.size() - 1, sel + 1));
+        }
+        notifySelection();
+        return true;
     }
 
     private void notifySelection() {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ModuleTreePane.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ModuleTreePane.java
@@ -230,6 +230,13 @@ class ModuleTreePane {
             var visible = visibleNodes();
             if (row >= 0 && row < visible.size()) {
                 tableState.select(row);
+                var node = visible.get(row);
+                if (node.hasChildren()) {
+                    int arrowX = area.x() + 1 + node.depth * 2; // border(1) + indent
+                    if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
+                        node.expanded = !node.expanded;
+                    }
+                }
                 notifySelection();
                 return true;
             }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -270,6 +270,8 @@ public class PilotShell {
         if (helpOverlay.isAnimating()) return true;
         // Panel loading in progress
         if (panelLoadingStatus != null) return true;
+        // Active panel has background work (e.g. async version resolution)
+        if (activePanel != null && activePanel.needsTickRedraw()) return true;
         return loadingStatusSupplier != null && loadingStatusSupplier.get() != null;
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
@@ -300,33 +300,39 @@ public class PomTui extends ToolPanel {
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
         if (handleMouseTabBar(mouse)) return true;
         if (mouse.isClick()) {
-            var visible = currentModel().visibleNodes();
-            int row = mouse.y() - area.y() - 2 + tableState.offset(); // tab bar + border
-            if (row >= 0 && row < visible.size()) {
-                tableState.select(row);
-                // Toggle expand/collapse when clicking the arrow
-                var node = visible.get(row);
-                if (node instanceof Element e && XmlTreeModel.hasTreeChildren(e)) {
-                    int arrowX = area.x() + 2 + currentModel().relativeDepth(e) * 2; // highlight(2) + indent
-                    if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
-                        currentModel().setExpanded(e, !currentModel().isExpanded(e));
-                    }
-                }
-                return true;
-            }
+            return handlePomMouseClick(mouse, area);
         }
         if (mouse.isScroll()) {
-            var visible = currentModel().visibleNodes();
-            if (visible.isEmpty()) return false;
-            int sel = tableState.selected();
-            if (mouse.kind() == MouseEventKind.SCROLL_UP) {
-                tableState.select(Math.max(0, sel - 1));
-            } else {
-                tableState.select(Math.min(visible.size() - 1, sel + 1));
-            }
-            return true;
+            return handlePomMouseScroll(mouse);
         }
         return false;
+    }
+
+    private boolean handlePomMouseClick(MouseEvent mouse, Rect area) {
+        var visible = currentModel().visibleNodes();
+        int row = mouse.y() - area.y() - 2 + tableState.offset(); // tab bar + border
+        if (row < 0 || row >= visible.size()) return false;
+        tableState.select(row);
+        var node = visible.get(row);
+        if (node instanceof Element e && XmlTreeModel.hasTreeChildren(e)) {
+            int arrowX = area.x() + 1 + 2 + currentModel().relativeDepth(e) * 2; // border(1) + highlight(2) + indent
+            if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
+                currentModel().setExpanded(e, !currentModel().isExpanded(e));
+            }
+        }
+        return true;
+    }
+
+    private boolean handlePomMouseScroll(MouseEvent mouse) {
+        var visible = currentModel().visibleNodes();
+        if (visible.isEmpty()) return false;
+        int sel = tableState.selected();
+        if (mouse.kind() == MouseEventKind.SCROLL_UP) {
+            tableState.select(Math.max(0, sel - 1));
+        } else {
+            tableState.select(Math.min(visible.size() - 1, sel + 1));
+        }
+        return true;
     }
 
     @Override

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
@@ -304,10 +304,13 @@ public class PomTui extends ToolPanel {
             int row = mouse.y() - area.y() - 2 + tableState.offset(); // tab bar + border
             if (row >= 0 && row < visible.size()) {
                 tableState.select(row);
-                // Toggle expand/collapse on click
+                // Toggle expand/collapse when clicking the arrow
                 var node = visible.get(row);
                 if (node instanceof Element e && XmlTreeModel.hasTreeChildren(e)) {
-                    currentModel().setExpanded(e, !currentModel().isExpanded(e));
+                    int arrowX = area.x() + 2 + currentModel().relativeDepth(e) * 2; // highlight(2) + indent
+                    if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
+                        currentModel().setExpanded(e, !currentModel().isExpanded(e));
+                    }
                 }
                 return true;
             }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ReactorCollector.java
@@ -64,7 +64,6 @@ public class ReactorCollector {
 
         String newestVersion;
         VersionComparator.UpdateType updateType;
-        boolean selected;
         boolean applied;
         LocalDate currentReleaseDate;
         LocalDate newestReleaseDate;
@@ -101,7 +100,6 @@ public class ReactorCollector {
 
         String newestVersion;
         VersionComparator.UpdateType updateType;
-        boolean selected;
         boolean applied;
         boolean expanded = false;
         float libYears = -1;

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
@@ -190,6 +190,11 @@ public class SearchTui extends ToolPanel {
     }
 
     @Override
+    boolean needsTickRedraw() {
+        return loading;
+    }
+
+    @Override
     void close() {
         httpPool.shutdownNow();
     }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
@@ -191,7 +191,7 @@ public class SearchTui extends ToolPanel {
 
     @Override
     boolean needsTickRedraw() {
-        return loading;
+        return loading || prefetchingMore;
     }
 
     @Override

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -92,6 +92,10 @@ public abstract class ToolPanel {
     /** Diff overlay for previewing POM changes. */
     protected final DiffOverlay diffOverlay = new DiffOverlay();
 
+    boolean needsTickRedraw() {
+        return false;
+    }
+
     /** Help overlay for standalone mode (shell has its own for panel mode). */
     protected final HelpOverlay helpOverlay = new HelpOverlay();
 
@@ -497,7 +501,7 @@ public abstract class ToolPanel {
      * The inner area of the last rendered table (after block borders/titles/padding).
      * This is where the Table widget positions the header and data rows.
      */
-    private Rect lastTableInner;
+    protected Rect lastTableInner;
 
     /**
      * The width of the highlight symbol used in the last rendered table.

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -173,33 +173,40 @@ public class TreeTui extends ToolPanel {
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
         if (handleMouseSortHeader(mouse, List.of(TREE_WIDTHS))) return true;
         if (mouse.isClick()) {
-            int row = mouse.y() - area.y() - 1 + tableState.offset(); // header + scroll
-            if (row >= 0 && row < displayNodes.size()) {
-                tableState.select(row);
-                var node = displayNodes.get(row);
-                if (node.hasChildren()) {
-                    int arrowX = area.x() + 2 + node.depth * 2; // highlight(2) + indent
-                    if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
-                        node.expanded = !node.expanded;
-                        refreshDisplay();
-                    }
-                }
-                fetchPomInfoIfNeeded();
-                return true;
-            }
+            return handleTreeMouseClick(mouse, area);
         }
         if (mouse.isScroll()) {
-            if (displayNodes.isEmpty()) return false;
-            int sel = tableState.selected();
-            if (mouse.kind() == MouseEventKind.SCROLL_UP) {
-                tableState.select(Math.max(0, sel - 1));
-            } else {
-                tableState.select(Math.min(displayNodes.size() - 1, sel + 1));
-            }
-            fetchPomInfoIfNeeded();
-            return true;
+            return handleTreeMouseScroll(mouse);
         }
         return false;
+    }
+
+    private boolean handleTreeMouseClick(MouseEvent mouse, Rect area) {
+        int row = mouse.y() - area.y() - 1 + tableState.offset(); // header + scroll
+        if (row < 0 || row >= displayNodes.size()) return false;
+        tableState.select(row);
+        var node = displayNodes.get(row);
+        if (node.hasChildren()) {
+            int arrowX = area.x() + 1 + 2 + node.depth * 2; // border(1) + highlight(2) + indent
+            if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
+                node.expanded = !node.expanded;
+                refreshDisplay();
+            }
+        }
+        fetchPomInfoIfNeeded();
+        return true;
+    }
+
+    private boolean handleTreeMouseScroll(MouseEvent mouse) {
+        if (displayNodes.isEmpty()) return false;
+        int sel = tableState.selected();
+        if (mouse.kind() == MouseEventKind.SCROLL_UP) {
+            tableState.select(Math.max(0, sel - 1));
+        } else {
+            tableState.select(Math.min(displayNodes.size() - 1, sel + 1));
+        }
+        fetchPomInfoIfNeeded();
+        return true;
     }
 
     @Override

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -176,6 +176,14 @@ public class TreeTui extends ToolPanel {
             int row = mouse.y() - area.y() - 1 + tableState.offset(); // header + scroll
             if (row >= 0 && row < displayNodes.size()) {
                 tableState.select(row);
+                var node = displayNodes.get(row);
+                if (node.hasChildren()) {
+                    int arrowX = area.x() + 2 + node.depth * 2; // highlight(2) + indent
+                    if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
+                        node.expanded = !node.expanded;
+                        refreshDisplay();
+                    }
+                }
                 fetchPomInfoIfNeeded();
                 return true;
             }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -876,24 +876,38 @@ public class UpdatesTui extends ToolPanel {
 
         var row = displayRows.get(sel);
         if (row.isGroupHeader()) {
-            if (row.propertyGroup.applied || !row.propertyGroup.hasUpdate()) {
-                status = row.propertyGroup.applied ? "Already applied" : "No update available";
+            applyGroupHeaderUpdate(row.propertyGroup);
+        } else if (row.dependency != null) {
+            applyDependencyUpdate(row.dependency);
+        }
+    }
+
+    private void applyGroupHeaderUpdate(ReactorCollector.PropertyGroup group) {
+        if (group.applied || !group.hasUpdate()) {
+            status = group.applied ? "Already applied" : "No update available";
+            return;
+        }
+        applyGroupUpdate(group);
+    }
+
+    private void applyDependencyUpdate(ReactorCollector.AggregatedDependency dep) {
+        if (!dep.hasUpdate() || dep.applied) {
+            status = dep.applied ? "Already applied" : "No update available";
+            return;
+        }
+        if (dep.isPropertyManaged()) {
+            applyPropertyManagedDep(dep);
+        } else {
+            applySingleUpdate(dep);
+        }
+    }
+
+    private void applyPropertyManagedDep(ReactorCollector.AggregatedDependency dep) {
+        for (var group : reactorResult.propertyGroups) {
+            if (group.dependencies.contains(dep)) {
+                applyGroupUpdate(group);
                 return;
             }
-            applyGroupUpdate(row.propertyGroup);
-        } else if (row.dependency != null && row.dependency.hasUpdate() && !row.dependency.applied) {
-            if (row.dependency.isPropertyManaged()) {
-                for (var group : reactorResult.propertyGroups) {
-                    if (group.dependencies.contains(row.dependency)) {
-                        applyGroupUpdate(group);
-                        break;
-                    }
-                }
-            } else {
-                applySingleUpdate(row.dependency);
-            }
-        } else {
-            status = (row.dependency != null && row.dependency.applied) ? "Already applied" : "No update available";
         }
     }
 
@@ -958,7 +972,8 @@ public class UpdatesTui extends ToolPanel {
         return diffs;
     }
 
-    private void toggleDiffView() {
+    @Override
+    protected void toggleDiffView() {
         var diffs = collectAllDiffs();
         if (diffs.isEmpty()) {
             status = "No changes to show";
@@ -980,7 +995,8 @@ public class UpdatesTui extends ToolPanel {
         return new UpdateLocation(dep.usages.get(0).project.pomPath, false);
     }
 
-    private void requestQuit() {
+    @Override
+    protected void requestQuit() {
         if (isDirty()) {
             pendingQuit = true;
             status = "Save changes to POM? (y/n/Esc)";
@@ -1332,7 +1348,7 @@ public class UpdatesTui extends ToolPanel {
             return;
         }
 
-        Row header = sortState.decorateHeader(List.of("module", "updates"), theme.tableHeader());
+        Row header = sortState.decorateHeader(List.of("module", ORIGIN_UPDATES), theme.tableHeader());
 
         List<Row> rows = new ArrayList<>();
         for (var node : visible) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -39,9 +39,7 @@ import dev.tamboui.widgets.table.Cell;
 import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
-import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.maven.Coordinates;
-import eu.maveniverse.domtrip.maven.PomEditor;
 import java.nio.file.Path;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -122,7 +120,6 @@ public class UpdatesTui extends ToolPanel {
     private static final String ARROW = " \u2192 ";
     private static final String KEY_NAV = ":Nav  ";
     private static final String KEY_SPACE = "Space";
-    private static final String KEY_ENTER = "Enter";
 
     private final ReactorCollector.CollectionResult reactorResult;
     private final ReactorModel reactorModel;
@@ -468,9 +465,9 @@ public class UpdatesTui extends ToolPanel {
 
     private String extractCheckColumn(ReactorRow row) {
         if (row.isGroupHeader()) {
-            return row.propertyGroup.selected ? "[✓]" : "[ ]";
+            return row.propertyGroup.applied ? "[·]" : "[ ]";
         }
-        return row.dependency.selected ? "[✓]" : "   ";
+        return row.dependency != null && row.dependency.applied ? "[·]" : "   ";
     }
 
     private String extractIdColumn(ReactorRow row) {
@@ -724,24 +721,12 @@ public class UpdatesTui extends ToolPanel {
             handleDepsLeftKey();
             return true;
         }
-        if (key.isCharIgnoreCase(' ')) {
-            toggleSelection();
-            return true;
-        }
-        if (key.isCharIgnoreCase('a')) {
-            selectAll();
-            return true;
-        }
-        if (key.isCharIgnoreCase('n')) {
-            deselectAll();
+        if (key.isCharIgnoreCase(' ') || key.isKey(KeyCode.ENTER)) {
+            applyCurrentUpdate();
             return true;
         }
         if (key.isCharIgnoreCase('d')) {
             toggleDiffView();
-            return true;
-        }
-        if (key.isKey(KeyCode.ENTER)) {
-            applyUpdates();
             return true;
         }
         if (key.isChar('f')) {
@@ -879,140 +864,96 @@ public class UpdatesTui extends ToolPanel {
         return false;
     }
 
-    private void toggleSelection() {
+    private void applyCurrentUpdate() {
         Integer sel = tableState.selected();
         if (sel == null || sel >= displayRows.size()) return;
 
         var row = displayRows.get(sel);
         if (row.isGroupHeader()) {
-            var group = row.propertyGroup;
-            if (group.applied) return;
-            boolean newState = !group.selected;
-            group.selected = newState;
-            for (var dep : group.dependencies) {
-                dep.selected = newState;
-            }
-        } else if (row.dependency != null && row.dependency.hasUpdate()) {
-            var dep = row.dependency;
-            if (dep.applied) return;
-            boolean newState = !dep.selected;
-            dep.selected = newState;
-            // If part of a property group, toggle the whole group
-            if (dep.isPropertyManaged()) {
+            applyGroupUpdate(row.propertyGroup);
+        } else if (row.dependency != null && row.dependency.hasUpdate() && !row.dependency.applied) {
+            if (row.dependency.isPropertyManaged()) {
                 for (var group : reactorResult.propertyGroups) {
-                    if (group.dependencies.contains(dep)) {
-                        group.selected = newState;
-                        for (var other : group.dependencies) {
-                            other.selected = newState;
-                        }
+                    if (group.dependencies.contains(row.dependency)) {
+                        applyGroupUpdate(group);
                         break;
                     }
                 }
+            } else {
+                applySingleUpdate(row.dependency);
             }
         }
     }
 
-    private void selectAll() {
-        for (var row : displayRows) {
-            if (row.isGroupHeader() && row.propertyGroup.hasUpdate() && !row.propertyGroup.applied) {
-                row.propertyGroup.selected = true;
-                for (var dep : row.propertyGroup.dependencies) {
-                    dep.selected = true;
-                }
-            } else if (row.dependency != null
-                    && !row.dependency.isPropertyManaged()
-                    && row.dependency.hasUpdate()
-                    && !row.dependency.applied) {
-                row.dependency.selected = true;
-            }
+    private void applyGroupUpdate(ReactorCollector.PropertyGroup group) {
+        if (group.applied || !group.hasUpdate()) return;
+
+        PomEditSession session = sessionProvider.apply(group.origin.pomPath);
+        session.beforeMutation();
+        session.editor().properties().updateProperty(true, group.propertyName, group.newestVersion);
+        session.recordChange(
+                PomEditSession.ChangeType.MODIFY,
+                "property",
+                group.propertyName,
+                group.resolvedVersion + ARROW + group.newestVersion,
+                "updates");
+        mutatedSessions.add(session);
+        group.applied = true;
+        for (var dep : group.dependencies) {
+            dep.applied = true;
         }
+        updateReactorCounts();
+        buildDisplayRows();
+        status = "Updated ${" + group.propertyName + "}: " + group.resolvedVersion + ARROW + group.newestVersion;
     }
 
-    private void deselectAll() {
-        for (var group : reactorResult.propertyGroups) {
-            group.selected = false;
-            for (var dep : group.dependencies) {
-                dep.selected = false;
-            }
+    private void applySingleUpdate(ReactorCollector.AggregatedDependency dep) {
+        if (dep.applied || !dep.hasUpdate()) return;
+
+        var loc = findUpdateLocation(dep);
+        PomEditSession session = sessionProvider.apply(loc.pomPath);
+        session.beforeMutation();
+        var coords = Coordinates.of(dep.groupId, dep.artifactId, dep.newestVersion);
+        if (loc.managed) {
+            session.editor().dependencies().updateManagedDependency(true, coords);
+        } else {
+            session.editor().dependencies().updateDependency(true, coords);
         }
-        for (var dep : reactorResult.ungroupedDependencies) {
-            dep.selected = false;
-        }
+        session.recordChange(
+                PomEditSession.ChangeType.MODIFY,
+                loc.managed ? "managed" : "dependency",
+                dep.ga(),
+                dep.primaryVersion + ARROW + dep.newestVersion,
+                "updates");
+        mutatedSessions.add(session);
+        dep.applied = true;
+        updateReactorCounts();
+        buildDisplayRows();
+        status = "Updated " + dep.ga() + ": " + dep.primaryVersion + ARROW + dep.newestVersion;
     }
 
     // -- Diff preview --
 
     @Override
-    protected void toggleDiffView() {
-        Map<Path, PomEditor> previewEditors = buildPreviewEditors();
-
-        // Merge applied diffs (this tool's sessions) with cross-tool diffs
-        Map<String, Map.Entry<String, String>> fileDiffs = collectAppliedDiffs();
-        fileDiffs.putAll(collectAllDiffs());
-        if (!previewEditors.isEmpty()) {
-            fileDiffs.putAll(collectPreviewDiffs(previewEditors));
+    protected Map<String, Map.Entry<String, String>> collectAllDiffs() {
+        Map<String, Map.Entry<String, String>> diffs = super.collectAllDiffs();
+        for (PomEditSession session : mutatedSessions) {
+            if (session.isDirty()) {
+                String key = displayPath(session.pomPath());
+                diffs.putIfAbsent(key, Map.entry(session.originalContent(), session.currentXml()));
+            }
         }
-        if (fileDiffs.isEmpty()) {
-            status = "No updates selected";
+        return diffs;
+    }
+
+    private void toggleDiffView() {
+        var diffs = collectAllDiffs();
+        if (diffs.isEmpty()) {
+            status = "No changes to show";
             return;
         }
-
-        long changes = diffOverlay.openMulti(fileDiffs);
-        status = changes == 0
-                ? "No changes to show"
-                : changes + " line(s) changed across " + fileDiffs.size() + " file(s)";
-    }
-
-    private Map<Path, PomEditor> buildPreviewEditors() {
-        Map<Path, PomEditor> editors = new LinkedHashMap<>();
-        for (var group : reactorResult.propertyGroups) {
-            if (group.selected && group.hasUpdate()) {
-                PomEditor editor = editors.computeIfAbsent(group.origin.pomPath, p -> {
-                    PomEditSession session = sessionProvider.apply(p);
-                    return new PomEditor(Document.of(session.currentXml()));
-                });
-                editor.properties().updateProperty(true, group.propertyName, group.newestVersion);
-            }
-        }
-        for (var dep : reactorResult.ungroupedDependencies) {
-            if (dep.selected && dep.hasUpdate() && !dep.usages.isEmpty()) {
-                var loc = findUpdateLocation(dep);
-                PomEditor editor = editors.computeIfAbsent(loc.pomPath, p -> {
-                    PomEditSession session = sessionProvider.apply(p);
-                    return new PomEditor(Document.of(session.currentXml()));
-                });
-                var coords = Coordinates.of(dep.groupId, dep.artifactId, dep.newestVersion);
-                if (loc.managed) {
-                    editor.dependencies().updateManagedDependency(true, coords);
-                } else {
-                    editor.dependencies().updateDependency(true, coords);
-                }
-            }
-        }
-        return editors;
-    }
-
-    private Map<String, Map.Entry<String, String>> collectAppliedDiffs() {
-        Map<String, Map.Entry<String, String>> diffs = new LinkedHashMap<>();
-        // Check all reactor modules for dirty sessions (includes changes from other tools)
-        for (var module : reactorModel.allModules) {
-            PomEditSession session = sessionProvider.apply(Path.of(module.pomPath));
-            if (session.isDirty()) {
-                diffs.put(displayPath(session.pomPath()), Map.entry(session.originalContent(), session.currentXml()));
-            }
-        }
-        return diffs;
-    }
-
-    private Map<String, Map.Entry<String, String>> collectPreviewDiffs(Map<Path, PomEditor> previewEditors) {
-        Map<String, Map.Entry<String, String>> diffs = new LinkedHashMap<>();
-        for (var entry : previewEditors.entrySet()) {
-            PomEditSession session = sessionProvider.apply(entry.getKey());
-            String original = session.originalContent();
-            String modified = entry.getValue().toXml();
-            diffs.put(displayPath(entry.getKey()), Map.entry(original, modified));
-        }
-        return diffs;
+        long changes = diffOverlay.openMulti(diffs);
+        status = changes == 0 ? "No changes to show" : changes + " line(s) changed across " + diffs.size() + " file(s)";
     }
 
     // -- Apply --
@@ -1027,144 +968,12 @@ public class UpdatesTui extends ToolPanel {
         return new UpdateLocation(dep.usages.get(0).project.pomPath, false);
     }
 
-    private Map<Path, List<Map.Entry<String, String>>> collectPropertyUpdates() {
-        Map<Path, List<Map.Entry<String, String>>> updates = new LinkedHashMap<>();
-        for (var group : reactorResult.propertyGroups) {
-            if (group.selected && group.hasUpdate()) {
-                updates.computeIfAbsent(group.origin.pomPath, k -> new ArrayList<>())
-                        .add(Map.entry(group.propertyName, group.newestVersion));
-            }
-        }
-        return updates;
-    }
-
-    private Map<Path, List<Map.Entry<ReactorCollector.AggregatedDependency, Boolean>>> collectDependencyUpdates() {
-        Map<Path, List<Map.Entry<ReactorCollector.AggregatedDependency, Boolean>>> updates = new LinkedHashMap<>();
-        for (var dep : reactorResult.ungroupedDependencies) {
-            if (dep.selected && dep.hasUpdate() && !dep.usages.isEmpty()) {
-                var loc = findUpdateLocation(dep);
-                updates.computeIfAbsent(loc.pomPath, k -> new ArrayList<>()).add(Map.entry(dep, loc.managed));
-            }
-        }
-        return updates;
-    }
-
-    private int applyPropertyChanges(
-            Map<Path, List<Map.Entry<String, String>>> propertyUpdates, Map<Path, PomEditSession> sessions) {
-        int count = 0;
-        for (var entry : propertyUpdates.entrySet()) {
-            PomEditSession session = sessions.get(entry.getKey());
-            for (var propEntry : entry.getValue()) {
-                session.editor().properties().updateProperty(true, propEntry.getKey(), propEntry.getValue());
-                session.recordChange(
-                        PomEditSession.ChangeType.MODIFY,
-                        "property",
-                        propEntry.getKey(),
-                        propEntry.getValue(),
-                        "reactor-updates");
-                count++;
-            }
-        }
-        return count;
-    }
-
-    private int applyDependencyChanges(
-            Map<Path, List<Map.Entry<ReactorCollector.AggregatedDependency, Boolean>>> depUpdates,
-            Map<Path, PomEditSession> sessions) {
-        int count = 0;
-        for (var entry : depUpdates.entrySet()) {
-            PomEditSession session = sessions.get(entry.getKey());
-            for (var depEntry : entry.getValue()) {
-                var dep = depEntry.getKey();
-                boolean managed = depEntry.getValue();
-                var coords = Coordinates.of(dep.groupId, dep.artifactId, dep.newestVersion);
-                if (managed) {
-                    session.editor().dependencies().updateManagedDependency(true, coords);
-                } else {
-                    session.editor().dependencies().updateDependency(true, coords);
-                }
-                session.recordChange(
-                        PomEditSession.ChangeType.MODIFY,
-                        managed ? "managed" : "dependency",
-                        dep.ga(),
-                        dep.primaryVersion + ARROW + dep.newestVersion,
-                        "reactor-updates");
-                count++;
-            }
-        }
-        return count;
-    }
-
-    private void markAppliedUpdates() {
-        for (var group : reactorResult.propertyGroups) {
-            if (group.selected && group.hasUpdate()) {
-                group.applied = true;
-                group.selected = false;
-                for (var dep : group.dependencies) {
-                    dep.applied = true;
-                    dep.selected = false;
-                }
-            }
-        }
-        for (var dep : reactorResult.ungroupedDependencies) {
-            if (dep.selected && dep.hasUpdate()) {
-                dep.applied = true;
-                dep.selected = false;
-            }
-        }
-    }
-
-    @Override
-    protected void saveAndQuit() {
-        if (save()) {
-            runner.quit();
+    private void requestQuit() {
+        if (isDirty()) {
+            pendingQuit = true;
+            status = "Save changes to POM? (y/n/Esc)";
         } else {
-            pendingQuit = false;
-        }
-    }
-
-    @Override
-    protected void onStatusChange(String message) {
-        this.status = message;
-    }
-
-    @Override
-    protected void onPendingQuitCancelled() {
-        status = buildStatusMessage();
-    }
-
-    private void applyUpdates() {
-        var propertyUpdates = collectPropertyUpdates();
-        var depUpdates = collectDependencyUpdates();
-
-        if (propertyUpdates.isEmpty() && depUpdates.isEmpty()) {
-            status = "No updates selected";
-            return;
-        }
-
-        try {
-            // Get sessions for all affected POMs and snapshot before mutations
-            Map<Path, PomEditSession> sessions = new LinkedHashMap<>();
-            for (Path p : propertyUpdates.keySet()) {
-                sessions.computeIfAbsent(p, sessionProvider);
-            }
-            for (Path p : depUpdates.keySet()) {
-                sessions.computeIfAbsent(p, sessionProvider);
-            }
-            for (PomEditSession session : sessions.values()) {
-                session.beforeMutation();
-            }
-
-            int totalUpdates = applyPropertyChanges(propertyUpdates, sessions);
-            totalUpdates += applyDependencyChanges(depUpdates, sessions);
-
-            mutatedSessions.addAll(sessions.values());
-            markAppliedUpdates();
-            updateReactorCounts();
-            buildDisplayRows();
-            status = "Applied " + totalUpdates + " update(s) — save on exit";
-        } catch (Exception e) {
-            status = "Failed to apply: " + e.getMessage();
+            runner.quit();
         }
     }
 
@@ -1288,14 +1097,7 @@ public class UpdatesTui extends ToolPanel {
 
     private Row createGroupHeaderRow(ReactorRow row, boolean highlight) {
         var group = row.propertyGroup;
-        String check;
-        if (group.applied) {
-            check = "[·]";
-        } else if (group.selected) {
-            check = "[✓]";
-        } else {
-            check = "[ ]";
-        }
+        String check = group.applied ? "[·]" : "[ ]";
         String name = (group.expanded ? "▾ " : "▸ ") + "${" + group.propertyName + "}";
         if (duplicatePropertyNames.contains(group.propertyName)) {
             name += " (" + group.origin.artifactId + ")";
@@ -1330,14 +1132,7 @@ public class UpdatesTui extends ToolPanel {
     }
 
     private Row createStandaloneDependencyRow(ReactorCollector.AggregatedDependency dep, boolean highlight) {
-        String check;
-        if (dep.applied) {
-            check = "[·]";
-        } else if (dep.selected) {
-            check = "[✓]";
-        } else {
-            check = "[ ]";
-        }
+        String check = dep.applied ? "[·]" : "[ ]";
         String ga = dep.artifactId;
         String current = dep.primaryVersion != null ? dep.primaryVersion : "";
         String arrow = dep.hasUpdate() ? "→" : "";
@@ -1579,18 +1374,11 @@ public class UpdatesTui extends ToolPanel {
                 .constraints(Constraint.length(1), Constraint.length(1), Constraint.length(1))
                 .split(area);
 
-        // Status + selected count
+        // Status + applied count
         List<Span> statusSpans = new ArrayList<>();
         statusSpans.add(Span.raw(" " + status).fg(theme.standaloneStatusColor()));
-        long selectedCount = reactorResult.allDependencies.stream()
-                .filter(d -> d.selected && d.hasUpdate())
-                .count();
         long appliedCount =
                 reactorResult.allDependencies.stream().filter(d -> d.applied).count();
-        if (selectedCount > 0) {
-            statusSpans.add(
-                    Span.raw("  " + selectedCount + " update(s) selected").fg(theme.selectedCountColor()));
-        }
         if (appliedCount > 0) {
             statusSpans.add(Span.raw("  " + appliedCount + " applied").dim());
         }
@@ -1629,15 +1417,9 @@ public class UpdatesTui extends ToolPanel {
         spans.add(Span.raw("←→").bold());
         spans.add(Span.raw(":Expand  "));
         spans.add(Span.raw(KEY_SPACE).bold());
-        spans.add(Span.raw(":Toggle  "));
-        spans.add(Span.raw("a").bold());
-        spans.add(Span.raw(":All  "));
-        spans.add(Span.raw("n").bold());
-        spans.add(Span.raw(":None  "));
+        spans.add(Span.raw(":Apply  "));
         spans.add(Span.raw("d").bold());
         spans.add(Span.raw(":Diff  "));
-        spans.add(Span.raw(KEY_ENTER).bold());
-        spans.add(Span.raw(":Apply  "));
         spans.add(Span.raw("f").bold());
         spans.add(Span.raw(":Filter  "));
         spans.add(Span.raw("i").bold());
@@ -1780,18 +1562,12 @@ public class UpdatesTui extends ToolPanel {
             spans.add(Span.raw("↑↓").bold());
             spans.add(Span.raw(KEY_NAV));
             spans.add(Span.raw(KEY_SPACE).bold());
-            spans.add(Span.raw(":Toggle  "));
-            spans.add(Span.raw("a").bold());
-            spans.add(Span.raw(":All  "));
-            spans.add(Span.raw("n").bold());
-            spans.add(Span.raw(":None  "));
+            spans.add(Span.raw(":Apply  "));
             spans.addAll(sortKeyHints());
             spans.add(Span.raw("/").bold());
             spans.add(Span.raw(":Search  "));
             spans.add(Span.raw("d").bold());
             spans.add(Span.raw(":Diff  "));
-            spans.add(Span.raw(KEY_ENTER).bold());
-            spans.add(Span.raw(":Apply  "));
             spans.add(Span.raw("f").bold());
             spans.add(Span.raw(":Filter"));
         }
@@ -1804,22 +1580,23 @@ public class UpdatesTui extends ToolPanel {
         if (singleModule) {
             descEntries.add(new HelpOverlay.Entry("", "Shows available dependency updates for this project."));
             descEntries.add(new HelpOverlay.Entry("", "Dependencies managed via properties (e.g."));
-            descEntries.add(new HelpOverlay.Entry("", "${jackson.version}) are grouped together — selecting"));
-            descEntries.add(new HelpOverlay.Entry("", "the group header toggles all dependencies in it."));
+            descEntries.add(new HelpOverlay.Entry("", "${jackson.version}) are grouped together — applying"));
+            descEntries.add(new HelpOverlay.Entry("", "updates the property and all dependencies in it."));
         } else {
             descEntries.add(new HelpOverlay.Entry("", "Aggregates dependency updates across all reactor"));
             descEntries.add(new HelpOverlay.Entry("", "modules. Dependencies managed via properties (e.g."));
-            descEntries.add(new HelpOverlay.Entry("", "${jackson.version}) are grouped together — selecting"));
-            descEntries.add(new HelpOverlay.Entry("", "the group header toggles all dependencies in it."));
+            descEntries.add(new HelpOverlay.Entry("", "${jackson.version}) are grouped together — applying"));
+            descEntries.add(new HelpOverlay.Entry("", "updates the property and all dependencies in it."));
             descEntries.add(new HelpOverlay.Entry("", ""));
             descEntries.add(new HelpOverlay.Entry("", "The 'N mod' column shows how many reactor modules"));
             descEntries.add(new HelpOverlay.Entry("", "use each dependency. 'M' indicates a managed"));
             descEntries.add(new HelpOverlay.Entry("", "dependency (from dependencyManagement)."));
         }
         descEntries.add(new HelpOverlay.Entry("", ""));
-        descEntries.add(new HelpOverlay.Entry("", "When you apply updates, property-based deps edit"));
-        descEntries.add(new HelpOverlay.Entry("", "the <properties> in the POM that defines them;"));
-        descEntries.add(new HelpOverlay.Entry("", "direct deps edit the module's own POM."));
+        descEntries.add(new HelpOverlay.Entry("", "Press Space to apply an update immediately."));
+        descEntries.add(new HelpOverlay.Entry("", "Property-based deps edit the <properties> in the"));
+        descEntries.add(new HelpOverlay.Entry("", "POM that defines them; direct deps edit the"));
+        descEntries.add(new HelpOverlay.Entry("", "module's own POM. Use Ctrl+Z to undo."));
 
         String sectionTitle = singleModule ? "Dependency Updates" : "Reactor Dependency Updates";
         String actionsTitle = singleModule ? "Actions" : "Reactor Updates Actions";
@@ -1839,11 +1616,10 @@ public class UpdatesTui extends ToolPanel {
                                 new HelpOverlay.Entry("← / →", "Collapse / expand property group"),
                                 new HelpOverlay.Entry("PgUp / PgDn", "Move selection up / down by one page"),
                                 new HelpOverlay.Entry("Home / End", "Jump to first / last row"),
-                                new HelpOverlay.Entry(KEY_SPACE, "Toggle selection (group or individual)"),
-                                new HelpOverlay.Entry("a / n", "Select all / deselect all"),
-                                new HelpOverlay.Entry(KEY_ENTER, "Apply selected updates to POM files"),
+                                new HelpOverlay.Entry(KEY_SPACE, "Apply update to POM immediately"),
+                                new HelpOverlay.Entry("Ctrl+Z", "Undo last change"),
                                 new HelpOverlay.Entry("f / F", "Cycle filter: all → patch → minor → major"),
-                                new HelpOverlay.Entry("d", "Preview changes as a multi-file diff"),
+                                new HelpOverlay.Entry("d", "Show POM changes as a multi-file diff"),
                                 new HelpOverlay.Entry("i", "Toggle detail pane for selected row"))));
     }
 

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -245,7 +245,12 @@ public class UpdatesTui extends ToolPanel {
     }
 
     void updateStatusIfDone() {
-        if (loadedCount < reactorResult.allDependencies.size()) {
+        int total = reactorResult.allDependencies.size();
+        if (loadedCount < total) {
+            status = "Checking dependencies " + loadedCount + "/" + total + "…";
+            computePropertyGroupVersions();
+            updateReactorCounts();
+            rebuildDisplayRowsKeepSelection();
             return;
         }
         loading = false;
@@ -1509,6 +1514,13 @@ public class UpdatesTui extends ToolPanel {
                 int row = mouseToTableRow(mouse, visible.size(), moduleTableState);
                 if (row >= 0) {
                     moduleTableState.select(row);
+                    var node = visible.get(row);
+                    if (node.hasChildren() && lastTableInner != null) {
+                        int arrowX = lastTableInner.x() + 2 + node.depth * 2; // highlight(2) + indent
+                        if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
+                            node.expanded = !node.expanded;
+                        }
+                    }
                     return true;
                 }
             }
@@ -1527,6 +1539,17 @@ public class UpdatesTui extends ToolPanel {
                 int row = mouseToTableRow(mouse, displayRows.size(), tableState);
                 if (row >= 0) {
                     tableState.select(row);
+                    // Toggle expand/collapse when clicking near the arrow
+                    if (lastTableInner != null) {
+                        int nameColStart = lastTableInner.x() + 3 + 2; // checkbox(3) + highlight(2)
+                        if (mouse.x() >= nameColStart && mouse.x() < nameColStart + 2) {
+                            var r = displayRows.get(row);
+                            if (r.isGroupHeader()) {
+                                r.propertyGroup.expanded = !r.propertyGroup.expanded;
+                                rebuildDisplayRowsKeepSelection();
+                            }
+                        }
+                    }
                     return true;
                 }
             }
@@ -1636,6 +1659,11 @@ public class UpdatesTui extends ToolPanel {
         if (loading) {
             fetchAllUpdates();
         }
+    }
+
+    @Override
+    boolean needsTickRedraw() {
+        return loading || datesLoading;
     }
 
     @Override

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -31,7 +31,6 @@ import dev.tamboui.tui.event.Event;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
 import dev.tamboui.tui.event.MouseEvent;
-import dev.tamboui.tui.event.MouseEventKind;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.paragraph.Paragraph;
@@ -727,7 +726,7 @@ public class UpdatesTui extends ToolPanel {
             handleDepsLeftKey();
             return true;
         }
-        if (key.isCharIgnoreCase(' ') || key.isKey(KeyCode.ENTER)) {
+        if (key.isChar(' ') || key.isKey(KeyCode.ENTER)) {
             applyCurrentUpdate();
             return true;
         }
@@ -909,6 +908,7 @@ public class UpdatesTui extends ToolPanel {
                 return;
             }
         }
+        status = "No matching property group found";
     }
 
     private void applyGroupUpdate(ReactorCollector.PropertyGroup group) {
@@ -1515,72 +1515,57 @@ public class UpdatesTui extends ToolPanel {
             return true;
         }
         if (handleMouseTabBar(mouse)) return true;
-        List<Constraint> widths;
-        if (view == View.DEPENDENCIES) {
-            widths = depsTableWidths();
-        } else {
-            widths = List.of(Constraint.percentage(75), Constraint.percentage(25));
-        }
-        if (handleMouseSortHeader(mouse, widths)) {
-            return true;
-        }
-        if (view == View.MODULES) {
-            List<ReactorModel.ModuleNode> visible = reactorModel.visibleNodes();
-            if (mouse.isClick()) {
-                int row = mouseToTableRow(mouse, visible.size(), moduleTableState);
-                if (row >= 0) {
-                    moduleTableState.select(row);
-                    var node = visible.get(row);
-                    if (node.hasChildren() && lastTableInner != null) {
-                        int arrowX = lastTableInner.x() + 2 + node.depth * 2; // highlight(2) + indent
-                        if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
-                            node.expanded = !node.expanded;
-                        }
-                    }
-                    return true;
-                }
-            }
-            if (mouse.isScroll()) {
-                if (visible.isEmpty()) return false;
-                int sel = moduleTableState.selected();
-                if (mouse.kind() == MouseEventKind.SCROLL_UP) {
-                    moduleTableState.select(Math.max(0, sel - 1));
-                } else {
-                    moduleTableState.select(Math.min(visible.size() - 1, sel + 1));
-                }
-                return true;
-            }
-        } else {
-            if (mouse.isClick()) {
-                int row = mouseToTableRow(mouse, displayRows.size(), tableState);
-                if (row >= 0) {
-                    tableState.select(row);
-                    // Toggle expand/collapse when clicking near the arrow
-                    if (lastTableInner != null) {
-                        int nameColStart = lastTableInner.x() + 3 + 2; // checkbox(3) + highlight(2)
-                        if (mouse.x() >= nameColStart && mouse.x() < nameColStart + 2) {
-                            var r = displayRows.get(row);
-                            if (r.isGroupHeader()) {
-                                r.propertyGroup.expanded = !r.propertyGroup.expanded;
-                                rebuildDisplayRowsKeepSelection();
-                            }
-                        }
-                    }
-                    return true;
-                }
-            }
-            if (mouse.isScroll()) {
-                if (displayRows.isEmpty()) return false;
-                int sel = tableState.selected();
-                if (mouse.kind() == MouseEventKind.SCROLL_UP) {
-                    tableState.select(Math.max(0, sel - 1));
-                } else {
-                    tableState.select(Math.min(displayRows.size() - 1, sel + 1));
-                }
+        List<Constraint> widths = view == View.DEPENDENCIES
+                ? depsTableWidths()
+                : List.of(Constraint.percentage(75), Constraint.percentage(25));
+        if (handleMouseSortHeader(mouse, widths)) return true;
+        return view == View.MODULES ? handleModulesMouseEvent(mouse) : handleDepsMouseEvent(mouse);
+    }
+
+    private boolean handleModulesMouseEvent(MouseEvent mouse) {
+        List<ReactorModel.ModuleNode> visible = reactorModel.visibleNodes();
+        if (mouse.isClick()) {
+            int row = mouseToTableRow(mouse, visible.size(), moduleTableState);
+            if (row >= 0) {
+                moduleTableState.select(row);
+                toggleModuleExpand(visible.get(row), mouse);
                 return true;
             }
         }
-        return false;
+        return handleMouseTableInteraction(mouse, visible.size(), moduleTableState);
+    }
+
+    private void toggleModuleExpand(ReactorModel.ModuleNode node, MouseEvent mouse) {
+        if (node.hasChildren() && lastTableInner != null) {
+            int arrowX = lastTableInner.x() + 2 + node.depth * 2; // highlight(2) + indent
+            if (mouse.x() >= arrowX && mouse.x() < arrowX + 2) {
+                node.expanded = !node.expanded;
+            }
+        }
+    }
+
+    private boolean handleDepsMouseEvent(MouseEvent mouse) {
+        if (mouse.isClick()) {
+            int row = mouseToTableRow(mouse, displayRows.size(), tableState);
+            if (row >= 0) {
+                tableState.select(row);
+                toggleGroupExpand(row, mouse);
+                return true;
+            }
+        }
+        return handleMouseTableInteraction(mouse, displayRows.size(), tableState);
+    }
+
+    private void toggleGroupExpand(int row, MouseEvent mouse) {
+        if (lastTableInner == null) return;
+        int nameColStart = lastTableInner.x() + 3 + 2; // checkbox(3) + highlight(2)
+        if (mouse.x() >= nameColStart && mouse.x() < nameColStart + 2) {
+            var r = displayRows.get(row);
+            if (r.isGroupHeader()) {
+                r.propertyGroup.expanded = !r.propertyGroup.expanded;
+                rebuildDisplayRowsKeepSelection();
+            }
+        }
     }
 
     @Override

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -120,6 +120,7 @@ public class UpdatesTui extends ToolPanel {
     private static final String ARROW = " \u2192 ";
     private static final String KEY_NAV = ":Nav  ";
     private static final String KEY_SPACE = "Space";
+    private static final String ORIGIN_UPDATES = "updates";
 
     private final ReactorCollector.CollectionResult reactorResult;
     private final ReactorModel reactorModel;
@@ -870,6 +871,10 @@ public class UpdatesTui extends ToolPanel {
 
         var row = displayRows.get(sel);
         if (row.isGroupHeader()) {
+            if (row.propertyGroup.applied || !row.propertyGroup.hasUpdate()) {
+                status = row.propertyGroup.applied ? "Already applied" : "No update available";
+                return;
+            }
             applyGroupUpdate(row.propertyGroup);
         } else if (row.dependency != null && row.dependency.hasUpdate() && !row.dependency.applied) {
             if (row.dependency.isPropertyManaged()) {
@@ -882,6 +887,8 @@ public class UpdatesTui extends ToolPanel {
             } else {
                 applySingleUpdate(row.dependency);
             }
+        } else {
+            status = (row.dependency != null && row.dependency.applied) ? "Already applied" : "No update available";
         }
     }
 
@@ -896,14 +903,14 @@ public class UpdatesTui extends ToolPanel {
                 "property",
                 group.propertyName,
                 group.resolvedVersion + ARROW + group.newestVersion,
-                "updates");
+                ORIGIN_UPDATES);
         mutatedSessions.add(session);
         group.applied = true;
         for (var dep : group.dependencies) {
             dep.applied = true;
         }
         updateReactorCounts();
-        buildDisplayRows();
+        rebuildDisplayRowsKeepSelection();
         status = "Updated ${" + group.propertyName + "}: " + group.resolvedVersion + ARROW + group.newestVersion;
     }
 
@@ -924,11 +931,11 @@ public class UpdatesTui extends ToolPanel {
                 loc.managed ? "managed" : "dependency",
                 dep.ga(),
                 dep.primaryVersion + ARROW + dep.newestVersion,
-                "updates");
+                ORIGIN_UPDATES);
         mutatedSessions.add(session);
         dep.applied = true;
         updateReactorCounts();
-        buildDisplayRows();
+        rebuildDisplayRowsKeepSelection();
         status = "Updated " + dep.ga() + ": " + dep.primaryVersion + ARROW + dep.newestVersion;
     }
 

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiRenderTest.java
@@ -345,21 +345,12 @@ class UpdatesTuiRenderTest {
     // ── Apply updates ──────────────────────────────────────────────────────
 
     @Test
-    void spaceAppliesUpdateShowsMessage() throws Exception {
+    void spaceAppliesUpdateShowsMessageAndMarker() throws Exception {
         var tui = createTuiWithUpdates();
         tui.handleEvent(KeyEvent.ofChar(' '), null); // apply first dep
 
         String output = render(tui::renderStandalone);
-        assertThat(output).contains("Updated");
-    }
-
-    @Test
-    void spaceAppliesUpdateShowsAppliedMarker() throws Exception {
-        var tui = createTuiWithUpdates();
-        tui.handleEvent(KeyEvent.ofChar(' '), null); // apply first dep
-
-        String output = render(tui::renderStandalone);
-        assertThat(output).contains("[\u00b7]");
+        assertThat(output).contains("Updated").contains("[\u00b7]");
     }
 
     // ── Diff overlay ───────────────────────────────────────────────────────

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiRenderTest.java
@@ -229,63 +229,44 @@ class UpdatesTuiRenderTest {
         assertThat(output).contains("─".repeat(10));
     }
 
-    // ── Selection ──────────────────────────────────────────────────────────
+    // ── Apply ─────────────────────────────────────────────────────────────
 
     @Test
-    void initiallyNoDependenciesSelected() throws Exception {
+    void initiallyNoDependenciesApplied() throws Exception {
         var tui = createTuiWithUpdates();
         String output = render(tui::renderStandalone);
 
-        assertThat(output).doesNotContain("[\u2713]"); // [✓]
+        assertThat(output).doesNotContain("[\u00b7]"); // [·]
     }
 
     @Test
-    void spaceTogglesSelectionOnCurrentRow() throws Exception {
+    void spaceAppliesCurrentRow() throws Exception {
         var tui = createTuiWithUpdates();
         tui.handleEvent(KeyEvent.ofChar(' '), null);
 
         String output = render(tui::renderStandalone);
-        assertThat(output).contains("[\u2713]");
-        assertThat(countOccurrences(output, "[\u2713]")).isEqualTo(1);
+        assertThat(output).contains("[\u00b7]");
+        assertThat(countOccurrences(output, "[\u00b7]")).isEqualTo(1);
     }
 
     @Test
-    void spaceTogglesSelectionOff() throws Exception {
+    void spaceOnAppliedRowDoesNothing() throws Exception {
         var tui = createTuiWithUpdates();
-        tui.handleEvent(KeyEvent.ofChar(' '), null); // select
-        tui.handleEvent(KeyEvent.ofChar(' '), null); // deselect
+        tui.handleEvent(KeyEvent.ofChar(' '), null); // apply
+        tui.handleEvent(KeyEvent.ofChar(' '), null); // no-op
 
         String output = render(tui::renderStandalone);
-        assertThat(output).doesNotContain("[\u2713]");
+        assertThat(countOccurrences(output, "[\u00b7]")).isEqualTo(1);
     }
 
     @Test
-    void selectAllMarksAllDependencies() throws Exception {
-        var tui = createTuiWithUpdates();
-        tui.handleEvent(KeyEvent.ofChar('a'), null);
-
-        String output = render(tui::renderStandalone);
-        assertThat(countOccurrences(output, "[\u2713]")).isEqualTo(3);
-    }
-
-    @Test
-    void deselectAllClearsCheckmarks() throws Exception {
-        var tui = createTuiWithUpdates();
-        tui.handleEvent(KeyEvent.ofChar('a'), null);
-        tui.handleEvent(KeyEvent.ofChar('n'), null);
-
-        String output = render(tui::renderStandalone);
-        assertThat(output).doesNotContain("[\u2713]");
-    }
-
-    @Test
-    void selectOnSecondRowAfterNavigation() throws Exception {
+    void applyOnSecondRowAfterNavigation() throws Exception {
         var tui = createTuiWithUpdates();
         tui.handleEvent(KeyEvent.ofKey(KeyCode.DOWN), null); // move to row 1
-        tui.handleEvent(KeyEvent.ofChar(' '), null); // select row 1
+        tui.handleEvent(KeyEvent.ofChar(' '), null); // apply row 1
 
         String output = render(tui::renderStandalone);
-        assertThat(countOccurrences(output, "[\u2713]")).isEqualTo(1);
+        assertThat(countOccurrences(output, "[\u00b7]")).isEqualTo(1);
     }
 
     // ── Filtering ──────────────────────────────────────────────────────────
@@ -338,16 +319,16 @@ class UpdatesTuiRenderTest {
     // ── Navigation ─────────────────────────────────────────────────────────
 
     @Test
-    void navigationDownThenSelectHitsSecondRow() throws Exception {
+    void navigationDownThenApplyHitsSecondRow() throws Exception {
         var tui = createTuiWithUpdates();
-        // Select first row
+        // Apply first row
         tui.handleEvent(KeyEvent.ofChar(' '), null);
-        // Move down and select second row
+        // Move down and apply second row
         tui.handleEvent(KeyEvent.ofKey(KeyCode.DOWN), null);
         tui.handleEvent(KeyEvent.ofChar(' '), null);
 
         String output = render(tui::renderStandalone);
-        assertThat(countOccurrences(output, "[\u2713]")).isEqualTo(2);
+        assertThat(countOccurrences(output, "[\u00b7]")).isEqualTo(2);
     }
 
     @Test
@@ -364,59 +345,38 @@ class UpdatesTuiRenderTest {
     // ── Apply updates ──────────────────────────────────────────────────────
 
     @Test
-    void applyWithNothingSelectedShowsMessage() throws Exception {
+    void spaceAppliesUpdateShowsMessage() throws Exception {
         var tui = createTuiWithUpdates();
-        tui.handleEvent(KeyEvent.ofKey(KeyCode.ENTER), null);
+        tui.handleEvent(KeyEvent.ofChar(' '), null); // apply first dep
 
         String output = render(tui::renderStandalone);
-        assertThat(output).contains("No updates selected");
+        assertThat(output).contains("Updated");
     }
 
     @Test
-    void applyUpdatesShowsAppliedMessage() throws Exception {
+    void spaceAppliesUpdateShowsAppliedMarker() throws Exception {
         var tui = createTuiWithUpdates();
-        tui.handleEvent(KeyEvent.ofChar(' '), null); // select first dep
-        tui.handleEvent(KeyEvent.ofKey(KeyCode.ENTER), null);
+        tui.handleEvent(KeyEvent.ofChar(' '), null); // apply first dep
 
         String output = render(tui::renderStandalone);
-        assertThat(output).contains("Applied").contains("update(s)");
-    }
-
-    @Test
-    void applyUpdatesShowsAppliedMarker() throws Exception {
-        var tui = createTuiWithUpdates();
-        tui.handleEvent(KeyEvent.ofChar(' '), null); // select first dep
-        tui.handleEvent(KeyEvent.ofKey(KeyCode.ENTER), null);
-
-        String output = render(tui::renderStandalone);
-        assertThat(output).contains("guava").contains("[·]").contains("slf4j-api");
-    }
-
-    @Test
-    void applyAllUpdatesShowsAllApplied() throws Exception {
-        var tui = createTuiWithUpdates();
-        tui.handleEvent(KeyEvent.ofChar('a'), null); // select all
-        tui.handleEvent(KeyEvent.ofKey(KeyCode.ENTER), null);
-
-        String output = render(tui::renderStandalone);
-        assertThat(output).contains("[·]").contains("applied");
+        assertThat(output).contains("[\u00b7]");
     }
 
     // ── Diff overlay ───────────────────────────────────────────────────────
 
     @Test
-    void diffWithNoSelectionShowsMessage() throws Exception {
+    void diffWithNoChangesShowsMessage() throws Exception {
         var tui = createTuiWithUpdates();
         tui.handleEvent(KeyEvent.ofChar('d'), null);
 
         String output = render(tui::renderStandalone);
-        assertThat(output).contains("No updates selected");
+        assertThat(output).contains("No changes to show");
     }
 
     @Test
-    void diffPreviewShowsOverlayTitle() throws Exception {
+    void diffAfterApplyShowsOverlayTitle() throws Exception {
         var tui = createTuiWithUpdates();
-        tui.handleEvent(KeyEvent.ofChar(' '), null); // select dep
+        tui.handleEvent(KeyEvent.ofChar(' '), null); // apply dep
         tui.handleEvent(KeyEvent.ofChar('d'), null); // open diff
 
         String output = render(tui::renderStandalone);
@@ -426,7 +386,7 @@ class UpdatesTuiRenderTest {
     @Test
     void diffOverlayClosesOnEscape() throws Exception {
         var tui = createTuiWithUpdates();
-        tui.handleEvent(KeyEvent.ofChar(' '), null);
+        tui.handleEvent(KeyEvent.ofChar(' '), null); // apply
         tui.handleEvent(KeyEvent.ofChar('d'), null);
         tui.handleEvent(KeyEvent.ofKey(KeyCode.ESCAPE), null);
 
@@ -435,12 +395,12 @@ class UpdatesTuiRenderTest {
     }
 
     @Test
-    void diffAfterApplyShowsChanges() throws Exception {
+    void diffAfterMultipleAppliesShowsChanges() throws Exception {
         var tui = createTuiWithUpdates();
         // Apply first dep
         tui.handleEvent(KeyEvent.ofChar(' '), null);
-        tui.handleEvent(KeyEvent.ofKey(KeyCode.ENTER), null);
-        // Select next dep and preview diff
+        // Move down and apply second dep
+        tui.handleEvent(KeyEvent.ofKey(KeyCode.DOWN), null);
         tui.handleEvent(KeyEvent.ofChar(' '), null);
         tui.handleEvent(KeyEvent.ofChar('d'), null);
 
@@ -455,18 +415,13 @@ class UpdatesTuiRenderTest {
         var tui = createTuiWithUpdates();
         String output = render(tui::renderStandalone);
 
-        assertThat(output)
-                .contains("Nav")
-                .contains("Toggle")
-                .contains("Apply")
-                .contains("Filter")
-                .contains("Quit");
+        assertThat(output).contains("Nav").contains("Apply").contains("Filter").contains("Quit");
     }
 
     @Test
     void diffOverlayShowsDiffKeyHints() throws Exception {
         var tui = createTuiWithUpdates();
-        tui.handleEvent(KeyEvent.ofChar(' '), null);
+        tui.handleEvent(KeyEvent.ofChar(' '), null); // apply first
         tui.handleEvent(KeyEvent.ofChar('d'), null);
 
         String output = render(tui::renderStandalone);
@@ -580,14 +535,5 @@ class UpdatesTuiRenderTest {
 
         String output = render(tui::renderStandalone);
         assertThat(output).contains("${spring.version}").contains("guava");
-    }
-
-    @Test
-    void selectAllIncludesPropertyGroupAndUngrouped() throws Exception {
-        var tui = createTuiWithPropertyGroup();
-        tui.handleEvent(KeyEvent.ofChar('a'), null);
-
-        String output = render(tui::renderStandalone);
-        assertThat(countOccurrences(output, "[\u2713]")).isGreaterThanOrEqualTo(2);
     }
 }

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
@@ -639,7 +639,7 @@ class UpdatesTuiTest {
         var dep = result.ungroupedDependencies.get(0);
         dep.newestVersion = "2.0.0";
         dep.updateType = VersionComparator.UpdateType.MAJOR;
-        dep.selected = true;
+        dep.applied = true;
 
         tui.loading = false;
         tui.buildDisplayRows();

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesTuiTest.java
@@ -626,7 +626,7 @@ class UpdatesTuiTest {
     }
 
     @Test
-    void renderWithSelectedUngroupedDependency() throws IOException {
+    void renderWithAppliedUngroupedDependency() throws IOException {
         Path dir = subdir("render6");
 
         PilotProject.Dep d = dep("com.example", "lib", "1.0");


### PR DESCRIPTION
## Summary
- **Immediate apply**: Space/Enter applies dependency updates directly to the POM without a separate confirmation step
- **Incremental loading progress**: UpdatesTui now shows "Checking dependencies N/M…" with partial results appearing in the table as each dependency resolves, instead of a static "Loading updates…" screen
- **Mouse click precision**: Expand/collapse in tree views now triggers only on arrow clicks, not the entire row (UpdatesTui, AuditTui, TreeTui, PomTui, ModuleTreePane)
- **Tick redraws**: Added `needsTickRedraw()` to panels with async work (AuditTui, ConflictsTui, SearchTui, UpdatesTui) so the shell repaints during loading

## Test plan
- [ ] Open Updates panel — verify progress counter increments and partial results appear during loading
- [ ] Press Space on a dependency — verify it applies immediately
- [ ] Click tree arrows — verify only arrow area toggles expand/collapse
- [ ] Verify all panels with async loading repaint correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Switched updates workflow from “select and apply” to immediate apply (Space/Enter) with applied indicators and Ctrl+Z undo; removed batch select mode and related key hints.
* **User Interface**
  * Clickable expand/collapse arrows for trees and module/dependency panes; updated info bar and diff/preview behavior to reflect applied state.
* **Tests**
  * UI tests updated to assert apply-centric interactions and markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->