### PR TITLE
chore: fall back to jline3 backend on Java < 22

### DIFF
--- a/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
+++ b/pilot-core/src/main/java/eu/maveniverse/maven/pilot/ToolPanel.java
@@ -390,6 +390,14 @@ public abstract class ToolPanel {
      * ioctl() calls fail and corrupt stdin — we must use the JLine backend instead.
      * For direct Maven (including Maven 4 which bundles JLine), Panama avoids
      * classloader conflicts with Maven's own JLine.
+     * <p>
+     * The Panama backend requires Java 22+ (tamboui-panama-backend 0.4.0 classes
+     * are compiled with class file version 66). On earlier runtimes the provider
+     * is silently skipped by SafeServiceLoader, but BackendFactory.resolveProviders()
+     * throws instead of falling through to the next entry in the comma-separated list.
+     * As a workaround we only request "panama" when the runtime can actually load it.
+     *
+     * @see <a href="https://github.com/tamboui/tamboui/pull/422">tamboui#422</a>
      */
     static void configureBackend() {
         if (System.getProperty("tamboui.backend") != null) {
@@ -397,8 +405,10 @@ public abstract class ToolPanel {
         }
         if (System.getProperty("mvnd.home") != null) {
             System.setProperty("tamboui.backend", "jline3");
-        } else {
+        } else if (Runtime.version().feature() >= 22) {
             System.setProperty("tamboui.backend", "panama,jline3");
+        } else {
+            System.setProperty("tamboui.backend", "jline3");
         }
     }
 


### PR DESCRIPTION
## Summary

- Workaround for [tamboui#422](https://github.com/tamboui/tamboui/pull/422): the CLI jar crashes on Java 21 with `BackendException: No BackendProvider found on classpath for provider name 'panama'`
- Guard the panama backend preference behind `Runtime.version().feature() >= 22` so Java 21 users get the jline3 backend automatically
- Can be simplified back to `"panama,jline3"` once tamboui ships the fix

## Root cause

The `tamboui-panama-backend` 0.4.0 classes are compiled for Java 22 (class file version 66). On Java 21, `SafeServiceLoader` correctly skips the unloadable provider, but `BackendFactory.resolveProviders()` treats every entry in the comma-separated spec as mandatory — it throws on `"panama"` before ever trying `"jline3"`. The upstream fix ([tamboui#422](https://github.com/tamboui/tamboui/pull/422)) changes `orElseThrow()` to `ifPresent()` so the list works as a preference order with fallback.

## Test plan

- [x] All 557 existing tests pass
- [x] CLI jar starts successfully on Java 21 (uses jline3 backend)
- [ ] Verify on Java 22+ that panama backend is still preferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)