### PR TITLE
Replace deprecated KeyEvent.character() with string()

### DIFF
--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -510,8 +510,10 @@ public class DependenciesTui extends ToolPanel {
         }
 
         // Number keys switch sub-views
-        if (key.code() == KeyCode.CHAR && key.character() >= '1' && key.character() <= '9') {
-            int idx = key.character() - '1';
+        if (key.code() == KeyCode.CHAR
+                && key.string().charAt(0) >= '1'
+                && key.string().charAt(0) <= '9') {
+            int idx = key.string().charAt(0) - '1';
             if (idx < views.length && views[idx] != view) {
                 view = views[idx];
                 if (view != View.TREE) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PilotShell.java
@@ -290,7 +290,7 @@ public class PilotShell {
         // Alt+letter: switch tool (checked before delegation because
         // isCharIgnoreCase does not check modifiers)
         if (key.modifiers().alt() && key.code() == KeyCode.CHAR) {
-            char c = Character.toLowerCase(key.character());
+            char c = Character.toLowerCase(key.string().charAt(0));
             for (int i = 0; i < TOOLS.size(); i++) {
                 if (c == TOOLS.get(i).mnemonic) {
                     switchTool(i);
@@ -373,8 +373,8 @@ public class PilotShell {
         if (key.code() == KeyCode.CHAR
                 && !key.hasCtrl()
                 && !key.hasAlt()
-                && key.character() >= '0'
-                && key.character() <= '9') {
+                && key.string().charAt(0) >= '0'
+                && key.string().charAt(0) <= '9') {
             return handleNumberKey(key);
         }
         if (key.isKey(KeyCode.ENTER) && focus == Focus.TREE) {
@@ -398,13 +398,13 @@ public class PilotShell {
 
     /** Handles digit keys: 0 focuses the module tree, 1-9 selects sub-view tabs. */
     private boolean handleNumberKey(KeyEvent key) {
-        if (key.character() == '0') {
+        if (key.string().charAt(0) == '0') {
             if (treePane != null) {
                 setFocus(Focus.TREE);
             }
             return true;
         }
-        int index = key.character() - '1';
+        int index = key.string().charAt(0) - '1';
         if (activePanel != null && index < activePanel.subViewCount()) {
             activePanel.setActiveSubView(index);
             if (focus != Focus.CONTENT) setFocus(Focus.CONTENT);

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchController.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchController.java
@@ -73,7 +73,7 @@ class SearchController {
             searchBuffer.deleteCharAt(searchBuffer.length() - 1);
             updateMatches();
         } else if (key.code() == KeyCode.CHAR && !key.hasCtrl() && !key.hasAlt()) {
-            searchBuffer.append(key.character());
+            searchBuffer.append(key.string());
             updateMatches();
         }
     }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchInput.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchInput.java
@@ -102,7 +102,7 @@ class SearchInput {
         }
 
         if (key.code() == KeyCode.CHAR) {
-            buffer.insert(cursorPos, key.character());
+            buffer.insert(cursorPos, key.string());
             cursorPos++;
             onChange.accept(buffer.toString());
             return true;

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
@@ -365,7 +365,7 @@ public class SearchTui extends ToolPanel {
             return true;
         }
         if (key.code() == KeyCode.CHAR) {
-            searchBuffer.insert(cursorPos, key.character());
+            searchBuffer.insert(cursorPos, key.string());
             cursorPos++;
             onQueryChanged();
             return true;
@@ -426,7 +426,7 @@ public class SearchTui extends ToolPanel {
         // Typing in table mode jumps back to search
         if (key.code() == KeyCode.CHAR) {
             focus = Focus.SEARCH;
-            searchBuffer.insert(cursorPos, key.character());
+            searchBuffer.insert(cursorPos, key.string());
             cursorPos++;
             onQueryChanged();
             return true;

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -667,7 +667,7 @@ public abstract class ToolPanel {
                 return true;
             }
             if (key.code() == KeyCode.CHAR && !key.hasCtrl() && !key.hasAlt()) {
-                searchBuffer.append(key.character());
+                searchBuffer.append(key.string());
                 updateSearchMatches();
                 return true;
             }

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@ under the License.
     <maven.compiler.release>17</maven.compiler.release>
     <mavenVersion>3.9.16</mavenVersion>
     <maven4Version>4.0.0-rc-5</maven4Version>
-    <tamboui.version>0.2.0</tamboui.version>
+    <tamboui.version>0.3.0</tamboui.version>
     <domtrip.version>1.5.0</domtrip.version>
 
     <!-- SonarCloud -->


### PR DESCRIPTION
## Summary
- Upgrade tamboui from 0.2.0 to 0.3.0 to access the new `KeyEvent.string()` API
- Replace all deprecated `KeyEvent.character()` calls with `KeyEvent.string()` across 6 files: `SearchTui`, `SearchController`, `SearchInput`, `ToolPanel`, `PilotShell`, `DependenciesTui`
- For char-based comparisons and arithmetic (digit checks, `Character.toLowerCase`, numeric offsets like `key.character() - '1'`), use `key.string().charAt(0)` to preserve identical behavior

## Test plan
- [x] `./mvnw compile -B` — zero deprecation warnings for `character()` in `KeyEvent`
- [x] `./mvnw test -B` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_Claude Code on behalf of Guillaume Nodet_