### PR TITLE
chore: fall back to jline3 backend on Java < 22

### DIFF
--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -390,6 +390,8 @@ public abstract class ToolPanel {
      * ioctl() calls fail and corrupt stdin — we must use the JLine backend instead.
      * For direct Maven (including Maven 4 which bundles JLine), Panama avoids
      * classloader conflicts with Maven's own JLine.
+     * The Panama backend requires Java 22+ (the tamboui-panama-backend classes are
+     * compiled for Java 22); on earlier runtimes we fall back to the JLine backend.
      */
     static void configureBackend() {
         if (System.getProperty("tamboui.backend") != null) {
@@ -397,8 +399,10 @@ public abstract class ToolPanel {
         }
         if (System.getProperty("mvnd.home") != null) {
             System.setProperty("tamboui.backend", "jline3");
-        } else {
+        } else if (Runtime.version().feature() >= 22) {
             System.setProperty("tamboui.backend", "panama,jline3");
+        } else {
+            System.setProperty("tamboui.backend", "jline3");
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix `BackendException: No BackendProvider found on classpath for provider name 'panama'` crash when running the CLI jar on Java 21
- The `tamboui-panama-backend` 0.4.0 classes are compiled for Java 22 (class file major version 66). On Java 21, `UnsupportedClassVersionError` is silently swallowed by tamboui's `SafeServiceLoader`, but `configureBackend()` unconditionally requests `"panama,jline3"` — causing `resolveProviders()` to throw before ever trying the available `jline3` backend
- Guard the panama preference behind `Runtime.version().feature() >= 22` so Java 21 users get the jline3 backend automatically

## Test plan

- [x] All 557 existing tests pass
- [x] CLI jar starts successfully on Java 21 (uses jline3 backend)
- [ ] Verify on Java 22+ that panama backend is still preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal backend compatibility for Java versions below 22 by automatically using the JLine backend.
  * Preserved existing backend behavior for Java 22 and newer, including direct Maven, mvnd, and explicitly configured setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->