### PR TITLE
chore: leverage DomTrip 1.4.0 updateManagedDependencyAligned and findManagedVersion APIs

### DIFF
--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -969,16 +969,7 @@ public class DependenciesTui extends ToolPanel {
         session.beforeMutation();
         PomEditor editor = session.editor();
         AlignOptions detected = editor.dependencies().detectConventions();
-        // TODO: replace with editor.dependencies().findManagedVersion(coords) != null
-        //  when DomTrip exposes it (https://github.com/maveniverse/domtrip/issues/215)
-        boolean hadManagedEntry = editor.document()
-                .root()
-                .childElement("dependencyManagement")
-                .flatMap(dm -> dm.childElement(SECTION_DEPENDENCIES))
-                .flatMap(deps -> deps.childElements(TARGET_DEPENDENCY)
-                        .filter(coords.predicateGATC())
-                        .findFirst())
-                .isPresent();
+        boolean hadManagedEntry = editor.dependencies().findManagedVersion(coords) != null;
         AlignOptions.Builder builder = AlignOptions.builder()
                 .versionStyle(detected.versionStyle())
                 .versionSource(detected.versionSource())

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomEditSession.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomEditSession.java
@@ -19,7 +19,6 @@
 package eu.maveniverse.maven.pilot;
 
 import eu.maveniverse.domtrip.Document;
-import eu.maveniverse.domtrip.maven.AlignOptions;
 import eu.maveniverse.domtrip.maven.Coordinates;
 import eu.maveniverse.domtrip.maven.PomEditor;
 import java.io.IOException;
@@ -184,20 +183,11 @@ public class PomEditSession {
      * @param managementSession the session whose POM should receive the managed dependency
      */
     void addManagedDependencyAligned(Coordinates coords, PomEditSession managementSession) {
-        PomEditor targetEditor = managementSession.editor();
-        AlignOptions conventions = targetEditor.dependencies().detectConventions();
-        AlignOptions.VersionSource versionSource = conventions.versionSource();
         String version = coords.version();
         if (managementSession != this) {
             managementSession.beforeMutation();
         }
-        if (versionSource == AlignOptions.VersionSource.PROPERTY) {
-            AlignOptions.PropertyNamingConvention naming = conventions.namingConvention();
-            String propName = AlignOptions.generatePropertyName(coords, naming);
-            targetEditor.properties().updateProperty(true, propName, version);
-            coords = Coordinates.of(coords.groupId(), coords.artifactId(), "${" + propName + "}");
-        }
-        targetEditor.dependencies().updateManagedDependency(true, coords);
+        managementSession.editor().dependencies().updateManagedDependencyAligned(true, coords);
         if (managementSession != this) {
             managementSession.recordChange(
                     ChangeType.ADD,


### PR DESCRIPTION
## Summary

- Replace manual convention-aware managed dependency logic in `PomEditSession.addManagedDependencyAligned()` with DomTrip's new `updateManagedDependencyAligned()` API
- Replace XML traversal workaround in `DependenciesTui.addDependencyToSession()` with the now-public `findManagedVersion()` API, resolving the TODO from [domtrip#215](https://github.com/maveniverse/domtrip/issues/215)

Net result: **-19 lines**, same behavior, delegating to DomTrip for convention detection and property management.

## Test plan

- [x] All 469 existing tests pass
- [x] `DependenciesTui` managed entry detection uses `findManagedVersion()` instead of manual XML traversal
- [x] `PomEditSession` cross-module managed dependency alignment delegates to `updateManagedDependencyAligned()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved dependency management internals by using higher-level editor APIs instead of manual processing.
  * Better handling of managed dependencies and aligned updates, reducing duplication when promoting dependencies to management POMs.
  * No user-facing behavior changes; maintenance and reliability of dependency operations are improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->