### PR TITLE
fix: scrollbar gutter clicks, empty-version fallback, and multi-char cursor positioning

### DIFF
--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AlignTui.java
@@ -621,6 +621,7 @@ public class AlignTui extends ToolPanel {
 
     @Override
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
+        if (isScrollbarGutter(mouse, area)) return false;
         if (mouse.isClick()) {
             int row = mouse.y() - area.y() - 2 + tableState.offset(); // border + header
             if (row >= 0 && row < ROW_COUNT) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/AuditTui.java
@@ -1824,6 +1824,7 @@ public class AuditTui extends ToolPanel {
         if (diffOverlay.isActive()) {
             return diffOverlay.handleMouseScroll(mouse, lastContentHeight);
         }
+        if (isScrollbarGutter(mouse, area)) return false;
         if (handleMouseTabBar(mouse)) return true;
         if (handleMouseSortHeader(mouse, currentTableWidths())) return true;
         if (mouse.isClick()) {

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ConflictsTui.java
@@ -335,6 +335,7 @@ public class ConflictsTui extends ToolPanel {
             diffOverlay.handleMouseScroll(mouse, lastContentHeight);
             return true;
         }
+        if (isScrollbarGutter(mouse, area)) return false;
         if (handleMouseSortHeader(
                 mouse,
                 List.of(

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/DependenciesTui.java
@@ -591,6 +591,7 @@ public class DependenciesTui extends ToolPanel {
             diffOverlay.handleMouseScroll(mouse, lastContentHeight);
             return true;
         }
+        if (isScrollbarGutter(mouse, area)) return false;
         if (handleMouseTabBar(mouse)) return true;
         if (view == View.TREE && treeTui != null) {
             return treeTui.handleMouseEvent(mouse, area);

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ModuleTreePane.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ModuleTreePane.java
@@ -224,6 +224,7 @@ class ModuleTreePane {
     }
 
     boolean handleMouseEvent(MouseEvent mouse, Rect area) {
+        if (mouse.isClick() && mouse.x() >= area.x() + area.width() - 1) return false; // scrollbar gutter
         if (mouse.isClick()) {
             return handleMouseClick(mouse, area);
         }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/PomTui.java
@@ -298,6 +298,7 @@ public class PomTui extends ToolPanel {
 
     @Override
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
+        if (isScrollbarGutter(mouse, area)) return false;
         if (handleMouseTabBar(mouse)) return true;
         if (mouse.isClick()) {
             return handlePomMouseClick(mouse, area);

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
@@ -125,10 +125,6 @@ public class SearchTui extends ToolPanel {
         pomInfoCache.put(groupId + ":" + artifactId + ":" + version, info);
     }
 
-    static List<String> versionsOrDefault(List<String> vers) {
-        return vers.isEmpty() ? List.of("") : vers;
-    }
-
     // Status
     private String status;
     private boolean loading;
@@ -280,6 +276,7 @@ public class SearchTui extends ToolPanel {
 
     @Override
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
+        if (isScrollbarGutter(mouse, area)) return false;
         if (handleMouseSortHeader(
                 mouse, List.of(Constraint.percentage(45), Constraint.percentage(30), Constraint.percentage(25)))) {
             return true;
@@ -369,7 +366,7 @@ public class SearchTui extends ToolPanel {
         }
         if (key.code() == KeyCode.CHAR) {
             searchBuffer.insert(cursorPos, key.string());
-            cursorPos++;
+            cursorPos += key.string().length();
             onQueryChanged();
             return true;
         }
@@ -430,7 +427,7 @@ public class SearchTui extends ToolPanel {
         if (key.code() == KeyCode.CHAR) {
             focus = Focus.SEARCH;
             searchBuffer.insert(cursorPos, key.string());
-            cursorPos++;
+            cursorPos += key.string().length();
             onQueryChanged();
             return true;
         }
@@ -823,6 +820,7 @@ public class SearchTui extends ToolPanel {
             }
             final String g = a[0];
             final String artId = a[1];
+            final String version = a[2];
             CompletableFuture.supplyAsync(() -> fetchVersionsFromMetadata(g, artId), httpPool)
                     .thenAccept(vers -> runner.runOnRenderThread(() -> {
                         if (gen != searchGeneration) {
@@ -830,7 +828,7 @@ public class SearchTui extends ToolPanel {
                         }
                         String k = g + ":" + artId;
                         if (!versionCache.containsKey(k)) {
-                            versionCache.put(k, versionsOrDefault(vers));
+                            versionCache.put(k, vers.isEmpty() ? List.of(version) : vers);
                         }
                     }));
         }

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/SearchTui.java
@@ -815,23 +815,23 @@ public class SearchTui extends ToolPanel {
         for (int i = 0; i < artifacts.size(); i++) {
             String[] a = artifacts.get(i);
             String key = a[0] + ":" + a[1];
-            if (versionCache.containsKey(key)) {
-                continue;
+            if (!versionCache.containsKey(key)) {
+                prefetchVersionForArtifact(a[0], a[1], a[2], gen);
             }
-            final String g = a[0];
-            final String artId = a[1];
-            final String version = a[2];
-            CompletableFuture.supplyAsync(() -> fetchVersionsFromMetadata(g, artId), httpPool)
-                    .thenAccept(vers -> runner.runOnRenderThread(() -> {
-                        if (gen != searchGeneration) {
-                            return; // stale
-                        }
-                        String k = g + ":" + artId;
-                        if (!versionCache.containsKey(k)) {
-                            versionCache.put(k, vers.isEmpty() ? List.of(version) : vers);
-                        }
-                    }));
         }
+    }
+
+    private void prefetchVersionForArtifact(String g, String artId, String version, int gen) {
+        CompletableFuture.supplyAsync(() -> fetchVersionsFromMetadata(g, artId), httpPool)
+                .thenAccept(vers -> runner.runOnRenderThread(() -> {
+                    if (gen != searchGeneration) {
+                        return; // stale
+                    }
+                    String k = g + ":" + artId;
+                    if (!versionCache.containsKey(k)) {
+                        versionCache.put(k, vers.isEmpty() ? List.of(version) : vers);
+                    }
+                }));
     }
 
     /**

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -532,6 +532,21 @@ public abstract class ToolPanel {
     }
 
     /**
+     * Test whether a mouse click lands on the scrollbar gutter column — the
+     * rightmost column of a panel area reserved for the scrollbar track.
+     * Panels that render scrollbars should call this early in
+     * {@link #handleMouseEvent(MouseEvent, Rect)} to avoid selecting a data
+     * row or toggling a sort header when the user clicks the scrollbar.
+     *
+     * @param mouse the mouse event (only clicks are meaningful)
+     * @param area  the outer area of the panel
+     * @return {@code true} if the click is on the scrollbar gutter
+     */
+    protected static boolean isScrollbarGutter(MouseEvent mouse, Rect area) {
+        return mouse.isClick() && mouse.x() >= area.x() + area.width() - 1;
+    }
+
+    /**
      * Handle mouse click on a table header row to toggle column sort.
      * Panels should call this in {@link #handleMouseEvent} and call
      * {@link #setTableArea(Rect, Block)} during rendering.

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/TreeTui.java
@@ -173,6 +173,7 @@ public class TreeTui extends ToolPanel {
 
     @Override
     public boolean handleMouseEvent(MouseEvent mouse, Rect area) {
+        if (isScrollbarGutter(mouse, area)) return false;
         if (handleMouseSortHeader(mouse, List.of(TREE_WIDTHS))) return true;
         if (mouse.isClick()) {
             return handleTreeMouseClick(mouse, area);

--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/UpdatesTui.java
@@ -1514,6 +1514,7 @@ public class UpdatesTui extends ToolPanel {
             diffOverlay.handleMouseScroll(mouse, lastContentHeight);
             return true;
         }
+        if (isScrollbarGutter(mouse, area)) return false;
         if (handleMouseTabBar(mouse)) return true;
         List<Constraint> widths = view == View.DEPENDENCIES
                 ? depsTableWidths()

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/SearchTuiTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/SearchTuiTest.java
@@ -88,7 +88,10 @@ class SearchTuiTest {
         MouseEvent normalClick = MouseEvent.press(MouseButton.LEFT, 78, 5);
 
         // Not rejected by the gutter guard — proceeds to row/sort handling
-        tui.handleMouseEvent(normalClick, area);
+        // (returns false because there are no result rows to select, but crucially
+        // the gutter guard did not short-circuit)
+        boolean handled = tui.handleMouseEvent(normalClick, area);
+        assertThat(handled).isFalse();
     }
 
     @Test
@@ -100,7 +103,8 @@ class SearchTuiTest {
         MouseEvent scrollAtGutter = MouseEvent.scrollDown(79, 0);
 
         // Scroll events are not clicks, so the gutter guard doesn't apply
-        tui.handleMouseEvent(scrollAtGutter, area);
+        boolean handled = tui.handleMouseEvent(scrollAtGutter, area);
+        assertThat(handled).isFalse();
     }
 
     // ── Multi-char cursor positioning ──────────────────────────────────────

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/SearchTuiTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/SearchTuiTest.java
@@ -20,7 +20,11 @@ package eu.maveniverse.maven.pilot;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import dev.tamboui.layout.Rect;
+import dev.tamboui.tui.event.KeyCode;
 import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.MouseButton;
+import dev.tamboui.tui.event.MouseEvent;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import java.util.List;
@@ -45,15 +49,100 @@ class SearchTuiTest {
         assertThat(tui.handleKeyEvent(KeyEvent.ofChar('x'))).isTrue();
     }
 
+    // ── Scrollbar gutter guard ──────────────────────────────────────────────
+
     @Test
-    void versionsOrDefaultReturnsPlaceholderWhenEmpty() {
-        assertThat(SearchTui.versionsOrDefault(List.of())).containsExactly("");
+    void gutterClickLeavesSortStateUnchanged() {
+        var tui = new SearchTui(NOOP_CLIENT, "", null, 0);
+        Rect area = new Rect(0, 0, 80, 20);
+
+        // Click on the scrollbar gutter column: x = area.width - 1 = 79
+        MouseEvent gutterClick = MouseEvent.press(MouseButton.LEFT, 79, 0);
+
+        boolean handled = tui.handleMouseEvent(gutterClick, area);
+
+        assertThat(handled).isFalse();
+        assertThat(tui.sortState.isSorted()).isFalse();
     }
 
     @Test
-    void versionsOrDefaultReturnsVersionsWhenNonEmpty() {
-        assertThat(SearchTui.versionsOrDefault(List.of("1.0", "2.0"))).containsExactly("1.0", "2.0");
+    void gutterClickWithOffsetAreaIsRejected() {
+        var tui = new SearchTui(NOOP_CLIENT, "", null, 0);
+        // Area starts at x=10, width=60 → gutter at x=69
+        Rect area = new Rect(10, 5, 60, 20);
+
+        MouseEvent gutterClick = MouseEvent.press(MouseButton.LEFT, 69, 5);
+
+        boolean handled = tui.handleMouseEvent(gutterClick, area);
+
+        assertThat(handled).isFalse();
+        assertThat(tui.sortState.isSorted()).isFalse();
     }
+
+    @Test
+    void clickInsideGutterBoundaryIsNotRejected() {
+        var tui = new SearchTui(NOOP_CLIENT, "", null, 0);
+        Rect area = new Rect(0, 0, 80, 20);
+
+        // x = 78 is one pixel left of the gutter — should NOT be rejected
+        MouseEvent normalClick = MouseEvent.press(MouseButton.LEFT, 78, 5);
+
+        // Not rejected by the gutter guard — proceeds to row/sort handling
+        tui.handleMouseEvent(normalClick, area);
+    }
+
+    @Test
+    void scrollEventsAreNotAffectedByGutterGuard() {
+        var tui = new SearchTui(NOOP_CLIENT, "", null, 0);
+        Rect area = new Rect(0, 0, 80, 20);
+
+        // Scroll at the gutter column — scrolls should still work (not clicks)
+        MouseEvent scrollAtGutter = MouseEvent.scrollDown(79, 0);
+
+        // Scroll events are not clicks, so the gutter guard doesn't apply
+        tui.handleMouseEvent(scrollAtGutter, area);
+    }
+
+    // ── Multi-char cursor positioning ──────────────────────────────────────
+
+    @Test
+    void supplementaryCharacterAdvancesCursorByStringLength() {
+        var tui = new SearchTui(NOOP_CLIENT, "", null, 0);
+
+        // U+1F600 GRINNING FACE — a supplementary character (2 UTF-16 code units)
+        tui.handleKeyEvent(KeyEvent.ofChar(0x1F600));
+
+        // Type a regular ASCII char after the supplementary character
+        tui.handleKeyEvent(KeyEvent.ofChar('a'));
+
+        // Then delete backwards: should remove 'a', not corrupt the buffer
+        tui.handleKeyEvent(KeyEvent.ofKey(KeyCode.BACKSPACE));
+
+        // Type another char — should still work without IndexOutOfBoundsException
+        assertThat(tui.handleKeyEvent(KeyEvent.ofChar('b'))).isTrue();
+    }
+
+    @Test
+    void multipleCharInsertionsThenCursorNavigationIsConsistent() {
+        var tui = new SearchTui(NOOP_CLIENT, "", null, 0);
+
+        // Type "abc" one char at a time
+        tui.handleKeyEvent(KeyEvent.ofChar('a'));
+        tui.handleKeyEvent(KeyEvent.ofChar('b'));
+        tui.handleKeyEvent(KeyEvent.ofChar('c'));
+
+        // Move cursor left twice (should be at position 1, between 'a' and 'b')
+        tui.handleKeyEvent(KeyEvent.ofKey(KeyCode.LEFT));
+        tui.handleKeyEvent(KeyEvent.ofKey(KeyCode.LEFT));
+
+        // Delete forward should remove 'b'
+        tui.handleKeyEvent(KeyEvent.ofKey(KeyCode.DELETE));
+
+        // Typing 'x' here should work without errors
+        assertThat(tui.handleKeyEvent(KeyEvent.ofChar('x'))).isTrue();
+    }
+
+    // ── Extract artifacts ──────────────────────────────────────────────────
 
     @Test
     void extractArtifactsFromDocs() {

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/TreeTuiTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/TreeTuiTest.java
@@ -79,8 +79,11 @@ class TreeTuiTest {
         // One pixel inside the gutter boundary: x = 78 (not the gutter)
         MouseEvent normalClick = MouseEvent.press(MouseButton.LEFT, 78, 5);
 
-        // Not rejected by the gutter guard — proceeds to row/sort handling
-        tui.handleMouseEvent(normalClick, area);
+        // Not rejected by the gutter guard — proceeds past the guard into
+        // row/sort handling (returns false because row 4 > visible node count,
+        // but the gutter guard did not short-circuit)
+        boolean handled = tui.handleMouseEvent(normalClick, area);
+        assertThat(handled).isFalse();
     }
 
     @Test

--- a/pilot-core/src/test/java/eu/maveniverse/maven/pilot/TreeTuiTest.java
+++ b/pilot-core/src/test/java/eu/maveniverse/maven/pilot/TreeTuiTest.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package eu.maveniverse.maven.pilot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import dev.tamboui.layout.Rect;
+import dev.tamboui.tui.event.KeyCode;
+import dev.tamboui.tui.event.KeyEvent;
+import dev.tamboui.tui.event.MouseButton;
+import dev.tamboui.tui.event.MouseEvent;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TreeTuiTest {
+
+    private static TreeTui createSimpleTreeTui() {
+        var root = new DependencyTreeModel.TreeNode("com.example", "root", "1.0", "compile", false, 0);
+        var child1 = new DependencyTreeModel.TreeNode("org.dep", "lib-a", "2.0", "compile", false, 1);
+        var child2 = new DependencyTreeModel.TreeNode("org.dep", "lib-b", "3.0", "compile", false, 1);
+        root.children.add(child1);
+        root.children.add(child2);
+        var model = new DependencyTreeModel(root, List.of(), 3);
+        return new TreeTui(model, "compile", "com.example:root:1.0");
+    }
+
+    // ── Scrollbar gutter guard ──────────────────────────────────────────────
+
+    @Test
+    void gutterClickLeavesSortStateUnchanged() {
+        var tui = createSimpleTreeTui();
+        Rect area = new Rect(0, 0, 80, 20);
+
+        // Click on the scrollbar gutter column: x = area.width - 1 = 79
+        MouseEvent gutterClick = MouseEvent.press(MouseButton.LEFT, 79, 0);
+
+        boolean handled = tui.handleMouseEvent(gutterClick, area);
+
+        assertThat(handled).isFalse();
+        assertThat(tui.sortState.sortColumn()).isEqualTo(-1);
+        assertThat(tui.sortState.isSorted()).isFalse();
+    }
+
+    @Test
+    void gutterClickWithOffsetAreaIsRejected() {
+        var tui = createSimpleTreeTui();
+        // Area starts at x=10, width=60 → gutter at x=69
+        Rect area = new Rect(10, 5, 60, 20);
+
+        MouseEvent gutterClick = MouseEvent.press(MouseButton.LEFT, 69, 5);
+
+        boolean handled = tui.handleMouseEvent(gutterClick, area);
+
+        assertThat(handled).isFalse();
+        assertThat(tui.sortState.isSorted()).isFalse();
+    }
+
+    @Test
+    void clickInsideGutterBoundaryIsNotRejected() {
+        var tui = createSimpleTreeTui();
+        Rect area = new Rect(0, 0, 80, 20);
+
+        // One pixel inside the gutter boundary: x = 78 (not the gutter)
+        MouseEvent normalClick = MouseEvent.press(MouseButton.LEFT, 78, 5);
+
+        // Not rejected by the gutter guard — proceeds to row/sort handling
+        tui.handleMouseEvent(normalClick, area);
+    }
+
+    @Test
+    void scrollEventsAreNotAffectedByGutterGuard() {
+        var tui = createSimpleTreeTui();
+        Rect area = new Rect(0, 0, 80, 20);
+
+        // Scroll at the gutter column — scrolls should still work
+        MouseEvent scrollAtGutter = MouseEvent.scrollDown(79, 0);
+
+        boolean handled = tui.handleMouseEvent(scrollAtGutter, area);
+
+        // Scroll events are not clicks, so the gutter guard doesn't apply
+        assertThat(handled).isTrue();
+    }
+
+    // ── Tree expand/collapse via keyboard ───────────────────────────────────
+
+    @Test
+    void rightKeyExpandsCollapsedNode() {
+        var tui = createSimpleTreeTui();
+        assertThat(tui.nodeCount()).isEqualTo(3);
+
+        // Collapse root via left key (root is selected at index 0)
+        tui.handleKeyEvent(KeyEvent.ofKey(KeyCode.LEFT));
+
+        // Now expand via right key
+        boolean handled = tui.handleKeyEvent(KeyEvent.ofKey(KeyCode.RIGHT));
+        assertThat(handled).isTrue();
+    }
+
+    @Test
+    void leftKeyCollapsesExpandedNode() {
+        var tui = createSimpleTreeTui();
+
+        // Root is expanded by default, pressing left should collapse it
+        boolean handled = tui.handleKeyEvent(KeyEvent.ofKey(KeyCode.LEFT));
+        assertThat(handled).isTrue();
+    }
+
+    @Test
+    void upDownNavigatesBetweenNodes() {
+        var tui = createSimpleTreeTui();
+
+        // Start at root (index 0), press down to move to child
+        boolean handled = tui.handleKeyEvent(KeyEvent.ofKey(KeyCode.DOWN));
+        assertThat(handled).isTrue();
+
+        // Press up to move back to root
+        handled = tui.handleKeyEvent(KeyEvent.ofKey(KeyCode.UP));
+        assertThat(handled).isTrue();
+    }
+
+    @Test
+    void expandAllThenCollapseAll() {
+        var tui = createSimpleTreeTui();
+
+        // 'E' expands all nodes
+        boolean handled = tui.handleKeyEvent(KeyEvent.ofChar('E'));
+        assertThat(handled).isTrue();
+
+        // 'W' collapses all nodes
+        handled = tui.handleKeyEvent(KeyEvent.ofChar('W'));
+        assertThat(handled).isTrue();
+    }
+
+    @Test
+    void cycleScopeChangesFilter() {
+        var tui = createSimpleTreeTui();
+
+        // 'f' cycles scope: compile → runtime
+        boolean handled = tui.handleKeyEvent(KeyEvent.ofChar('f'));
+        assertThat(handled).isTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- **Scrollbar gutter click guard**: `SearchTui.handleMouseEvent` and `TreeTui.handleTreeMouseClick` now ignore clicks on the scrollbar gutter column (`mouse.x() >= area.x() + area.width() - 1`), preventing accidental row selection when clicking the scrollbar track.
- **Preserve search result version**: In `SearchTui.prefetchVersions`, when Maven metadata returns no versions, the cache now stores the original search result version (`a[2]`) instead of an empty-string placeholder `List.of("")`, mirroring the fallback logic in `cycleVersion`.
- **Multi-char cursor positioning**: Both character insertion sites in `SearchTui` now advance the cursor by `key.string().length()` instead of hardcoded `1`, correctly handling supplementary Unicode codepoints.

## Test plan
- [x] `./mvnw compile test -B -pl pilot-core` — all 557 tests pass (0 failures, 0 errors)
- [ ] Manual: click the scrollbar track in search results and dependency tree — should not select a row
- [ ] Manual: search for an artifact whose Maven metadata returns no versions — version column should show the original search result version, not blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented scrollbar-gutter clicks from selecting, expanding, sorting, or otherwise affecting table content.
  * Improved cursor positioning when inserting search terms and table text, including supplementary characters.
  * Ensured version prefetching uses the artifact’s current version when no metadata versions are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->