### PR TITLE
feat: add report action and used-transitive detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Pilot is a Maven plugin (and standalone CLI) that replaces hard-to-read CLI outp
 | `pilot:conflicts` | Detect version conflicts across the dependency tree and pin versions via `dependencyManagement` |
 | `pilot:audit` | License overview and CVE lookup (via OSV.dev) for all transitive dependencies |
 | `pilot:align` | Detect and align dependency conventions (version style, property naming) across POMs |
+| `pilot:analyze-dependencies` | CI-friendly dependency analysis: detect unused declared and used transitive dependencies, with check/report/fix actions |
 
 ## Quick Start
 
@@ -56,6 +57,11 @@ mvn pilot:audit
 
 # Align dependency conventions
 mvn pilot:align
+
+# Analyze dependencies (CI-friendly, non-interactive)
+mvn compile pilot:analyze-dependencies                    # check mode (fails on issues)
+mvn compile pilot:analyze-dependencies -Dpilot.action=report  # report mode (warns only)
+mvn compile pilot:analyze-dependencies -Dpilot.action=fix     # fix mode (edits POM)
 ```
 
 ### Standalone CLI
@@ -157,6 +163,31 @@ Detects the project's current dependency conventions (inline vs managed versions
 ![pilot:align](docs/images/align.svg)
 
 **Keys:** `jk` -- navigate options, `<>/Enter` -- cycle values, `p` -- preview diff, `w` -- apply, `h` -- help
+
+### Dependency Analyzer (`pilot:analyze-dependencies`)
+
+Non-interactive, CI-friendly dependency analysis. Detects two kinds of issues: unused declared dependencies (can be removed) and used transitive dependencies (should be declared explicitly). Three actions via `-Dpilot.action`:
+
+- **`check`** (default) — reports issues and fails the build
+- **`report`** — reports issues without failing
+- **`fix`** — removes unused declared and adds used transitive dependencies to the POM
+
+Supports allowlists (`runtimeArtifacts`, `annotationOnlyArtifacts`, `reflectionLoadedClasses`) for false positives from bytecode analysis, and ignore lists (`ignoredUnusedDeclared`, `ignoredUsedTransitive`) for suppressing known findings. All pattern sets support `groupId:artifactId` exact match and `groupId:*` wildcards.
+
+```xml
+<plugin>
+  <groupId>eu.maveniverse.maven.plugins</groupId>
+  <artifactId>pilot-plugin</artifactId>
+  <configuration>
+    <runtimeArtifacts>
+      <runtimeArtifact>org.postgresql:postgresql</runtimeArtifact>
+    </runtimeArtifacts>
+    <ignoredUsedTransitive>
+      <ignoredUsedTransitive>org.slf4j:slf4j-api</ignoredUsedTransitive>
+    </ignoredUsedTransitive>
+  </configuration>
+</plugin>
+```
 
 ## How POM Editing Works
 

--- a/pilot-core/pom.xml
+++ b/pilot-core/pom.xml
@@ -97,27 +97,4 @@ under the License.
     </dependency>
   </dependencies>
 
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.jacoco</groupId>
-        <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.14</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>prepare-agent</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>report</id>
-            <goals>
-              <goal>report</goal>
-            </goals>
-            <phase>test</phase>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 </project>

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependencyUsageAnalyzer.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependencyUsageAnalyzer.java
@@ -224,7 +224,7 @@ public final class DependencyUsageAnalyzer {
      * For dependencies with a classifier ({@code groupId:artifactId:classifier}), the pattern
      * is also matched against the base {@code groupId:artifactId}.
      */
-    static boolean matchesArtifactPattern(String ga, Set<String> patterns) {
+    public static boolean matchesArtifactPattern(String ga, Set<String> patterns) {
         if (patterns.isEmpty()) {
             return false;
         }

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/DependencyUsageAnalyzerTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/DependencyUsageAnalyzerTest.java
@@ -93,6 +93,37 @@ class DependencyUsageAnalyzerTest {
     }
 
     @Test
+    void unusedTransitiveDependency() {
+        var dep = new DependenciesTui.DepEntry("com.transitive", "lib", "", "1.0", "compile", false);
+
+        Map<String, String> classIndex = Map.of("com.transitive.Helper", "com.transitive:lib");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .build()
+                .analyze(Set.of("com.other.Unrelated"), Set.of(), classIndex, gaToJar, List.of(), List.of(dep));
+
+        assertThat(result.transitiveUsage())
+                .containsEntry("com.transitive:lib", DependencyUsageAnalyzer.UsageStatus.UNUSED);
+    }
+
+    @Test
+    void transitiveRuntimeArtifactAllowlistMarksAsUsed() {
+        var dep = new DependenciesTui.DepEntry("org.postgresql", "postgresql", "", "42.7", "runtime", false);
+
+        Map<String, String> classIndex = Map.of("org.postgresql.Driver", "org.postgresql:postgresql");
+        Map<String, File> gaToJar = Map.of();
+
+        var result = DependencyUsageAnalyzer.builder()
+                .runtimeArtifacts(Set.of("org.postgresql:postgresql"))
+                .build()
+                .analyze(Set.of(), Set.of(), classIndex, gaToJar, List.of(), List.of(dep));
+
+        assertThat(result.transitiveUsage())
+                .containsEntry("org.postgresql:postgresql", DependencyUsageAnalyzer.UsageStatus.USED);
+    }
+
+    @Test
     void testScopedDepCheckedAgainstTestRefs() {
         var dep = new DependenciesTui.DepEntry("org.junit", "junit-api", "", "5.0", "test", true);
 
@@ -502,6 +533,15 @@ class DependencyUsageAnalyzerTest {
         assertThat(DependencyUsageAnalyzer.matchesArtifactPattern(
                         "com.oracle.database.jdbc:ojdbc11", Set.of("com.oracle.database.jdbc:*")))
                 .isTrue();
+    }
+
+    @Test
+    void classifiedDepGaMatchesClassifiedKey() {
+        var dep = new DependenciesTui.DepEntry("com.example", "lib", "tests", "1.0", "test", true);
+        assertThat(dep.ga()).isEqualTo("com.example:lib:tests");
+
+        Map<String, String> gaToVersion = Map.of("com.example:lib:tests", "1.0");
+        assertThat(gaToVersion.get(dep.ga())).isEqualTo("1.0");
     }
 
     @Test

--- a/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/AnalyzeDependenciesMojo.java
+++ b/pilot-plugin/src/main/java/eu/maveniverse/maven/pilot/mvn3/AnalyzeDependenciesMojo.java
@@ -19,6 +19,7 @@
 package eu.maveniverse.maven.pilot.mvn3;
 
 import eu.maveniverse.domtrip.Document;
+import eu.maveniverse.domtrip.maven.AlignOptions;
 import eu.maveniverse.domtrip.maven.Coordinates;
 import eu.maveniverse.domtrip.maven.PomEditor;
 import eu.maveniverse.maven.pilot.ClassFileScanner;
@@ -52,10 +53,17 @@ import org.eclipse.aether.resolution.DependencyResult;
 /**
  * Analyzes declared dependencies for usage and reports or removes unused ones.
  *
- * <p>Requires prior compilation ({@code target/classes} must exist). Two actions:</p>
+ * <p>Requires prior compilation ({@code target/classes} must exist). Three actions:</p>
  * <ul>
- *   <li><b>check</b> (default) — reports unused declared dependencies and fails the build</li>
- *   <li><b>fix</b> — removes unused declared dependencies from the POM</li>
+ *   <li><b>check</b> (default) — reports issues and fails the build</li>
+ *   <li><b>report</b> — reports issues without failing the build</li>
+ *   <li><b>fix</b> — removes unused declared and adds used transitive dependencies</li>
+ * </ul>
+ *
+ * <p>Detects two kinds of dependency issues:</p>
+ * <ul>
+ *   <li>Unused declared dependencies (can be removed)</li>
+ *   <li>Used transitive dependencies (should be declared explicitly)</li>
  * </ul>
  *
  * <p>Usage:</p>
@@ -77,6 +85,12 @@ import org.eclipse.aether.resolution.DependencyResult;
  *     <annotationOnlyArtifacts>
  *       <annotationOnlyArtifact>org.projectlombok:lombok</annotationOnlyArtifact>
  *     </annotationOnlyArtifacts>
+ *     <ignoredUnusedDeclared>
+ *       <ignoredUnusedDeclared>com.example:kept-for-runtime</ignoredUnusedDeclared>
+ *     </ignoredUnusedDeclared>
+ *     <ignoredUsedTransitive>
+ *       <ignoredUsedTransitive>org.slf4j:slf4j-api</ignoredUsedTransitive>
+ *     </ignoredUsedTransitive>
  *   </configuration>
  * </plugin>
  * }</pre>
@@ -107,6 +121,12 @@ public class AnalyzeDependenciesMojo extends AbstractMojo {
     @Parameter
     private Map<String, String> reflectionLoadedClasses;
 
+    @Parameter
+    private List<String> ignoredUnusedDeclared;
+
+    @Parameter
+    private List<String> ignoredUsedTransitive;
+
     private final RepositorySystem repoSystem;
 
     @Inject
@@ -116,8 +136,8 @@ public class AnalyzeDependenciesMojo extends AbstractMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
-        if (!"check".equals(action) && !"fix".equals(action)) {
-            throw new MojoExecutionException("Invalid action '" + action + "'. Use 'check' or 'fix'.");
+        if (!"check".equals(action) && !"report".equals(action) && !"fix".equals(action)) {
+            throw new MojoExecutionException("Invalid action '" + action + "'. Use 'check', 'report', or 'fix'.");
         }
         try {
             executeForProject(project);
@@ -152,12 +172,20 @@ public class AnalyzeDependenciesMojo extends AbstractMojo {
         List<DependenciesTui.DepEntry> transitive = new ArrayList<>();
         DependenciesTui.collectTransitive(depTree.root, declaredGAs, transitiveGAs, transitive);
 
-        // Build GA-to-JAR map
+        // Build GA-to-JAR and GA-to-version maps from resolved artifacts
         Map<String, File> gaToJar = new HashMap<>();
+        Map<String, String> gaToVersion = new HashMap<>();
         for (ArtifactResult ar : depResult.getArtifactResults()) {
             var art = ar.getArtifact();
-            if (art != null && art.getFile() != null && art.getFile().getName().endsWith(".jar")) {
-                gaToJar.put(art.getGroupId() + ":" + art.getArtifactId(), art.getFile());
+            if (art != null) {
+                String classifier = art.getClassifier();
+                String ga = (classifier != null && !classifier.isEmpty())
+                        ? art.getGroupId() + ":" + art.getArtifactId() + ":" + classifier
+                        : art.getGroupId() + ":" + art.getArtifactId();
+                gaToVersion.put(ga, art.getVersion());
+                if (art.getFile() != null && art.getFile().getName().endsWith(".jar")) {
+                    gaToJar.put(ga, art.getFile());
+                }
             }
         }
 
@@ -181,28 +209,44 @@ public class AnalyzeDependenciesMojo extends AbstractMojo {
                 mainScan.referencedClasses(), testScan.referencedClasses(), classIndex, gaToJar, declared, transitive);
 
         // Find unused declared dependencies
-        List<DependenciesTui.DepEntry> unused = new ArrayList<>();
+        List<DependenciesTui.DepEntry> unusedDeclared = new ArrayList<>();
         for (var dep : declared) {
             DependencyUsageAnalyzer.UsageStatus status =
                     usage.declaredUsage().getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
             if (status == DependencyUsageAnalyzer.UsageStatus.UNUSED) {
-                unused.add(dep);
+                unusedDeclared.add(dep);
             }
         }
 
-        if (unused.isEmpty()) {
-            getLog().info("No unused declared dependencies found.");
+        // Find used transitive dependencies (should be declared)
+        List<DependenciesTui.DepEntry> usedTransitive = new ArrayList<>();
+        for (var dep : transitive) {
+            DependencyUsageAnalyzer.UsageStatus status =
+                    usage.transitiveUsage().getOrDefault(dep.ga(), DependencyUsageAnalyzer.UsageStatus.UNDETERMINED);
+            if (status == DependencyUsageAnalyzer.UsageStatus.USED) {
+                usedTransitive.add(dep);
+            }
+        }
+
+        // Apply ignore lists
+        Set<String> ignoredUnused = buildIgnoreSet(ignoredUnusedDeclared);
+        Set<String> ignoredTransitive = buildIgnoreSet(ignoredUsedTransitive);
+        unusedDeclared.removeIf(dep -> DependencyUsageAnalyzer.matchesArtifactPattern(dep.ga(), ignoredUnused));
+        usedTransitive.removeIf(dep -> DependencyUsageAnalyzer.matchesArtifactPattern(dep.ga(), ignoredTransitive));
+
+        if (unusedDeclared.isEmpty() && usedTransitive.isEmpty()) {
+            getLog().info("No dependency issues found.");
             return;
         }
 
-        if ("fix".equals(action)) {
-            fix(proj, unused);
-        } else {
-            check(unused);
+        switch (action) {
+            case "fix" -> fix(proj, unusedDeclared, usedTransitive, gaToVersion);
+            case "report" -> report(unusedDeclared, usedTransitive);
+            default -> check(unusedDeclared, usedTransitive);
         }
     }
 
-    private DependencyUsageAnalyzer buildAnalyzer() {
+    DependencyUsageAnalyzer buildAnalyzer() {
         DependencyUsageAnalyzer.Builder builder = DependencyUsageAnalyzer.builder();
         if (runtimeArtifacts != null && !runtimeArtifacts.isEmpty()) {
             builder.runtimeArtifacts(new HashSet<>(runtimeArtifacts));
@@ -220,36 +264,101 @@ public class AnalyzeDependenciesMojo extends AbstractMojo {
         return builder.build();
     }
 
-    private void check(List<DependenciesTui.DepEntry> unused) throws MojoFailureException {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Found ").append(unused.size()).append(" unused declared dependenc");
-        sb.append(unused.size() == 1 ? "y" : "ies").append(":\n");
-        for (var dep : unused) {
-            sb.append("  - ").append(dep.ga());
-            if (dep.scope != null && !dep.scope.isEmpty() && !"compile".equals(dep.scope)) {
-                sb.append(" (").append(dep.scope).append(")");
-            }
-            sb.append("\n");
-        }
-        sb.append("\nRun with -Dpilot.action=fix to remove them, or configure allowlists for false positives.");
-        throw new MojoFailureException(sb.toString());
+    static Set<String> buildIgnoreSet(List<String> patterns) {
+        return patterns != null && !patterns.isEmpty() ? new HashSet<>(patterns) : Set.of();
     }
 
-    private void fix(MavenProject proj, List<DependenciesTui.DepEntry> unused) throws Exception {
+    String formatFindings(
+            List<DependenciesTui.DepEntry> unusedDeclared, List<DependenciesTui.DepEntry> usedTransitive) {
+        StringBuilder sb = new StringBuilder();
+        if (!unusedDeclared.isEmpty()) {
+            sb.append("Unused declared dependenc");
+            sb.append(unusedDeclared.size() == 1 ? "y" : "ies");
+            sb.append(" (can be removed):\n");
+            for (var dep : unusedDeclared) {
+                sb.append("  - ").append(dep.ga());
+                appendScope(sb, dep);
+                sb.append("\n");
+            }
+        }
+        if (!usedTransitive.isEmpty()) {
+            if (!unusedDeclared.isEmpty()) {
+                sb.append("\n");
+            }
+            sb.append("Used transitive dependenc");
+            sb.append(usedTransitive.size() == 1 ? "y" : "ies");
+            sb.append(" (should be declared):\n");
+            for (var dep : usedTransitive) {
+                sb.append("  - ").append(dep.ga());
+                appendScope(sb, dep);
+                sb.append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    static void appendScope(StringBuilder sb, DependenciesTui.DepEntry dep) {
+        if (dep.scope != null && !dep.scope.isEmpty() && !"compile".equals(dep.scope)) {
+            sb.append(" (").append(dep.scope).append(")");
+        }
+    }
+
+    void report(List<DependenciesTui.DepEntry> unusedDeclared, List<DependenciesTui.DepEntry> usedTransitive) {
+        getLog().warn(formatFindings(unusedDeclared, usedTransitive));
+    }
+
+    void check(List<DependenciesTui.DepEntry> unusedDeclared, List<DependenciesTui.DepEntry> usedTransitive)
+            throws MojoFailureException {
+        throw new MojoFailureException(formatFindings(unusedDeclared, usedTransitive)
+                + "\nRun with -Dpilot.action=fix to apply changes, or configure allowlists for false positives.");
+    }
+
+    private void fix(
+            MavenProject proj,
+            List<DependenciesTui.DepEntry> unusedDeclared,
+            List<DependenciesTui.DepEntry> usedTransitive,
+            Map<String, String> gaToVersion)
+            throws Exception {
         Path pomPath = proj.getFile().toPath();
         String pomContent = Files.readString(pomPath);
-        PomEditor editor = new PomEditor(Document.of(pomContent));
 
-        for (var dep : unused) {
+        for (var dep : unusedDeclared) {
+            PomEditor editor = new PomEditor(Document.of(pomContent));
             String[] parts = dep.ga().split(":");
             Coordinates coords = parts.length > 2
                     ? Coordinates.of(parts[0], parts[1], null, parts[2], "jar")
                     : Coordinates.of(parts[0], parts[1], null);
             editor.dependencies().deleteDependency(coords);
+            pomContent = editor.toXml();
             getLog().info("Removed unused dependency: " + dep.ga());
         }
 
-        Files.writeString(pomPath, editor.toXml());
+        for (var dep : usedTransitive) {
+            String[] parts = dep.ga().split(":");
+            String groupId = parts[0];
+            String artifactId = parts[1];
+            String classifier = parts.length > 2 ? parts[2] : null;
+            String version = gaToVersion.getOrDefault(dep.ga(), "");
+            String scope = dep.scope;
+
+            PomEditor editor = new PomEditor(Document.of(pomContent));
+            Coordinates coords = (classifier != null && !classifier.isEmpty())
+                    ? Coordinates.of(groupId, artifactId, version, classifier, "jar")
+                    : Coordinates.of(groupId, artifactId, version);
+            AlignOptions detected = editor.dependencies().detectConventions();
+            AlignOptions.Builder optBuilder = AlignOptions.builder()
+                    .versionStyle(detected.versionStyle())
+                    .versionSource(detected.versionSource())
+                    .namingConvention(detected.namingConvention());
+            if (scope != null && !scope.isEmpty() && !"compile".equals(scope)) {
+                optBuilder.scope(scope);
+            }
+            editor.dependencies().addAligned(coords, optBuilder.build());
+            pomContent = editor.toXml();
+            getLog().info("Added used transitive dependency: " + dep.ga());
+        }
+
+        Files.writeString(pomPath, pomContent);
         getLog().info("Updated " + pomPath);
     }
 }

--- a/pilot-plugin/src/test/java/eu/maveniverse/maven/pilot/mvn3/AnalyzeDependenciesMojoTest.java
+++ b/pilot-plugin/src/test/java/eu/maveniverse/maven/pilot/mvn3/AnalyzeDependenciesMojoTest.java
@@ -1,0 +1,251 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot.mvn3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import eu.maveniverse.maven.pilot.DependenciesTui;
+import eu.maveniverse.maven.pilot.DependencyUsageAnalyzer;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.junit.jupiter.api.Test;
+
+class AnalyzeDependenciesMojoTest {
+
+    private final AnalyzeDependenciesMojo mojo = new AnalyzeDependenciesMojo(null);
+
+    @Test
+    void formatFindingsUnusedDeclaredOnly() {
+        var dep = new DependenciesTui.DepEntry("com.example", "unused-lib", "", "1.0", "compile", true);
+
+        String output = mojo.formatFindings(List.of(dep), List.of());
+
+        assertThat(output)
+                .contains("Unused declared dependency (can be removed):")
+                .contains("com.example:unused-lib")
+                .doesNotContain("transitive");
+    }
+
+    @Test
+    void formatFindingsUsedTransitiveOnly() {
+        var dep = new DependenciesTui.DepEntry("com.transitive", "lib", "", "2.0", "compile", false);
+
+        String output = mojo.formatFindings(List.of(), List.of(dep));
+
+        assertThat(output)
+                .contains("Used transitive dependency (should be declared):")
+                .contains("com.transitive:lib")
+                .doesNotContain("Unused");
+    }
+
+    @Test
+    void formatFindingsBothSections() {
+        var unused = new DependenciesTui.DepEntry("com.example", "unused", "", "1.0", "compile", true);
+        var transitive = new DependenciesTui.DepEntry("com.transitive", "needed", "", "2.0", "runtime", false);
+
+        String output = mojo.formatFindings(List.of(unused), List.of(transitive));
+
+        assertThat(output)
+                .contains("Unused declared dependency (can be removed):")
+                .contains("com.example:unused")
+                .contains("Used transitive dependency (should be declared):")
+                .contains("com.transitive:needed (runtime)");
+    }
+
+    @Test
+    void formatFindingsMultipleDeps() {
+        var unused1 = new DependenciesTui.DepEntry("com.a", "one", "", "1.0", "compile", true);
+        var unused2 = new DependenciesTui.DepEntry("com.b", "two", "", "1.0", "test", true);
+
+        String output = mojo.formatFindings(List.of(unused1, unused2), List.of());
+
+        assertThat(output)
+                .contains("Unused declared dependencies (can be removed):")
+                .contains("com.a:one")
+                .contains("com.b:two (test)");
+    }
+
+    @Test
+    void formatFindingsCompileScopeOmitted() {
+        var dep = new DependenciesTui.DepEntry("com.example", "lib", "", "1.0", "compile", true);
+
+        String output = mojo.formatFindings(List.of(dep), List.of());
+
+        assertThat(output).contains("com.example:lib\n").doesNotContain("(compile)");
+    }
+
+    @Test
+    void formatFindingsNonCompileScopeShown() {
+        var dep = new DependenciesTui.DepEntry("com.example", "lib", "", "1.0", "provided", true);
+
+        String output = mojo.formatFindings(List.of(dep), List.of());
+
+        assertThat(output).contains("com.example:lib (provided)");
+    }
+
+    @Test
+    void appendScopeSkipsCompile() {
+        StringBuilder sb = new StringBuilder();
+        var dep = new DependenciesTui.DepEntry("g", "a", "", "1", "compile", true);
+        AnalyzeDependenciesMojo.appendScope(sb, dep);
+        assertThat(sb).isEmpty();
+    }
+
+    @Test
+    void appendScopeIncludesNonCompile() {
+        StringBuilder sb = new StringBuilder();
+        var dep = new DependenciesTui.DepEntry("g", "a", "", "1", "test", true);
+        AnalyzeDependenciesMojo.appendScope(sb, dep);
+        assertThat(sb.toString()).isEqualTo(" (test)");
+    }
+
+    @Test
+    void ignoreListFiltersUnusedDeclared() {
+        var kept = new DependenciesTui.DepEntry("com.example", "kept", "", "1.0", "compile", true);
+        var ignored = new DependenciesTui.DepEntry("com.example", "ignored", "", "1.0", "compile", true);
+        List<DependenciesTui.DepEntry> unused = new ArrayList<>(List.of(kept, ignored));
+
+        Set<String> ignoreSet = Set.of("com.example:ignored");
+        unused.removeIf(dep -> DependencyUsageAnalyzer.matchesArtifactPattern(dep.ga(), ignoreSet));
+
+        assertThat(unused).hasSize(1);
+        assertThat(unused.get(0).ga()).isEqualTo("com.example:kept");
+    }
+
+    @Test
+    void ignoreListFiltersUsedTransitive() {
+        var reported = new DependenciesTui.DepEntry("com.needed", "lib", "", "1.0", "compile", false);
+        var suppressed = new DependenciesTui.DepEntry("org.slf4j", "slf4j-api", "", "2.0", "compile", false);
+        List<DependenciesTui.DepEntry> transitive = new ArrayList<>(List.of(reported, suppressed));
+
+        Set<String> ignoreSet = Set.of("org.slf4j:slf4j-api");
+        transitive.removeIf(dep -> DependencyUsageAnalyzer.matchesArtifactPattern(dep.ga(), ignoreSet));
+
+        assertThat(transitive).hasSize(1);
+        assertThat(transitive.get(0).ga()).isEqualTo("com.needed:lib");
+    }
+
+    @Test
+    void ignoreListWildcardFiltersEntireGroup() {
+        var dep1 = new DependenciesTui.DepEntry("org.slf4j", "slf4j-api", "", "2.0", "compile", false);
+        var dep2 = new DependenciesTui.DepEntry("org.slf4j", "slf4j-simple", "", "2.0", "runtime", false);
+        var dep3 = new DependenciesTui.DepEntry("com.other", "lib", "", "1.0", "compile", false);
+        List<DependenciesTui.DepEntry> deps = new ArrayList<>(List.of(dep1, dep2, dep3));
+
+        Set<String> ignoreSet = Set.of("org.slf4j:*");
+        deps.removeIf(dep -> DependencyUsageAnalyzer.matchesArtifactPattern(dep.ga(), ignoreSet));
+
+        assertThat(deps).hasSize(1);
+        assertThat(deps.get(0).ga()).isEqualTo("com.other:lib");
+    }
+
+    // --- check/report action tests ---
+
+    @Test
+    void checkThrowsMojoFailureException() {
+        var dep = new DependenciesTui.DepEntry("com.example", "unused", "", "1.0", "compile", true);
+
+        assertThatThrownBy(() -> mojo.check(List.of(dep), List.of()))
+                .isInstanceOf(MojoFailureException.class)
+                .hasMessageContaining("com.example:unused")
+                .hasMessageContaining("pilot.action=fix");
+    }
+
+    @Test
+    void checkIncludesUsedTransitiveInMessage() {
+        var transitive = new DependenciesTui.DepEntry("org.slf4j", "slf4j-api", "", "2.0", "compile", false);
+
+        assertThatThrownBy(() -> mojo.check(List.of(), List.of(transitive)))
+                .isInstanceOf(MojoFailureException.class)
+                .hasMessageContaining("org.slf4j:slf4j-api")
+                .hasMessageContaining("should be declared");
+    }
+
+    @Test
+    void reportDoesNotThrow() {
+        var dep = new DependenciesTui.DepEntry("com.example", "unused", "", "1.0", "compile", true);
+        var transitive = new DependenciesTui.DepEntry("org.slf4j", "slf4j-api", "", "2.0", "compile", false);
+
+        mojo.report(List.of(dep), List.of(transitive));
+    }
+
+    // --- buildIgnoreSet tests ---
+
+    @Test
+    void buildIgnoreSetNull() {
+        assertThat(AnalyzeDependenciesMojo.buildIgnoreSet(null)).isEmpty();
+    }
+
+    @Test
+    void buildIgnoreSetEmpty() {
+        assertThat(AnalyzeDependenciesMojo.buildIgnoreSet(List.of())).isEmpty();
+    }
+
+    @Test
+    void buildIgnoreSetPopulated() {
+        Set<String> result = AnalyzeDependenciesMojo.buildIgnoreSet(List.of("org.slf4j:slf4j-api", "com.example:*"));
+        assertThat(result).containsExactlyInAnyOrder("org.slf4j:slf4j-api", "com.example:*");
+    }
+
+    // --- buildAnalyzer tests ---
+
+    @Test
+    void buildAnalyzerDefaults() {
+        var analyzer = mojo.buildAnalyzer();
+        assertThat(analyzer).isNotNull();
+    }
+
+    @Test
+    void buildAnalyzerWithConfig() throws Exception {
+        var configuredMojo = new AnalyzeDependenciesMojo(null);
+        setField(configuredMojo, "runtimeArtifacts", List.of("org.postgresql:postgresql"));
+        setField(configuredMojo, "annotationOnlyArtifacts", List.of("org.projectlombok:lombok"));
+        setField(
+                configuredMojo,
+                "reflectionLoadedClasses",
+                Map.of("org.postgresql:postgresql", "org.postgresql.Driver"));
+
+        var analyzer = configuredMojo.buildAnalyzer();
+        assertThat(analyzer).isNotNull();
+    }
+
+    // --- execute validation tests ---
+
+    @Test
+    void executeRejectsInvalidAction() throws Exception {
+        var invalidMojo = new AnalyzeDependenciesMojo(null);
+        setField(invalidMojo, "action", "invalid");
+
+        assertThatThrownBy(invalidMojo::execute)
+                .isInstanceOf(MojoExecutionException.class)
+                .hasMessageContaining("Invalid action 'invalid'");
+    }
+
+    private static void setField(Object target, String name, Object value) throws Exception {
+        Field f = AnalyzeDependenciesMojo.class.getDeclaredField(name);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,25 @@ under the License.
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.14</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+            <phase>test</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
## Summary

Enhances `pilot:analyze-dependencies` with:

- **`report` action** — logs dependency issues without failing the build (`-Dpilot.action=report`)
- **Used transitive detection** — identifies transitive dependencies your code references directly that should be declared explicitly in the POM
- **Fix action** now handles both directions: removes unused declared deps and adds used transitives using convention-aware alignment (AlignOptions)
- **Ignore lists** for suppressing known false positives at the report level:
  - `ignoredUnusedDeclared` — declared deps to keep even though they appear unused
  - `ignoredUsedTransitive` — transitives you intentionally rely on without declaring
  - Both support `groupId:artifactId` exact match and `groupId:*` wildcards
- **Classifier-aware GA keys** — `gaToVersion`/`gaToJar` maps now include classifiers, matching `dep.ga()` format

Three actions: `check` (default, fails) | `report` (warns) | `fix` (edits POM)

Configuration example:
```xml
<plugin>
  <groupId>eu.maveniverse.maven</groupId>
  <artifactId>pilot-plugin</artifactId>
  <configuration>
    <runtimeArtifacts>
      <runtimeArtifact>org.postgresql:postgresql</runtimeArtifact>
    </runtimeArtifacts>
    <ignoredUnusedDeclared>
      <ignoredUnusedDeclared>com.example:kept-for-runtime</ignoredUnusedDeclared>
    </ignoredUnusedDeclared>
    <ignoredUsedTransitive>
      <ignoredUsedTransitive>org.slf4j:slf4j-api</ignoredUsedTransitive>
    </ignoredUsedTransitive>
  </configuration>
</plugin>
```

## Test plan

- [x] 34 analyzer unit tests pass (including classifier key, transitive allowlist)
- [x] 11 mojo unit tests pass (formatting, scope display, ignore list filtering, wildcard)
- [x] Manual test on `camel-core-model`: correctly reports 4 used transitive deps
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)