### PR TITLE
chore: replace inline FQCNs with imports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,10 @@ Use `./mvnw` instead of `mvn` for all Maven commands. Always add `-B` (batch mod
 
 After packaging (`./mvnw package -B -DskipTests`), compute the full absolute path to the pilot-cli jar (matching `pilot-cli/target/pilot-cli-*-SNAPSHOT.jar` under the project root) and give the `java -jar <path>` command to the user so they can run it from any directory.
 
+## Code Style
+
+Avoid inline fully-qualified class names (FQCNs). Use `import` statements and simple class names instead. Exception: when two classes share the same simple name (e.g., `org.apache.maven.model.Dependency` vs `org.apache.maven.api.model.Dependency`), keep FQCNs to disambiguate.
+
 ## After Creating a PR
 
 After pushing a PR, monitor and address all automated feedback:

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -49,6 +49,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Interactive TUI showing declared vs transitive dependency overview.
@@ -230,7 +231,7 @@ public class DependenciesTui extends ToolPanel {
     private final boolean bytecodeAnalyzed;
     private final boolean reactorMode;
     private final PomEditSession managementSession;
-    private final java.util.function.Function<Path, PomEditSession> sessionProvider;
+    private final Function<Path, PomEditSession> sessionProvider;
     private final TableState tableState = new TableState();
 
     private View view = View.DECLARED;
@@ -338,7 +339,7 @@ public class DependenciesTui extends ToolPanel {
             String projectGav,
             int modulesScanned,
             int modulesSkipped,
-            java.util.function.Function<Path, PomEditSession> sessionProvider,
+            Function<Path, PomEditSession> sessionProvider,
             PomEditSession managementSession) {
         this.editSession = null;
         this.managementSession = managementSession;
@@ -364,7 +365,7 @@ public class DependenciesTui extends ToolPanel {
     @Override
     boolean onSessionChanged() {
         if (editSession == null) return true;
-        Set<String> existingGAs = managed.stream().map(ManagedEntry::ga).collect(java.util.stream.Collectors.toSet());
+        Set<String> existingGAs = managed.stream().map(ManagedEntry::ga).collect(Collectors.toSet());
         for (PomEditSession.Change change : editSession.changes()) {
             if (change.type() == PomEditSession.ChangeType.REMOVE) {
                 return false;

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -21,6 +21,7 @@ package eu.maveniverse.maven.pilot;
 import eu.maveniverse.domtrip.Document;
 import eu.maveniverse.domtrip.maven.PomEditor;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -30,8 +31,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.logging.Logger;
 
 /**
@@ -46,8 +49,8 @@ public class PilotEngine {
     private final PilotResolver resolver;
     private final List<PilotProject> allProjects;
     private final String scope;
-    private final Map<String, DependencyTreeModel> treeCache = new java.util.concurrent.ConcurrentHashMap<>();
-    private final Map<String, AuditTui.AuditEntry> auditEntryCache = new java.util.concurrent.ConcurrentHashMap<>();
+    private final Map<String, DependencyTreeModel> treeCache = new ConcurrentHashMap<>();
+    private final Map<String, AuditTui.AuditEntry> auditEntryCache = new ConcurrentHashMap<>();
     private static final Set<String> TEST_SCOPES = Set.of("test", "test-only", "test-runtime");
 
     public PilotEngine(PilotResolver resolver, List<PilotProject> allProjects, String scope) {
@@ -79,7 +82,7 @@ public class PilotEngine {
             PilotProject proj,
             List<PilotProject> projects,
             PomEditSession session,
-            java.util.function.Function<java.nio.file.Path, PomEditSession> sessionProvider,
+            Function<Path, PomEditSession> sessionProvider,
             Consumer<String> progress)
             throws Exception {
         return switch (toolId) {
@@ -98,7 +101,7 @@ public class PilotEngine {
             PilotProject proj,
             List<PilotProject> projects,
             PomEditSession session,
-            java.util.function.Function<Path, PomEditSession> sessionProvider,
+            Function<Path, PomEditSession> sessionProvider,
             Consumer<String> progress)
             throws Exception {
         if (projects.size() > 1) {
@@ -112,7 +115,7 @@ public class PilotEngine {
             PilotProject proj,
             PomEditSession session,
             List<PilotProject> projects,
-            java.util.function.Function<Path, PomEditSession> sessionProvider)
+            Function<Path, PomEditSession> sessionProvider)
             throws Exception {
         Set<String> declaredGAs = new HashSet<>();
         List<DependenciesTui.DepEntry> declared = new ArrayList<>();
@@ -176,9 +179,7 @@ public class PilotEngine {
     }
 
     private ToolPanel createReactorDependenciesPanel(
-            List<PilotProject> projects,
-            java.util.function.Function<Path, PomEditSession> sessionProvider,
-            Consumer<String> progress)
+            List<PilotProject> projects, Function<Path, PomEditSession> sessionProvider, Consumer<String> progress)
             throws Exception {
         Map<String, DependenciesTui.DepEntry> unusedMap = new LinkedHashMap<>();
         Map<String, DependenciesTui.DepEntry> usedTransMap = new LinkedHashMap<>();
@@ -230,7 +231,7 @@ public class PilotEngine {
         List<DependenciesTui.DepEntry> transitive = new ArrayList<>();
         DependenciesTui.collectTransitive(resolved.tree().root, declaredGAs, transitiveGAs, transitive);
 
-        Map<String, java.io.File> gaToJar = resolved.gaToJar();
+        Map<String, File> gaToJar = resolved.gaToJar();
         ClassFileScanner.ScanResult mainScan = ClassFileScanner.scanDirectory(p.outputDirectory);
         ClassFileScanner.ScanResult testScan = p.testOutputDirectory != null && Files.isDirectory(p.testOutputDirectory)
                 ? ClassFileScanner.scanDirectory(p.testOutputDirectory)
@@ -364,7 +365,7 @@ public class PilotEngine {
             PilotProject proj,
             List<PilotProject> projects,
             PomEditSession session,
-            java.util.function.Function<java.nio.file.Path, PomEditSession> sessionProvider,
+            Function<Path, PomEditSession> sessionProvider,
             Consumer<String> progress) {
         UpdatesTui.VersionResolver versionResolver = resolver::resolveVersions;
         List<PilotProject> targetProjects = projects.size() > 1 ? projects : List.of(proj);
@@ -378,7 +379,7 @@ public class PilotEngine {
             PilotProject proj,
             List<PilotProject> projects,
             PomEditSession session,
-            java.util.function.Function<java.nio.file.Path, PomEditSession> sessionProvider,
+            Function<Path, PomEditSession> sessionProvider,
             Consumer<String> progress) {
         List<PilotProject> targetProjects = projects.size() > 1 ? projects : List.of(proj);
         resolveAllDependencies(targetProjects, progress);
@@ -414,7 +415,7 @@ public class PilotEngine {
             PilotProject proj,
             List<PilotProject> projects,
             PomEditSession session,
-            java.util.function.Function<java.nio.file.Path, PomEditSession> sessionProvider,
+            Function<Path, PomEditSession> sessionProvider,
             Consumer<String> progress) {
         if (projects.size() > 1) {
             resolveAllDependencies(projects, progress);
@@ -452,7 +453,7 @@ public class PilotEngine {
         }
     }
 
-    private ToolPanel createPomPanel(PilotProject proj, PomEditSession session) throws java.io.IOException {
+    private ToolPanel createPomPanel(PilotProject proj, PomEditSession session) throws IOException {
         String rawPom = (session != null && session.isDirty()) ? session.currentXml() : Files.readString(proj.pomPath);
         String effectivePom = resolver.effectivePom(proj);
         XmlTreeModel effectiveTree = XmlTreeModel.parse(effectivePom);
@@ -528,7 +529,7 @@ public class PilotEngine {
             PilotProject proj,
             List<PilotProject> projects,
             PomEditSession currentSession,
-            java.util.function.Function<java.nio.file.Path, PomEditSession> sessionProvider) {
+            Function<Path, PomEditSession> sessionProvider) {
         if (sessionProvider == null) {
             return currentSession;
         }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -37,6 +37,9 @@ import dev.tamboui.tui.event.TickEvent;
 import dev.tamboui.widgets.block.Block;
 import dev.tamboui.widgets.block.BorderType;
 import dev.tamboui.widgets.paragraph.Paragraph;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -46,6 +49,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * Unified shell container for the Pilot TUI.
@@ -80,8 +85,8 @@ public class PilotShell {
                 PilotProject project,
                 List<PilotProject> scope,
                 PomEditSession session,
-                java.util.function.Function<java.nio.file.Path, PomEditSession> sessionProvider,
-                java.util.function.Consumer<String> progress)
+                Function<Path, PomEditSession> sessionProvider,
+                Consumer<String> progress)
                 throws Exception;
     }
 
@@ -125,9 +130,6 @@ public class PilotShell {
     private PilotProject selectedProject;
     private List<PilotProject> selectedScope;
     private TuiRunner runner;
-
-    // Captured log output (redirected from System.out/err during TUI)
-    private java.io.ByteArrayOutputStream capturedLog;
 
     // Async panel creation
     private final ExecutorService panelExecutor = Executors.newCachedThreadPool(r -> {
@@ -192,8 +194,8 @@ public class PilotShell {
         // to a buffer to prevent corruption of the TUI on the alternate screen
         var origOut = System.out;
         var origErr = System.err;
-        capturedLog = new java.io.ByteArrayOutputStream();
-        var logStream = new java.io.PrintStream(capturedLog, true);
+        var capturedLog = new ByteArrayOutputStream();
+        var logStream = new PrintStream(capturedLog, true);
         System.setOut(logStream);
         System.setErr(logStream);
         try {
@@ -449,7 +451,7 @@ public class PilotShell {
     }
 
     @SuppressWarnings("unused")
-    private void invalidatePanelCacheForPom(java.nio.file.Path pomPath) {
+    private void invalidatePanelCacheForPom(Path pomPath) {
         panelCache.entrySet().removeIf(entry -> {
             // Cache keys are "toolId:moduleGA" — we need to match by POM path
             // which requires checking the project. For simplicity, clear all module-dependent panels.
@@ -648,7 +650,7 @@ public class PilotShell {
         } else {
             session = null;
         }
-        final java.util.function.Function<java.nio.file.Path, PomEditSession> sessionProvider = path -> {
+        final Function<Path, PomEditSession> sessionProvider = path -> {
             if (PilotEngine.isRepositoryPom(path)) {
                 throw new IllegalArgumentException("Cannot modify repository POM: " + path);
             }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/Theme.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/Theme.java
@@ -128,7 +128,7 @@ class Theme {
                 ? label.toLowerCase().indexOf(mnemonic)
                 : label.indexOf(mnemonic);
         if (idx < 0) idx = label.toLowerCase().indexOf(Character.toLowerCase(mnemonic));
-        List<Span> spans = new java.util.ArrayList<>();
+        List<Span> spans = new ArrayList<>();
         spans.add(Span.raw("[▸").bold().cyan());
         if (idx >= 0) {
             if (idx > 0) spans.add(Span.raw(label.substring(0, idx)).bold().cyan());
@@ -148,7 +148,7 @@ class Theme {
                 ? label.toLowerCase().indexOf(mnemonic)
                 : label.indexOf(mnemonic);
         if (idx < 0) idx = label.toLowerCase().indexOf(Character.toLowerCase(mnemonic));
-        List<Span> spans = new java.util.ArrayList<>();
+        List<Span> spans = new ArrayList<>();
         if (idx >= 0) {
             if (idx > 0) spans.add(Span.raw(label.substring(0, idx)));
             spans.add(Span.raw(String.valueOf(label.charAt(idx))).underlined());
@@ -165,7 +165,7 @@ class Theme {
                 ? label.toLowerCase().indexOf(mnemonic)
                 : label.indexOf(mnemonic);
         if (idx < 0) idx = label.toLowerCase().indexOf(Character.toLowerCase(mnemonic));
-        List<Span> spans = new java.util.ArrayList<>();
+        List<Span> spans = new ArrayList<>();
         if (idx >= 0) {
             if (idx > 0) spans.add(Span.raw(label.substring(0, idx)).fg(Color.DARK_GRAY));
             spans.add(Span.raw(String.valueOf(label.charAt(idx)))

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -40,11 +40,13 @@ import dev.tamboui.widgets.table.Row;
 import dev.tamboui.widgets.table.Table;
 import dev.tamboui.widgets.table.TableState;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
 
 /**
  * Interactive TUI for browsing the dependency tree.
@@ -695,15 +697,15 @@ public class TreeTui extends ToolPanel {
         if (col < 0) {
             model = fullModel.filterByScope(scope);
         } else {
-            java.util.function.Function<DependencyTreeModel.TreeNode, String> extractor =
+            Function<DependencyTreeModel.TreeNode, String> extractor =
                     switch (col) {
                         case COL_GA -> n -> n.groupId + ":" + n.artifactId;
                         case COL_VERSION -> n -> n.version;
                         case COL_SCOPE -> n -> n.scope;
                         default -> n -> "";
                     };
-            java.util.Comparator<DependencyTreeModel.TreeNode> cmp =
-                    java.util.Comparator.comparing(extractor, String.CASE_INSENSITIVE_ORDER);
+            Comparator<DependencyTreeModel.TreeNode> cmp =
+                    Comparator.comparing(extractor, String.CASE_INSENSITIVE_ORDER);
             if (!sortState.ascending()) {
                 cmp = cmp.reversed();
             }
@@ -714,7 +716,7 @@ public class TreeTui extends ToolPanel {
     }
 
     private void sortChildrenRecursive(
-            DependencyTreeModel.TreeNode node, java.util.Comparator<DependencyTreeModel.TreeNode> cmp) {
+            DependencyTreeModel.TreeNode node, Comparator<DependencyTreeModel.TreeNode> cmp) {
         node.children.sort(cmp);
         for (var child : node.children) {
             sortChildrenRecursive(child, cmp);

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/AlignBatchTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/AlignBatchTest.java
@@ -24,6 +24,7 @@ import eu.maveniverse.domtrip.maven.AlignOptions;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -675,7 +676,7 @@ class AlignBatchTest {
                 List.of(),
                 List.of(),
                 List.of(),
-                new java.util.Properties(),
+                new Properties(),
                 null,
                 null);
     }

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ConflictsTuiRenderTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ConflictsTuiRenderTest.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
@@ -430,7 +431,7 @@ class ConflictsTuiRenderTest {
                 List.of(),
                 List.of(),
                 List.of(),
-                new java.util.Properties(),
+                new Properties(),
                 null,
                 null);
     }

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/OsvClientTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/OsvClientTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
+import java.io.StringReader;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class OsvClientTest {
 
     private JsonObject buildResponse(String json) {
-        try (var reader = Json.createReader(new java.io.StringReader(json))) {
+        try (var reader = Json.createReader(new StringReader(json))) {
             return reader.readObject();
         }
     }

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PageNavigationTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/PageNavigationTest.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -176,7 +177,7 @@ class PageNavigationTest {
                 List.of(),
                 deps,
                 List.of(),
-                new java.util.Properties(),
+                new Properties(),
                 null,
                 null);
         List<PilotProject> projects = List.of(proj);

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/RecordingDemoTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/RecordingDemoTest.java
@@ -36,6 +36,7 @@ import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
@@ -449,7 +450,7 @@ class RecordingDemoTest {
                 List.of(),
                 deps,
                 List.of(),
-                new java.util.Properties(),
+                new Properties(),
                 null,
                 null);
         List<PilotProject> projects = List.of(proj);

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ScreenshotTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/ScreenshotTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.junit.jupiter.api.io.TempDir;
@@ -194,7 +195,7 @@ class ScreenshotTest {
                 List.of(),
                 deps,
                 List.of(),
-                new java.util.Properties(),
+                new Properties(),
                 null,
                 null);
         List<PilotProject> projects = List.of(proj);

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesDemoTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/UpdatesDemoTest.java
@@ -28,6 +28,7 @@ import dev.tamboui.terminal.TestBackend;
 import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.pilot.Pilot;
 import dev.tamboui.tui.pilot.TuiTestRunner;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,7 @@ class UpdatesDemoTest {
     }
 
     @Test
-    void browseAndSwitchViews(@TempDir java.nio.file.Path tempDir) throws Exception {
+    void browseAndSwitchViews(@TempDir Path tempDir) throws Exception {
         var root = createProject("parent", tempDir);
         var child = createProject("child", TestProjects.subdir(tempDir, "child"));
         child.parent = root;

--- a/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/DependenciesMojo.java
+++ b/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/DependenciesMojo.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import javax.inject.Inject;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Dependency;
@@ -199,7 +200,7 @@ public class DependenciesMojo extends AbstractMojo {
         } else {
             dep.totalClasses = depClasses.size();
             Set<String> refs = TEST_SCOPES.contains(dep.scope) ? allClassRefs : mainClassRefs;
-            Map<String, List<String>> members = new java.util.TreeMap<>();
+            Map<String, List<String>> members = new TreeMap<>();
             for (String className : depClasses) {
                 if (refs.contains(className)) {
                     Set<String> memberSet = allMemberRefs.get(className);


### PR DESCRIPTION
## Summary
- Replace inline fully-qualified class names with proper `import` statements across 13 source and test files in `pilot-core` and `pilot-plugin`
- Add CLAUDE.md code style guideline to avoid FQCNs going forward
- Preserves FQCNs where name collisions require disambiguation (`org.apache.maven.model.Dependency` vs `org.apache.maven.api.model.Dependency`)

## Test plan
- [x] `./mvnw compile -B -pl pilot-core,pilot-plugin,pilot-cli` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated coding conventions for contributors.

* **Refactor**
  * Code cleanup and simplification improvements throughout the codebase for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->