### PR TITLE
feat: configurable allowlists and analyze-dependencies goal

### DIFF
--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependencyUsageAnalyzer.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependencyUsageAnalyzer.java
@@ -33,6 +33,24 @@ import java.util.jar.JarFile;
 /**
  * Builds a class-to-artifact index from resolved JARs and classifies dependency usage
  * based on bytecode analysis results.
+ *
+ * <p>The analyzer supports three optional allowlists that override the default classification
+ * for dependencies that are legitimately used but cannot be detected through bytecode analysis:</p>
+ * <ul>
+ *   <li><b>runtimeArtifacts</b> — artifacts needed only at runtime (JDBC drivers, SLF4J backends)</li>
+ *   <li><b>annotationOnlyArtifacts</b> — artifacts providing source/class-retention annotations</li>
+ *   <li><b>reflectionLoadedClasses</b> — classes loaded via reflection, verified against the JAR</li>
+ * </ul>
+ *
+ * <p>Use {@link #builder()} to configure allowlists:</p>
+ * <pre>{@code
+ * DependencyUsageAnalyzer analyzer = DependencyUsageAnalyzer.builder()
+ *     .runtimeArtifacts(Set.of("org.postgresql:postgresql"))
+ *     .annotationOnlyArtifacts(Set.of("org.projectlombok:lombok"))
+ *     .reflectionLoadedClasses(Map.of(
+ *         "org.postgresql:postgresql", List.of("org.postgresql.Driver")))
+ *     .build();
+ * }</pre>
  */
 public final class DependencyUsageAnalyzer {
 
@@ -48,7 +66,21 @@ public final class DependencyUsageAnalyzer {
 
     public record AnalysisResult(Map<String, UsageStatus> declaredUsage, Map<String, UsageStatus> transitiveUsage) {}
 
-    private DependencyUsageAnalyzer() {}
+    private final Set<String> runtimeArtifacts;
+    private final Set<String> annotationOnlyArtifacts;
+    private final Map<String, List<String>> reflectionLoadedClasses;
+
+    private DependencyUsageAnalyzer(Builder builder) {
+        this.runtimeArtifacts = Set.copyOf(builder.runtimeArtifacts);
+        this.annotationOnlyArtifacts = Set.copyOf(builder.annotationOnlyArtifacts);
+        HashMap<String, List<String>> copy = new HashMap<>();
+        builder.reflectionLoadedClasses.forEach((k, v) -> copy.put(k, List.copyOf(v)));
+        this.reflectionLoadedClasses = Collections.unmodifiableMap(copy);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
 
     /**
      * Build an index mapping fully-qualified class names to their providing artifact's
@@ -92,7 +124,7 @@ public final class DependencyUsageAnalyzer {
      * @param transitive   transitive dependency entries
      * @return analysis result with usage status for each dependency
      */
-    public static AnalysisResult analyze(
+    public AnalysisResult analyze(
             Set<String> mainRefs,
             Set<String> testRefs,
             Map<String, String> classIndex,
@@ -123,7 +155,7 @@ public final class DependencyUsageAnalyzer {
         return new AnalysisResult(declaredUsage, transitiveUsage);
     }
 
-    private static UsageStatus classify(
+    private UsageStatus classify(
             DependenciesTui.DepEntry dep,
             Map<String, Set<String>> gaToClasses,
             Map<String, File> gaToJar,
@@ -155,11 +187,61 @@ public final class DependencyUsageAnalyzer {
             }
         }
 
+        // Allowlist: annotation-only artifacts (source/class-retention annotations)
+        if (matchesArtifactPattern(dep.ga(), annotationOnlyArtifacts)) {
+            return UsageStatus.USED;
+        }
+
+        // Allowlist: runtime-only artifacts (JDBC drivers, SLF4J backends, etc.)
+        if (matchesArtifactPattern(dep.ga(), runtimeArtifacts)) {
+            return UsageStatus.USED;
+        }
+
+        // Allowlist: reflection-loaded classes (verified against the artifact's class index)
+        if (depClasses != null) {
+            List<String> expectedClasses = reflectionLoadedClasses.get(dep.ga());
+            if (expectedClasses != null) {
+                for (String cls : expectedClasses) {
+                    if (depClasses.contains(cls)) {
+                        return UsageStatus.USED;
+                    }
+                }
+            }
+        }
+
         if (depClasses == null) {
             return UsageStatus.UNDETERMINED;
         }
 
         return UsageStatus.UNUSED;
+    }
+
+    /**
+     * Check whether a dependency's GA coordinates match any pattern in the given set.
+     * Supports exact matches ({@code groupId:artifactId}) and wildcard matches ({@code groupId:*}).
+     * For dependencies with a classifier ({@code groupId:artifactId:classifier}), the pattern
+     * is also matched against the base {@code groupId:artifactId}.
+     */
+    static boolean matchesArtifactPattern(String ga, Set<String> patterns) {
+        if (patterns.isEmpty()) {
+            return false;
+        }
+        if (patterns.contains(ga)) {
+            return true;
+        }
+        int firstColon = ga.indexOf(':');
+        if (firstColon > 0) {
+            // Check wildcard: groupId:*
+            if (patterns.contains(ga.substring(0, firstColon) + ":*")) {
+                return true;
+            }
+            // For classifier deps (g:a:c), also try matching g:a
+            int secondColon = ga.indexOf(':', firstColon + 1);
+            if (secondColon > 0) {
+                return patterns.contains(ga.substring(0, secondColon));
+            }
+        }
+        return false;
     }
 
     /**
@@ -205,6 +287,48 @@ public final class DependencyUsageAnalyzer {
             if (!entry.contains("/") && !entry.isEmpty()) {
                 classes.add(entry);
             }
+        }
+    }
+
+    public static final class Builder {
+        private Set<String> runtimeArtifacts = Set.of();
+        private Set<String> annotationOnlyArtifacts = Set.of();
+        private Map<String, List<String>> reflectionLoadedClasses = Map.of();
+
+        private Builder() {}
+
+        /**
+         * Artifacts that are needed only at runtime and never referenced in bytecode
+         * (JDBC drivers, SLF4J backends, XML parser implementations, JVM agents).
+         * Patterns: {@code groupId:artifactId} or {@code groupId:*}.
+         */
+        public Builder runtimeArtifacts(Set<String> patterns) {
+            this.runtimeArtifacts = patterns;
+            return this;
+        }
+
+        /**
+         * Artifacts that provide only source- or class-retention annotations which are
+         * erased during compilation (Lombok, SpotBugs annotations, ErrorProne).
+         * Patterns: {@code groupId:artifactId} or {@code groupId:*}.
+         */
+        public Builder annotationOnlyArtifacts(Set<String> patterns) {
+            this.annotationOnlyArtifacts = patterns;
+            return this;
+        }
+
+        /**
+         * Classes known to be loaded via reflection, mapped by their providing artifact.
+         * During classification the artifact's class index is checked to verify the class
+         * is actually present, so the allowlist stays valid even if a class moves.
+         */
+        public Builder reflectionLoadedClasses(Map<String, List<String>> classes) {
+            this.reflectionLoadedClasses = classes;
+            return this;
+        }
+
+        public DependencyUsageAnalyzer build() {
+            return new DependencyUsageAnalyzer(this);
         }
     }
 }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -149,13 +149,15 @@ public class PilotEngine {
                     ? ClassFileScanner.scanDirectory(testClassesDir)
                     : new ClassFileScanner.ScanResult(Set.of(), Map.of());
             Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
-            DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.analyze(
-                    mainScan.referencedClasses(),
-                    testScan.referencedClasses(),
-                    classIndex,
-                    gaToJar,
-                    declared,
-                    transitive);
+            DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.builder()
+                    .build()
+                    .analyze(
+                            mainScan.referencedClasses(),
+                            testScan.referencedClasses(),
+                            classIndex,
+                            gaToJar,
+                            declared,
+                            transitive);
             for (var dep : declared) {
                 dep.usageStatus =
                         usage.declaredUsage().getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
@@ -237,8 +239,15 @@ public class PilotEngine {
                 ? ClassFileScanner.scanDirectory(p.testOutputDirectory)
                 : new ClassFileScanner.ScanResult(Set.of(), Map.of());
         Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
-        DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.analyze(
-                mainScan.referencedClasses(), testScan.referencedClasses(), classIndex, gaToJar, declared, transitive);
+        DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(
+                        mainScan.referencedClasses(),
+                        testScan.referencedClasses(),
+                        classIndex,
+                        gaToJar,
+                        declared,
+                        transitive);
         populateDepDetails(declared, transitive, classIndex, gaToJar, mainScan, testScan);
 
         accumulateEntries(

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/DependencyUsageAnalyzerTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/DependencyUsageAnalyzerTest.java
@@ -53,8 +53,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, String> classIndex = Map.of("com.example.Foo", "com.example:used-lib");
         Map<String, File> gaToJar = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.example.Foo"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.example.Foo"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:used-lib", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -67,8 +68,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, String> classIndex = Map.of("com.example.Bar", "com.example:unused-lib");
         Map<String, File> gaToJar = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.other.Unrelated"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.other.Unrelated"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:unused-lib", DependencyUsageAnalyzer.UsageStatus.UNUSED);
@@ -82,8 +84,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, String> classIndex = Map.of("com.transitive.Helper", "com.transitive:lib");
         Map<String, File> gaToJar = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.transitive.Helper"), Set.of(), classIndex, gaToJar, List.of(), List.of(dep));
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.transitive.Helper"), Set.of(), classIndex, gaToJar, List.of(), List.of(dep));
 
         assertThat(result.transitiveUsage())
                 .containsEntry("com.transitive:lib", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -97,8 +100,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of();
 
         // Not in main refs but in test refs — should be USED
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of(), Set.of("org.junit.Test"), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of(), Set.of("org.junit.Test"), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("org.junit:junit-api", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -112,8 +116,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of();
 
         // Maven 4 "test-only" scope: should be checked against allRefs (main + test)
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of(), Set.of("org.junit.Test"), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of(), Set.of("org.junit.Test"), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("org.junit:junit-api", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -127,8 +132,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of();
 
         // Maven 4 "test-runtime" scope: should be checked against allRefs (main + test)
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of(), Set.of("org.example.TestUtil"), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of(), Set.of("org.example.TestUtil"), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("org.example:test-util", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -142,8 +148,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of();
 
         // Only in test refs, not main refs — compile-scoped dep should be UNUSED
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of(), Set.of("com.example.Foo"), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of(), Set.of("com.example.Foo"), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage()).containsEntry("com.example:lib", DependencyUsageAnalyzer.UsageStatus.UNUSED);
     }
@@ -156,8 +163,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, String> classIndex = Map.of();
         Map<String, File> gaToJar = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.example.Foo"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.example.Foo"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.mystery:lib", DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
@@ -193,8 +201,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:service-lib", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.example.SomeService"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.example.SomeService"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:service-lib", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -209,7 +218,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:processor", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:processor", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -224,7 +235,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("org.projectlombok:lombok", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("org.projectlombok:lombok", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -240,8 +253,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:lib", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.example.SomeService"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.example.SomeService"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:lib", DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
@@ -256,8 +270,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:sisu-lib", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("javax.inject.Named"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("javax.inject.Named"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:sisu-lib", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -272,13 +287,15 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:spring-lib", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("org.springframework.stereotype.Component"),
-                Set.of(),
-                classIndex,
-                gaToJar,
-                List.of(dep),
-                List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(
+                        Set.of("org.springframework.stereotype.Component"),
+                        Set.of(),
+                        classIndex,
+                        gaToJar,
+                        List.of(dep),
+                        List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:spring-lib", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -293,13 +310,15 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:spring-boot-lib", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("org.springframework.boot.autoconfigure.EnableAutoConfiguration"),
-                Set.of(),
-                classIndex,
-                gaToJar,
-                List.of(dep),
-                List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(
+                        Set.of("org.springframework.boot.autoconfigure.EnableAutoConfiguration"),
+                        Set.of(),
+                        classIndex,
+                        gaToJar,
+                        List.of(dep),
+                        List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:spring-boot-lib", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -314,10 +333,176 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:unused-svc", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.other.Unrelated"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.other.Unrelated"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:unused-svc", DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
+    }
+
+    // --- Allowlist tests ---
+
+    @Test
+    void runtimeArtifactAllowlistMarksAsUsed() {
+        var dep = new DependenciesTui.DepEntry("org.postgresql", "postgresql", "", "42.7", "runtime", true);
+
+        Map<String, String> classIndex = Map.of("org.postgresql.Driver", "org.postgresql:postgresql");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .runtimeArtifacts(Set.of("org.postgresql:postgresql"))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("org.postgresql:postgresql", DependencyUsageAnalyzer.UsageStatus.USED);
+    }
+
+    @Test
+    void runtimeArtifactWildcardMarksAsUsed() {
+        var dep = new DependenciesTui.DepEntry("com.oracle.database.jdbc", "ojdbc11", "", "23.3", "runtime", true);
+
+        Map<String, String> classIndex = Map.of("oracle.jdbc.OracleDriver", "com.oracle.database.jdbc:ojdbc11");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .runtimeArtifacts(Set.of("com.oracle.database.jdbc:*"))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("com.oracle.database.jdbc:ojdbc11", DependencyUsageAnalyzer.UsageStatus.USED);
+    }
+
+    @Test
+    void runtimeArtifactNotInAllowlistRemainsUnused() {
+        var dep = new DependenciesTui.DepEntry("com.example", "not-allowlisted", "", "1.0", "compile", true);
+
+        Map<String, String> classIndex = Map.of("com.example.Foo", "com.example:not-allowlisted");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .runtimeArtifacts(Set.of("org.postgresql:postgresql"))
+                .build()
+                .analyze(Set.of("com.other.Unrelated"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("com.example:not-allowlisted", DependencyUsageAnalyzer.UsageStatus.UNUSED);
+    }
+
+    @Test
+    void annotationOnlyArtifactAllowlistMarksAsUsed() {
+        var dep = new DependenciesTui.DepEntry("org.projectlombok", "lombok", "", "1.18", "provided", true);
+
+        Map<String, String> classIndex = Map.of("lombok.Getter", "org.projectlombok:lombok");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .annotationOnlyArtifacts(Set.of("org.projectlombok:lombok"))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("org.projectlombok:lombok", DependencyUsageAnalyzer.UsageStatus.USED);
+    }
+
+    @Test
+    void annotationOnlyArtifactWorksEvenWithNoClassesInIndex() {
+        var dep = new DependenciesTui.DepEntry("org.projectlombok", "lombok", "", "1.18", "provided", true);
+
+        // No classes from lombok in the index at all
+        Map<String, String> classIndex = Map.of();
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .annotationOnlyArtifacts(Set.of("org.projectlombok:lombok"))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("org.projectlombok:lombok", DependencyUsageAnalyzer.UsageStatus.USED);
+    }
+
+    @Test
+    void reflectionLoadedClassMarksAsUsedWhenClassPresent() {
+        var dep = new DependenciesTui.DepEntry("org.postgresql", "postgresql", "", "42.7", "runtime", true);
+
+        Map<String, String> classIndex = Map.of("org.postgresql.Driver", "org.postgresql:postgresql");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .reflectionLoadedClasses(Map.of("org.postgresql:postgresql", List.of("org.postgresql.Driver")))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("org.postgresql:postgresql", DependencyUsageAnalyzer.UsageStatus.USED);
+    }
+
+    @Test
+    void reflectionLoadedClassRemainsUnusedWhenClassAbsent() {
+        var dep = new DependenciesTui.DepEntry("org.postgresql", "postgresql", "", "42.7", "runtime", true);
+
+        // The JAR provides different classes, not the expected one
+        Map<String, String> classIndex = Map.of("org.postgresql.PGProperty", "org.postgresql:postgresql");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .reflectionLoadedClasses(Map.of("org.postgresql:postgresql", List.of("org.postgresql.Driver")))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("org.postgresql:postgresql", DependencyUsageAnalyzer.UsageStatus.UNUSED);
+    }
+
+    @Test
+    void reflectionLoadedClassUndeterminedWhenNoClassIndex() {
+        var dep = new DependenciesTui.DepEntry("org.postgresql", "postgresql", "", "42.7", "runtime", true);
+
+        // No classes in index at all for this artifact
+        Map<String, String> classIndex = Map.of();
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .reflectionLoadedClasses(Map.of("org.postgresql:postgresql", List.of("org.postgresql.Driver")))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("org.postgresql:postgresql", DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
+    }
+
+    @Test
+    void matchesArtifactPatternExact() {
+        assertThat(DependencyUsageAnalyzer.matchesArtifactPattern(
+                        "org.slf4j:slf4j-simple", Set.of("org.slf4j:slf4j-simple")))
+                .isTrue();
+    }
+
+    @Test
+    void matchesArtifactPatternWildcard() {
+        assertThat(DependencyUsageAnalyzer.matchesArtifactPattern(
+                        "com.oracle.database.jdbc:ojdbc11", Set.of("com.oracle.database.jdbc:*")))
+                .isTrue();
+    }
+
+    @Test
+    void matchesArtifactPatternClassifierFallback() {
+        assertThat(DependencyUsageAnalyzer.matchesArtifactPattern("com.example:lib:tests", Set.of("com.example:lib")))
+                .isTrue();
+    }
+
+    @Test
+    void matchesArtifactPatternNoMatch() {
+        assertThat(DependencyUsageAnalyzer.matchesArtifactPattern("com.example:other", Set.of("com.example:lib")))
+                .isFalse();
+    }
+
+    @Test
+    void matchesArtifactPatternEmptySet() {
+        assertThat(DependencyUsageAnalyzer.matchesArtifactPattern("com.example:lib", Set.of()))
+                .isFalse();
     }
 }

--- a/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/AnalyzeDependenciesMojo.java
+++ b/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/AnalyzeDependenciesMojo.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot.mvn3;
+
+import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.maven.Coordinates;
+import eu.maveniverse.domtrip.maven.PomEditor;
+import eu.maveniverse.maven.pilot.ClassFileScanner;
+import eu.maveniverse.maven.pilot.DependenciesTui;
+import eu.maveniverse.maven.pilot.DependencyTreeModel;
+import eu.maveniverse.maven.pilot.DependencyUsageAnalyzer;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.resolution.ArtifactResult;
+import org.eclipse.aether.resolution.DependencyRequest;
+import org.eclipse.aether.resolution.DependencyResult;
+
+/**
+ * Analyzes declared dependencies for usage and reports or removes unused ones.
+ *
+ * <p>Requires prior compilation ({@code target/classes} must exist). Two actions:</p>
+ * <ul>
+ *   <li><b>check</b> (default) — reports unused declared dependencies and fails the build</li>
+ *   <li><b>fix</b> — removes unused declared dependencies from the POM</li>
+ * </ul>
+ *
+ * <p>Usage:</p>
+ * <pre>
+ * mvn compile pilot:analyze-dependencies
+ * mvn compile pilot:analyze-dependencies -Dpilot.action=fix
+ * </pre>
+ *
+ * <p>Allowlists can be configured to prevent false positives:</p>
+ * <pre>{@code
+ * <plugin>
+ *   <groupId>eu.maveniverse.maven</groupId>
+ *   <artifactId>pilot-plugin</artifactId>
+ *   <configuration>
+ *     <runtimeArtifacts>
+ *       <runtimeArtifact>org.postgresql:postgresql</runtimeArtifact>
+ *       <runtimeArtifact>com.oracle.database.jdbc:*</runtimeArtifact>
+ *     </runtimeArtifacts>
+ *     <annotationOnlyArtifacts>
+ *       <annotationOnlyArtifact>org.projectlombok:lombok</annotationOnlyArtifact>
+ *     </annotationOnlyArtifacts>
+ *   </configuration>
+ * </plugin>
+ * }</pre>
+ *
+ * @since 0.2.3
+ */
+@Mojo(name = "analyze-dependencies", requiresProject = true, aggregator = true, threadSafe = true)
+public class AnalyzeDependenciesMojo extends AbstractMojo {
+
+    @Parameter(defaultValue = "${project}", readonly = true, required = true)
+    private MavenProject project;
+
+    @Parameter(defaultValue = "${session}", readonly = true, required = true)
+    private MavenSession session;
+
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
+    private RepositorySystemSession repoSession;
+
+    @Parameter(property = "pilot.action", defaultValue = "check")
+    private String action;
+
+    @Parameter
+    private List<String> runtimeArtifacts;
+
+    @Parameter
+    private List<String> annotationOnlyArtifacts;
+
+    @Parameter
+    private Map<String, String> reflectionLoadedClasses;
+
+    private final RepositorySystem repoSystem;
+
+    @Inject
+    AnalyzeDependenciesMojo(RepositorySystem repoSystem) {
+        this.repoSystem = repoSystem;
+    }
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+        if (!"check".equals(action) && !"fix".equals(action)) {
+            throw new MojoExecutionException("Invalid action '" + action + "'. Use 'check' or 'fix'.");
+        }
+        try {
+            executeForProject(project);
+        } catch (MojoFailureException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new MojoExecutionException("Failed to analyze dependencies: " + e.getMessage(), e);
+        }
+    }
+
+    private void executeForProject(MavenProject proj) throws Exception {
+        // Collect declared dependencies
+        Set<String> declaredGAs = new HashSet<>();
+        List<DependenciesTui.DepEntry> declared = new ArrayList<>();
+        for (Dependency dep : proj.getDependencies()) {
+            DependenciesTui.addDeclaredEntry(
+                    declaredGAs,
+                    declared,
+                    dep.getGroupId(),
+                    dep.getArtifactId(),
+                    dep.getClassifier(),
+                    dep.getVersion(),
+                    dep.getScope());
+        }
+
+        // Resolve transitive tree
+        DependencyRequest depRequest = new DependencyRequest(MojoHelper.buildCollectRequest(proj), null);
+        DependencyResult depResult = repoSystem.resolveDependencies(repoSession, depRequest);
+
+        DependencyTreeModel depTree = MojoHelper.fromDependencyNode(depResult.getRoot());
+        Set<String> transitiveGAs = new HashSet<>();
+        List<DependenciesTui.DepEntry> transitive = new ArrayList<>();
+        DependenciesTui.collectTransitive(depTree.root, declaredGAs, transitiveGAs, transitive);
+
+        // Build GA-to-JAR map
+        Map<String, File> gaToJar = new HashMap<>();
+        for (ArtifactResult ar : depResult.getArtifactResults()) {
+            var art = ar.getArtifact();
+            if (art != null && art.getFile() != null && art.getFile().getName().endsWith(".jar")) {
+                gaToJar.put(art.getGroupId() + ":" + art.getArtifactId(), art.getFile());
+            }
+        }
+
+        // Bytecode analysis
+        Path classesDir = Path.of(proj.getBuild().getOutputDirectory());
+        if (!Files.isDirectory(classesDir)) {
+            throw new MojoExecutionException(
+                    "target/classes not found — run 'mvn compile' before analyze-dependencies.");
+        }
+
+        Path testClassesDir = Path.of(proj.getBuild().getTestOutputDirectory());
+        ClassFileScanner.ScanResult mainScan = ClassFileScanner.scanDirectory(classesDir);
+        ClassFileScanner.ScanResult testScan = Files.isDirectory(testClassesDir)
+                ? ClassFileScanner.scanDirectory(testClassesDir)
+                : new ClassFileScanner.ScanResult(Set.of(), Map.of());
+
+        Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
+
+        DependencyUsageAnalyzer analyzer = buildAnalyzer();
+        DependencyUsageAnalyzer.AnalysisResult usage = analyzer.analyze(
+                mainScan.referencedClasses(), testScan.referencedClasses(), classIndex, gaToJar, declared, transitive);
+
+        // Find unused declared dependencies
+        List<DependenciesTui.DepEntry> unused = new ArrayList<>();
+        for (var dep : declared) {
+            DependencyUsageAnalyzer.UsageStatus status =
+                    usage.declaredUsage().getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
+            if (status == DependencyUsageAnalyzer.UsageStatus.UNUSED) {
+                unused.add(dep);
+            }
+        }
+
+        if (unused.isEmpty()) {
+            getLog().info("No unused declared dependencies found.");
+            return;
+        }
+
+        if ("fix".equals(action)) {
+            fix(proj, unused);
+        } else {
+            check(unused);
+        }
+    }
+
+    private DependencyUsageAnalyzer buildAnalyzer() {
+        DependencyUsageAnalyzer.Builder builder = DependencyUsageAnalyzer.builder();
+        if (runtimeArtifacts != null && !runtimeArtifacts.isEmpty()) {
+            builder.runtimeArtifacts(new HashSet<>(runtimeArtifacts));
+        }
+        if (annotationOnlyArtifacts != null && !annotationOnlyArtifacts.isEmpty()) {
+            builder.annotationOnlyArtifacts(new HashSet<>(annotationOnlyArtifacts));
+        }
+        if (reflectionLoadedClasses != null && !reflectionLoadedClasses.isEmpty()) {
+            Map<String, List<String>> parsed = new HashMap<>();
+            for (var entry : reflectionLoadedClasses.entrySet()) {
+                parsed.put(entry.getKey(), List.of(entry.getValue().split(",")));
+            }
+            builder.reflectionLoadedClasses(parsed);
+        }
+        return builder.build();
+    }
+
+    private void check(List<DependenciesTui.DepEntry> unused) throws MojoFailureException {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Found ").append(unused.size()).append(" unused declared dependenc");
+        sb.append(unused.size() == 1 ? "y" : "ies").append(":\n");
+        for (var dep : unused) {
+            sb.append("  - ").append(dep.ga());
+            if (dep.scope != null && !dep.scope.isEmpty() && !"compile".equals(dep.scope)) {
+                sb.append(" (").append(dep.scope).append(")");
+            }
+            sb.append("\n");
+        }
+        sb.append("\nRun with -Dpilot.action=fix to remove them, or configure allowlists for false positives.");
+        throw new MojoFailureException(sb.toString());
+    }
+
+    private void fix(MavenProject proj, List<DependenciesTui.DepEntry> unused) throws Exception {
+        Path pomPath = proj.getFile().toPath();
+        String pomContent = Files.readString(pomPath);
+        PomEditor editor = new PomEditor(Document.of(pomContent));
+
+        for (var dep : unused) {
+            String[] parts = dep.ga().split(":");
+            Coordinates coords = parts.length > 2
+                    ? Coordinates.of(parts[0], parts[1], null, parts[2], "jar")
+                    : Coordinates.of(parts[0], parts[1], null);
+            editor.dependencies().deleteDependency(coords);
+            getLog().info("Removed unused dependency: " + dep.ga());
+        }
+
+        Files.writeString(pomPath, editor.toXml());
+        getLog().info("Updated " + pomPath);
+    }
+}

--- a/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/DependenciesMojo.java
+++ b/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/DependenciesMojo.java
@@ -138,13 +138,15 @@ public class DependenciesMojo extends AbstractMojo {
                     : new ClassFileScanner.ScanResult(Set.of(), Map.of());
 
             Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
-            DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.analyze(
-                    mainScan.referencedClasses(),
-                    testScan.referencedClasses(),
-                    classIndex,
-                    gaToJar,
-                    declared,
-                    transitive);
+            DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.builder()
+                    .build()
+                    .analyze(
+                            mainScan.referencedClasses(),
+                            testScan.referencedClasses(),
+                            classIndex,
+                            gaToJar,
+                            declared,
+                            transitive);
 
             // Build reverse index: GA -> set of class names provided
             Map<String, Set<String>> gaToClasses = new HashMap<>();


### PR DESCRIPTION
## Summary

- **Configurable allowlists for `DependencyUsageAnalyzer`** — three allowlist types to reduce false-positive UNUSED classifications:
  - `runtimeArtifacts` — runtime-only deps (JDBC drivers, SLF4J backends, JVM agents) via exact or `groupId:*` wildcard patterns
  - `annotationOnlyArtifacts` — source/class-retention annotation providers (Lombok, SpotBugs, ErrorProne)
  - `reflectionLoadedClasses` — reflection-loaded classes, verified against the JAR's class index to stay valid when classes move between artifacts
- **New `pilot:analyze-dependencies` goal** with a `pilot.action` property:
  - `check` (default) — reports unused declared dependencies and fails the build (CI-friendly)
  - `fix` — removes unused declared dependencies from the POM using DomTrip
  - Allowlists configurable via `<configuration>` block in the plugin

## Test plan

- [x] 30 unit tests pass (17 existing + 13 new allowlist tests)
- [ ] Manual test: `mvn compile pilot:analyze-dependencies` on a project with unused deps
- [ ] Manual test: `mvn compile pilot:analyze-dependencies -Dpilot.action=fix` removes unused deps from POM
- [ ] Manual test: allowlists configured in plugin `<configuration>` prevent false positives
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `pilot:analyze-dependencies` Maven goal to detect unused dependencies and optionally remove them from the POM.
  * Configurable allowlists to mark dependencies as used (runtime artifacts, annotation-only libraries, reflection-loaded classes).
  * Check mode (fails build with report) and fix mode (auto-removes unused dependencies).

* **Refactor**
  * Improved dependency analyzer API with flexible configuration patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->