### PR TITLE
feat: configurable allowlists for DependencyUsageAnalyzer

### DIFF
--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependencyUsageAnalyzer.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependencyUsageAnalyzer.java
@@ -33,6 +33,24 @@ import java.util.jar.JarFile;
 /**
  * Builds a class-to-artifact index from resolved JARs and classifies dependency usage
  * based on bytecode analysis results.
+ *
+ * <p>The analyzer supports three optional allowlists that override the default classification
+ * for dependencies that are legitimately used but cannot be detected through bytecode analysis:</p>
+ * <ul>
+ *   <li><b>runtimeArtifacts</b> — artifacts needed only at runtime (JDBC drivers, SLF4J backends)</li>
+ *   <li><b>annotationOnlyArtifacts</b> — artifacts providing source/class-retention annotations</li>
+ *   <li><b>reflectionLoadedClasses</b> — classes loaded via reflection, verified against the JAR</li>
+ * </ul>
+ *
+ * <p>Use {@link #builder()} to configure allowlists:</p>
+ * <pre>{@code
+ * DependencyUsageAnalyzer analyzer = DependencyUsageAnalyzer.builder()
+ *     .runtimeArtifacts(Set.of("org.postgresql:postgresql"))
+ *     .annotationOnlyArtifacts(Set.of("org.projectlombok:lombok"))
+ *     .reflectionLoadedClasses(Map.of(
+ *         "org.postgresql:postgresql", List.of("org.postgresql.Driver")))
+ *     .build();
+ * }</pre>
  */
 public final class DependencyUsageAnalyzer {
 
@@ -48,7 +66,21 @@ public final class DependencyUsageAnalyzer {
 
     public record AnalysisResult(Map<String, UsageStatus> declaredUsage, Map<String, UsageStatus> transitiveUsage) {}
 
-    private DependencyUsageAnalyzer() {}
+    private final Set<String> runtimeArtifacts;
+    private final Set<String> annotationOnlyArtifacts;
+    private final Map<String, List<String>> reflectionLoadedClasses;
+
+    private DependencyUsageAnalyzer(Builder builder) {
+        this.runtimeArtifacts = Set.copyOf(builder.runtimeArtifacts);
+        this.annotationOnlyArtifacts = Set.copyOf(builder.annotationOnlyArtifacts);
+        HashMap<String, List<String>> copy = new HashMap<>();
+        builder.reflectionLoadedClasses.forEach((k, v) -> copy.put(k, List.copyOf(v)));
+        this.reflectionLoadedClasses = Collections.unmodifiableMap(copy);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
 
     /**
      * Build an index mapping fully-qualified class names to their providing artifact's
@@ -92,7 +124,7 @@ public final class DependencyUsageAnalyzer {
      * @param transitive   transitive dependency entries
      * @return analysis result with usage status for each dependency
      */
-    public static AnalysisResult analyze(
+    public AnalysisResult analyze(
             Set<String> mainRefs,
             Set<String> testRefs,
             Map<String, String> classIndex,
@@ -123,7 +155,7 @@ public final class DependencyUsageAnalyzer {
         return new AnalysisResult(declaredUsage, transitiveUsage);
     }
 
-    private static UsageStatus classify(
+    private UsageStatus classify(
             DependenciesTui.DepEntry dep,
             Map<String, Set<String>> gaToClasses,
             Map<String, File> gaToJar,
@@ -141,25 +173,77 @@ public final class DependencyUsageAnalyzer {
             return UsageStatus.USED;
         }
 
+        if (isUsedByRuntimeDiscovery(dep, gaToJar, refs)) {
+            return UsageStatus.USED;
+        }
+
+        if (matchesArtifactPattern(dep.ga(), annotationOnlyArtifacts)
+                || matchesArtifactPattern(dep.ga(), runtimeArtifacts)
+                || matchesReflectionLoadedClasses(dep.ga(), depClasses)) {
+            return UsageStatus.USED;
+        }
+
+        return depClasses == null ? UsageStatus.UNDETERMINED : UsageStatus.UNUSED;
+    }
+
+    private static boolean isUsedByRuntimeDiscovery(
+            DependenciesTui.DepEntry dep, Map<String, File> gaToJar, Set<String> refs) {
         File jarFile = gaToJar.get(dep.ga());
-        if (jarFile != null) {
-            Set<String> discoveryClasses = getRuntimeDiscoveryClasses(jarFile);
-            if (!Collections.disjoint(discoveryClasses, refs)) {
-                return UsageStatus.USED;
-            }
-            // Annotation processors are used at compile time without direct bytecode references.
-            // They can be declared with "provided" or "compile" scope (e.g. Lombok).
-            if (("provided".equals(dep.scope) || "compile".equals(dep.scope))
-                    && discoveryClasses.contains("javax.annotation.processing.Processor")) {
-                return UsageStatus.USED;
-            }
+        if (jarFile == null) {
+            return false;
         }
+        Set<String> discoveryClasses = getRuntimeDiscoveryClasses(jarFile);
+        if (!Collections.disjoint(discoveryClasses, refs)) {
+            return true;
+        }
+        // Annotation processors are used at compile time without direct bytecode references.
+        // They can be declared with "provided" or "compile" scope (e.g. Lombok).
+        return ("provided".equals(dep.scope) || "compile".equals(dep.scope))
+                && discoveryClasses.contains("javax.annotation.processing.Processor");
+    }
 
+    private boolean matchesReflectionLoadedClasses(String ga, Set<String> depClasses) {
         if (depClasses == null) {
-            return UsageStatus.UNDETERMINED;
+            return false;
         }
+        List<String> expectedClasses = reflectionLoadedClasses.get(ga);
+        if (expectedClasses == null) {
+            return false;
+        }
+        for (String cls : expectedClasses) {
+            if (depClasses.contains(cls)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-        return UsageStatus.UNUSED;
+    /**
+     * Check whether a dependency's GA coordinates match any pattern in the given set.
+     * Supports exact matches ({@code groupId:artifactId}) and wildcard matches ({@code groupId:*}).
+     * For dependencies with a classifier ({@code groupId:artifactId:classifier}), the pattern
+     * is also matched against the base {@code groupId:artifactId}.
+     */
+    static boolean matchesArtifactPattern(String ga, Set<String> patterns) {
+        if (patterns.isEmpty()) {
+            return false;
+        }
+        if (patterns.contains(ga)) {
+            return true;
+        }
+        int firstColon = ga.indexOf(':');
+        if (firstColon > 0) {
+            // Check wildcard: groupId:*
+            if (patterns.contains(ga.substring(0, firstColon) + ":*")) {
+                return true;
+            }
+            // For classifier deps (g:a:c), also try matching g:a
+            int secondColon = ga.indexOf(':', firstColon + 1);
+            if (secondColon > 0) {
+                return patterns.contains(ga.substring(0, secondColon));
+            }
+        }
+        return false;
     }
 
     /**
@@ -205,6 +289,50 @@ public final class DependencyUsageAnalyzer {
             if (!entry.contains("/") && !entry.isEmpty()) {
                 classes.add(entry);
             }
+        }
+    }
+
+    public static final class Builder {
+        private Set<String> runtimeArtifacts = Set.of();
+        private Set<String> annotationOnlyArtifacts = Set.of();
+        private Map<String, List<String>> reflectionLoadedClasses = Map.of();
+
+        private Builder() {}
+
+        /**
+         * Artifacts that are needed only at runtime and never referenced in bytecode
+         * (JDBC drivers, SLF4J backends, XML parser implementations, JVM agents).
+         * Patterns: {@code groupId:artifactId} or {@code groupId:*}.
+         */
+        public Builder runtimeArtifacts(Set<String> patterns) {
+            this.runtimeArtifacts = patterns;
+            return this;
+        }
+
+        /**
+         * Artifacts that provide only source- or class-retention annotations which are
+         * erased during compilation (Lombok, SpotBugs annotations, ErrorProne).
+         * Patterns: {@code groupId:artifactId} or {@code groupId:*}.
+         */
+        public Builder annotationOnlyArtifacts(Set<String> patterns) {
+            this.annotationOnlyArtifacts = patterns;
+            return this;
+        }
+
+        /**
+         * Classes known to be loaded via reflection, mapped by their providing artifact.
+         * Keys must be exact {@code groupId:artifactId} coordinates; wildcard patterns
+         * like {@code groupId:*} are not supported. During classification the artifact's
+         * class index is checked to verify the class is actually present, so the allowlist
+         * stays valid even if a class moves.
+         */
+        public Builder reflectionLoadedClasses(Map<String, List<String>> classes) {
+            this.reflectionLoadedClasses = classes;
+            return this;
+        }
+
+        public DependencyUsageAnalyzer build() {
+            return new DependencyUsageAnalyzer(this);
         }
     }
 }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotEngine.java
@@ -149,13 +149,15 @@ public class PilotEngine {
                     ? ClassFileScanner.scanDirectory(testClassesDir)
                     : new ClassFileScanner.ScanResult(Set.of(), Map.of());
             Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
-            DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.analyze(
-                    mainScan.referencedClasses(),
-                    testScan.referencedClasses(),
-                    classIndex,
-                    gaToJar,
-                    declared,
-                    transitive);
+            DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.builder()
+                    .build()
+                    .analyze(
+                            mainScan.referencedClasses(),
+                            testScan.referencedClasses(),
+                            classIndex,
+                            gaToJar,
+                            declared,
+                            transitive);
             for (var dep : declared) {
                 dep.usageStatus =
                         usage.declaredUsage().getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
@@ -237,8 +239,15 @@ public class PilotEngine {
                 ? ClassFileScanner.scanDirectory(p.testOutputDirectory)
                 : new ClassFileScanner.ScanResult(Set.of(), Map.of());
         Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
-        DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.analyze(
-                mainScan.referencedClasses(), testScan.referencedClasses(), classIndex, gaToJar, declared, transitive);
+        DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(
+                        mainScan.referencedClasses(),
+                        testScan.referencedClasses(),
+                        classIndex,
+                        gaToJar,
+                        declared,
+                        transitive);
         populateDepDetails(declared, transitive, classIndex, gaToJar, mainScan, testScan);
 
         accumulateEntries(

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/DependencyUsageAnalyzerTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/DependencyUsageAnalyzerTest.java
@@ -53,8 +53,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, String> classIndex = Map.of("com.example.Foo", "com.example:used-lib");
         Map<String, File> gaToJar = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.example.Foo"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.example.Foo"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:used-lib", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -67,8 +68,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, String> classIndex = Map.of("com.example.Bar", "com.example:unused-lib");
         Map<String, File> gaToJar = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.other.Unrelated"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.other.Unrelated"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:unused-lib", DependencyUsageAnalyzer.UsageStatus.UNUSED);
@@ -82,8 +84,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, String> classIndex = Map.of("com.transitive.Helper", "com.transitive:lib");
         Map<String, File> gaToJar = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.transitive.Helper"), Set.of(), classIndex, gaToJar, List.of(), List.of(dep));
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.transitive.Helper"), Set.of(), classIndex, gaToJar, List.of(), List.of(dep));
 
         assertThat(result.transitiveUsage())
                 .containsEntry("com.transitive:lib", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -97,8 +100,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of();
 
         // Not in main refs but in test refs — should be USED
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of(), Set.of("org.junit.Test"), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of(), Set.of("org.junit.Test"), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("org.junit:junit-api", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -112,8 +116,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of();
 
         // Maven 4 "test-only" scope: should be checked against allRefs (main + test)
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of(), Set.of("org.junit.Test"), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of(), Set.of("org.junit.Test"), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("org.junit:junit-api", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -127,8 +132,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of();
 
         // Maven 4 "test-runtime" scope: should be checked against allRefs (main + test)
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of(), Set.of("org.example.TestUtil"), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of(), Set.of("org.example.TestUtil"), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("org.example:test-util", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -142,8 +148,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of();
 
         // Only in test refs, not main refs — compile-scoped dep should be UNUSED
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of(), Set.of("com.example.Foo"), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of(), Set.of("com.example.Foo"), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage()).containsEntry("com.example:lib", DependencyUsageAnalyzer.UsageStatus.UNUSED);
     }
@@ -156,8 +163,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, String> classIndex = Map.of();
         Map<String, File> gaToJar = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.example.Foo"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.example.Foo"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.mystery:lib", DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
@@ -193,8 +201,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:service-lib", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.example.SomeService"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.example.SomeService"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:service-lib", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -209,7 +218,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:processor", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:processor", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -224,7 +235,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("org.projectlombok:lombok", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("org.projectlombok:lombok", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -240,8 +253,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:lib", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.example.SomeService"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.example.SomeService"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:lib", DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
@@ -256,8 +270,9 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:sisu-lib", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("javax.inject.Named"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("javax.inject.Named"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:sisu-lib", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -272,13 +287,15 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:spring-lib", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("org.springframework.stereotype.Component"),
-                Set.of(),
-                classIndex,
-                gaToJar,
-                List.of(dep),
-                List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(
+                        Set.of("org.springframework.stereotype.Component"),
+                        Set.of(),
+                        classIndex,
+                        gaToJar,
+                        List.of(dep),
+                        List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:spring-lib", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -293,13 +310,15 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:spring-boot-lib", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("org.springframework.boot.autoconfigure.EnableAutoConfiguration"),
-                Set.of(),
-                classIndex,
-                gaToJar,
-                List.of(dep),
-                List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(
+                        Set.of("org.springframework.boot.autoconfigure.EnableAutoConfiguration"),
+                        Set.of(),
+                        classIndex,
+                        gaToJar,
+                        List.of(dep),
+                        List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:spring-boot-lib", DependencyUsageAnalyzer.UsageStatus.USED);
@@ -314,10 +333,192 @@ class DependencyUsageAnalyzerTest {
         Map<String, File> gaToJar = Map.of("com.example:unused-svc", tempJar.toFile());
         Map<String, String> classIndex = Map.of();
 
-        var result = DependencyUsageAnalyzer.analyze(
-                Set.of("com.other.Unrelated"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.other.Unrelated"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
 
         assertThat(result.declaredUsage())
                 .containsEntry("com.example:unused-svc", DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
+    }
+
+    // --- Allowlist tests ---
+
+    @Test
+    void runtimeArtifactAllowlistMarksAsUsed() {
+        var dep = new DependenciesTui.DepEntry("org.postgresql", "postgresql", "", "42.7", "runtime", true);
+
+        Map<String, String> classIndex = Map.of("org.postgresql.Driver", "org.postgresql:postgresql");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .runtimeArtifacts(Set.of("org.postgresql:postgresql"))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("org.postgresql:postgresql", DependencyUsageAnalyzer.UsageStatus.USED);
+    }
+
+    @Test
+    void runtimeArtifactWildcardMarksAsUsed() {
+        var dep = new DependenciesTui.DepEntry("com.oracle.database.jdbc", "ojdbc11", "", "23.3", "runtime", true);
+
+        Map<String, String> classIndex = Map.of("oracle.jdbc.OracleDriver", "com.oracle.database.jdbc:ojdbc11");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .runtimeArtifacts(Set.of("com.oracle.database.jdbc:*"))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("com.oracle.database.jdbc:ojdbc11", DependencyUsageAnalyzer.UsageStatus.USED);
+    }
+
+    @Test
+    void runtimeArtifactWorksEvenWithNoClassesInIndex() {
+        var dep = new DependenciesTui.DepEntry("org.postgresql", "postgresql", "", "42.7", "runtime", true);
+
+        Map<String, String> classIndex = Map.of();
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .runtimeArtifacts(Set.of("org.postgresql:postgresql"))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("org.postgresql:postgresql", DependencyUsageAnalyzer.UsageStatus.USED);
+    }
+
+    @Test
+    void runtimeArtifactNotInAllowlistRemainsUnused() {
+        var dep = new DependenciesTui.DepEntry("com.example", "not-allowlisted", "", "1.0", "compile", true);
+
+        Map<String, String> classIndex = Map.of("com.example.Foo", "com.example:not-allowlisted");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .runtimeArtifacts(Set.of("org.postgresql:postgresql"))
+                .build()
+                .analyze(Set.of("com.other.Unrelated"), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("com.example:not-allowlisted", DependencyUsageAnalyzer.UsageStatus.UNUSED);
+    }
+
+    @Test
+    void annotationOnlyArtifactAllowlistMarksAsUsed() {
+        var dep = new DependenciesTui.DepEntry("org.projectlombok", "lombok", "", "1.18", "provided", true);
+
+        Map<String, String> classIndex = Map.of("lombok.Getter", "org.projectlombok:lombok");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .annotationOnlyArtifacts(Set.of("org.projectlombok:lombok"))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("org.projectlombok:lombok", DependencyUsageAnalyzer.UsageStatus.USED);
+    }
+
+    @Test
+    void annotationOnlyArtifactWorksEvenWithNoClassesInIndex() {
+        var dep = new DependenciesTui.DepEntry("org.projectlombok", "lombok", "", "1.18", "provided", true);
+
+        // No classes from lombok in the index at all
+        Map<String, String> classIndex = Map.of();
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .annotationOnlyArtifacts(Set.of("org.projectlombok:lombok"))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("org.projectlombok:lombok", DependencyUsageAnalyzer.UsageStatus.USED);
+    }
+
+    @Test
+    void reflectionLoadedClassMarksAsUsedWhenClassPresent() {
+        var dep = new DependenciesTui.DepEntry("org.postgresql", "postgresql", "", "42.7", "runtime", true);
+
+        Map<String, String> classIndex = Map.of("org.postgresql.Driver", "org.postgresql:postgresql");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .reflectionLoadedClasses(Map.of("org.postgresql:postgresql", List.of("org.postgresql.Driver")))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("org.postgresql:postgresql", DependencyUsageAnalyzer.UsageStatus.USED);
+    }
+
+    @Test
+    void reflectionLoadedClassRemainsUnusedWhenClassAbsent() {
+        var dep = new DependenciesTui.DepEntry("org.postgresql", "postgresql", "", "42.7", "runtime", true);
+
+        // The JAR provides different classes, not the expected one
+        Map<String, String> classIndex = Map.of("org.postgresql.PGProperty", "org.postgresql:postgresql");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .reflectionLoadedClasses(Map.of("org.postgresql:postgresql", List.of("org.postgresql.Driver")))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("org.postgresql:postgresql", DependencyUsageAnalyzer.UsageStatus.UNUSED);
+    }
+
+    @Test
+    void reflectionLoadedClassUndeterminedWhenNoClassIndex() {
+        var dep = new DependenciesTui.DepEntry("org.postgresql", "postgresql", "", "42.7", "runtime", true);
+
+        // No classes in index at all for this artifact
+        Map<String, String> classIndex = Map.of();
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .reflectionLoadedClasses(Map.of("org.postgresql:postgresql", List.of("org.postgresql.Driver")))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(dep), List.of());
+
+        assertThat(result.declaredUsage())
+                .containsEntry("org.postgresql:postgresql", DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
+    }
+
+    @Test
+    void matchesArtifactPatternExact() {
+        assertThat(DependencyUsageAnalyzer.matchesArtifactPattern(
+                        "org.slf4j:slf4j-simple", Set.of("org.slf4j:slf4j-simple")))
+                .isTrue();
+    }
+
+    @Test
+    void matchesArtifactPatternWildcard() {
+        assertThat(DependencyUsageAnalyzer.matchesArtifactPattern(
+                        "com.oracle.database.jdbc:ojdbc11", Set.of("com.oracle.database.jdbc:*")))
+                .isTrue();
+    }
+
+    @Test
+    void matchesArtifactPatternClassifierFallback() {
+        assertThat(DependencyUsageAnalyzer.matchesArtifactPattern("com.example:lib:tests", Set.of("com.example:lib")))
+                .isTrue();
+    }
+
+    @Test
+    void matchesArtifactPatternNoMatch() {
+        assertThat(DependencyUsageAnalyzer.matchesArtifactPattern("com.example:other", Set.of("com.example:lib")))
+                .isFalse();
+    }
+
+    @Test
+    void matchesArtifactPatternEmptySet() {
+        assertThat(DependencyUsageAnalyzer.matchesArtifactPattern("com.example:lib", Set.of()))
+                .isFalse();
     }
 }

--- a/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/DependenciesMojo.java
+++ b/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/DependenciesMojo.java
@@ -138,13 +138,15 @@ public class DependenciesMojo extends AbstractMojo {
                     : new ClassFileScanner.ScanResult(Set.of(), Map.of());
 
             Map<String, String> classIndex = DependencyUsageAnalyzer.buildClassIndex(gaToJar);
-            DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.analyze(
-                    mainScan.referencedClasses(),
-                    testScan.referencedClasses(),
-                    classIndex,
-                    gaToJar,
-                    declared,
-                    transitive);
+            DependencyUsageAnalyzer.AnalysisResult usage = DependencyUsageAnalyzer.builder()
+                    .build()
+                    .analyze(
+                            mainScan.referencedClasses(),
+                            testScan.referencedClasses(),
+                            classIndex,
+                            gaToJar,
+                            declared,
+                            transitive);
 
             // Build reverse index: GA -> set of class names provided
             Map<String, Set<String>> gaToClasses = new HashMap<>();


### PR DESCRIPTION
## Summary

- Convert `DependencyUsageAnalyzer` from static utility to instance-based with a `Builder`
- Add three configurable allowlists to reduce false-positive UNUSED classifications:
  - `runtimeArtifacts` — runtime-only deps (JDBC drivers, SLF4J backends, JVM agents)
  - `annotationOnlyArtifacts` — source/class-retention annotation providers (Lombok, SpotBugs, ErrorProne)
  - `reflectionLoadedClasses` — reflection-loaded classes, verified against the JAR's class index
- Artifact patterns support exact match (`groupId:artifactId`) and wildcard (`groupId:*`)
- 13 new unit tests (30 total), all passing

## Test plan

- [x] All 30 unit tests pass (17 existing + 13 new)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-instance, configurable allowlists for dependency analysis (runtime, annotation-only, reflection) to control used/unused classification.
  * Reflection verification now cross-checks detected classes against artifact indices for more accurate results.

* **Refactor**
  * Analysis is now builder-configurable and invoked on configured analyzer instances for greater flexibility.

* **Tests**
  * Added unit tests for allowlist behavior and artifact-pattern matching (including wildcard and classifier cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->